### PR TITLE
feat: Ochre Phase 5 knowledge bases (bedrock-agent KB/data-source + RAG)

### DIFF
--- a/cmd/spinifex/cmd/admin_ochre_vector_test.go
+++ b/cmd/spinifex/cmd/admin_ochre_vector_test.go
@@ -28,6 +28,8 @@ type fakeVectorService struct {
 	describeErr    error
 	query          []handlers_ochrevector.QueryResult
 	queryErr       error
+	listJobs       []handlers_ochrevector.JobRecord
+	listJobsErr    error
 
 	createIndexInputs []*handlers_ochrevector.CreateIndexRequest
 	deleteIndexInputs []*handlers_ochrevector.DeleteIndexRequest
@@ -83,6 +85,13 @@ func (f *fakeVectorService) Query(_ context.Context, in *handlers_ochrevector.Qu
 		return nil, f.queryErr
 	}
 	return &handlers_ochrevector.QueryResponse{Results: f.query}, nil
+}
+
+func (f *fakeVectorService) ListJobs(_ context.Context, _ *handlers_ochrevector.ListJobsRequest, _ string) (*handlers_ochrevector.ListJobsResponse, error) {
+	if f.listJobsErr != nil {
+		return nil, f.listJobsErr
+	}
+	return &handlers_ochrevector.ListJobsResponse{Jobs: f.listJobs}, nil
 }
 
 var _ handlers_ochrevector.VectorService = (*fakeVectorService)(nil)

--- a/docs/service-interfaces.yaml
+++ b/docs/service-interfaces.yaml
@@ -33,12 +33,14 @@ services:
       - "acm.*"
       - "iam.*"
       - "rds.*"
+      - "ochre.vector.*"
     depends_on:
       - "ec2.*"
       - "elbv2.*"
       - "acm.*"
       - "iam.*"
       - "rds.*"
+      - "ochre.vector.*"
 
   spinifex_daemon:
     path: spinifex/services/spinifex
@@ -134,6 +136,7 @@ services:
       - "ochre.vector.ingest"
       - "ochre.vector.describeJob"
       - "ochre.vector.query"
+      - "ochre.vector.listJobs"
     publishes:
       # → vpcd
       - "vpc.create"

--- a/spinifex/awserrors/awserrors.go
+++ b/spinifex/awserrors/awserrors.go
@@ -653,6 +653,13 @@ var errorLookupByService = map[string]map[string]ErrorMessage{
 	"bedrock-agent": {
 		ErrorResourceNotFoundException: {HTTPCode: 404, Message: bedrockAgentResourceNotFoundMessage},
 	},
+	// bedrock-agent-runtime addresses the same knowledge-base resources as
+	// bedrock-agent (Retrieve/RetrieveAndGenerate resolve a knowledgeBaseId),
+	// so it shares bedrock-agent's wording rather than either the EKS default
+	// or bedrockResourceNotFoundMessage.
+	"bedrock-agent-runtime": {
+		ErrorResourceNotFoundException: {HTTPCode: 404, Message: bedrockAgentResourceNotFoundMessage},
+	},
 	"rds": {
 		ErrorOperationNotSupported: {HTTPCode: 400, Message: "The specified RDS action is not supported in the RDS v1 API."},
 	},

--- a/spinifex/awserrors/awserrors.go
+++ b/spinifex/awserrors/awserrors.go
@@ -547,6 +547,9 @@ var (
 	ErrorModelNotReadyException      = "ModelNotReadyException"
 	ErrorServiceUnavailableException = "ServiceUnavailableException"
 	ErrorModelErrorException         = "ModelErrorException"
+	// ErrorConflictException is bedrock-agent's wire code for an id already
+	// claimed by another resource (CreateKnowledgeBase/CreateDataSource).
+	ErrorConflictException = "ConflictException"
 	// ErrorServiceQuotaExceededException is for genuine per-account limits
 	// (e.g. Ochre's tokens-per-month cap) — unlike ErrorModelNotReadyException,
 	// which is reserved for transient capacity conditions that breach no quota.
@@ -644,6 +647,12 @@ var errorLookupByService = map[string]map[string]ErrorMessage{
 	"bedrock-runtime": {
 		ErrorResourceNotFoundException: {HTTPCode: 404, Message: bedrockResourceNotFoundMessage},
 	},
+	// bedrock-agent addresses knowledge bases/data sources/ingestion jobs, not
+	// foundation models, so it needs its own wording rather than either the
+	// EKS default or bedrockResourceNotFoundMessage above.
+	"bedrock-agent": {
+		ErrorResourceNotFoundException: {HTTPCode: 404, Message: bedrockAgentResourceNotFoundMessage},
+	},
 	"rds": {
 		ErrorOperationNotSupported: {HTTPCode: 400, Message: "The specified RDS action is not supported in the RDS v1 API."},
 	},
@@ -653,6 +662,11 @@ var errorLookupByService = map[string]map[string]ErrorMessage{
 // for the shared ResourceNotFoundException wire code, which otherwise tells a
 // Bedrock caller to go and list EKS clusters.
 const bedrockResourceNotFoundMessage = "Could not resolve the foundation model from the provided model identifier."
+
+// bedrockAgentResourceNotFoundMessage overrides the EKS wording ErrorLookup
+// carries for the shared ResourceNotFoundException wire code, which
+// otherwise tells a bedrock-agent caller to go and list EKS clusters.
+const bedrockAgentResourceNotFoundMessage = "The specified knowledge base, data source, or ingestion job resource could not be found."
 
 // LookupErrorMessage returns the ErrorMessage for code, scoped to service
 // where errorLookupByService has an override, otherwise ErrorLookup's global
@@ -1214,4 +1228,5 @@ var ErrorLookup = map[string]ErrorMessage{
 	ErrorServiceUnavailableException:   {HTTPCode: 503, Message: "The service isn't currently available. Try again later."},
 	ErrorModelErrorException:           {HTTPCode: 424, Message: "The request failed because of an error while running the model."},
 	ErrorServiceQuotaExceededException: {HTTPCode: 400, Message: "The number of requests exceeds the service quota. Resubmit your request later."},
+	ErrorConflictException:             {HTTPCode: 409, Message: "There was a conflict performing an operation."},
 }

--- a/spinifex/daemon/ochre_deps.go
+++ b/spinifex/daemon/ochre_deps.go
@@ -146,6 +146,7 @@ func (d *Daemon) startOchreVector() {
 		{handlers_ochrevector.SubjectIngest, handleNATSRequest(vectorService.Ingest), "spinifex-workers"},
 		{handlers_ochrevector.SubjectDescribeJob, handleNATSRequest(vectorService.DescribeJob), "spinifex-workers"},
 		{handlers_ochrevector.SubjectQuery, handleNATSRequest(vectorService.Query), "spinifex-workers"},
+		{handlers_ochrevector.SubjectListJobs, handleNATSRequest(vectorService.ListJobs), "spinifex-workers"},
 	}
 	if err := d.registerNatsSubs(subs); err != nil {
 		slog.Error("Ochre vector store: failed to register NATS subjects", "err", err)

--- a/spinifex/daemon/ochre_deps.go
+++ b/spinifex/daemon/ochre_deps.go
@@ -77,13 +77,17 @@ func (d *Daemon) startOchreVector() {
 		NodeID:   d.node,
 	})
 
-	// registry and jobs need only js, never a live backend, so they are built
-	// (and attached) here rather than after Connect: Teardown must be able to
-	// purge them even for an appliance that never comes up. Reused below,
-	// once connected, rather than reconstructed.
+	// registry, jobs, kb and ds need only js, never a live backend, so they
+	// are built (and attached) here rather than after Connect: Teardown must
+	// be able to purge them even for an appliance that never comes up.
+	// registry/jobs are reused below, once connected, rather than
+	// reconstructed; kb/ds are gateway-owned metadata this daemon never reads
+	// or writes itself -- they exist here solely so Teardown can purge them
+	// alongside registry/jobs.
 	registry := handlers_ochrevector.NewRegistry(js)
 	jobs := handlers_ochrevector.NewJobStore(js)
 	appliance.WithStores(registry, jobs)
+	appliance.WithKBStores(handlers_ochrevector.NewKBStore(js), handlers_ochrevector.NewDataSourceStore(js))
 
 	// Publish the appliance and register the operator teardown subject BEFORE
 	// Connect: recovering a broken singleton is teardown's whole purpose, so it

--- a/spinifex/gateway/bedrockagent.go
+++ b/spinifex/gateway/bedrockagent.go
@@ -1,0 +1,853 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"net/url"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrockagent"
+	"github.com/google/uuid"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
+)
+
+// bedrockAgentRoute maps one HTTP method + path regex to an AWS action and handler.
+type bedrockAgentRoute struct {
+	method  string
+	pattern *regexp.Regexp
+	action  string
+	handler bedrockAgentRouteHandler
+}
+
+// bedrockAgentRouteHandler invokes a per-action bedrock-agent (control-plane)
+// gateway function. params holds the regex capture groups, PathUnescape'd.
+// kb/ds are gw.BedrockAgentKB / gw.BedrockAgentDataSources; vector is
+// gw.BedrockAgentVector, the NATSVectorService forwarding client to .9's
+// daemon-side VectorService.
+type bedrockAgentRouteHandler func(ctx context.Context, accountID, region string, params []string, body []byte, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService) (any, error)
+
+// bedrockAgentRoutes is the dispatch table. Real AWS HTTP paths/methods
+// (verified against the vendored aws-sdk-go bedrockagent request
+// definitions), not invented ones. More-specific paths must precede
+// less-specific ones with the same prefix so the regex matcher picks the
+// deeper route first.
+var bedrockAgentRoutes = []bedrockAgentRoute{
+	{"PUT", regexp.MustCompile(`^/knowledgebases/$`), "CreateKnowledgeBase",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, _ *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService) (any, error) {
+			input := new(bedrockagent.CreateKnowledgeBaseInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			return CreateKnowledgeBase(ctx, acct, region, kb, vector, input)
+		}},
+	{"POST", regexp.MustCompile(`^/knowledgebases/$`), "ListKnowledgeBases",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, _ *handlers_ochrevector.DataSourceStore, _ handlers_ochrevector.VectorService) (any, error) {
+			return ListKnowledgeBases(ctx, acct, kb, new(bedrockagent.ListKnowledgeBasesInput))
+		}},
+	{"GET", regexp.MustCompile(`^/knowledgebases/([^/]+)$`), "GetKnowledgeBase",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, _ *handlers_ochrevector.DataSourceStore, _ handlers_ochrevector.VectorService) (any, error) {
+			return GetKnowledgeBase(ctx, acct, region, kb, &bedrockagent.GetKnowledgeBaseInput{KnowledgeBaseId: aws.String(p[0])})
+		}},
+	{"DELETE", regexp.MustCompile(`^/knowledgebases/([^/]+)$`), "DeleteKnowledgeBase",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService) (any, error) {
+			return DeleteKnowledgeBase(ctx, acct, kb, ds, vector, &bedrockagent.DeleteKnowledgeBaseInput{KnowledgeBaseId: aws.String(p[0])})
+		}},
+	{"PUT", regexp.MustCompile(`^/knowledgebases/([^/]+)/datasources/$`), "CreateDataSource",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, _ handlers_ochrevector.VectorService) (any, error) {
+			input := new(bedrockagent.CreateDataSourceInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.KnowledgeBaseId = aws.String(p[0])
+			return CreateDataSource(ctx, acct, region, kb, ds, input)
+		}},
+	{"POST", regexp.MustCompile(`^/knowledgebases/([^/]+)/datasources/$`), "ListDataSources",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, _ handlers_ochrevector.VectorService) (any, error) {
+			return ListDataSources(ctx, acct, kb, ds, &bedrockagent.ListDataSourcesInput{KnowledgeBaseId: aws.String(p[0])})
+		}},
+	{"GET", regexp.MustCompile(`^/knowledgebases/([^/]+)/datasources/([^/]+)$`), "GetDataSource",
+		func(ctx context.Context, acct, region string, p []string, b []byte, _ *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, _ handlers_ochrevector.VectorService) (any, error) {
+			return GetDataSource(ctx, acct, region, ds, &bedrockagent.GetDataSourceInput{KnowledgeBaseId: aws.String(p[0]), DataSourceId: aws.String(p[1])})
+		}},
+	{"DELETE", regexp.MustCompile(`^/knowledgebases/([^/]+)/datasources/([^/]+)$`), "DeleteDataSource",
+		func(ctx context.Context, acct, region string, p []string, b []byte, _ *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, _ handlers_ochrevector.VectorService) (any, error) {
+			return DeleteDataSource(ctx, acct, ds, &bedrockagent.DeleteDataSourceInput{KnowledgeBaseId: aws.String(p[0]), DataSourceId: aws.String(p[1])})
+		}},
+	{"PUT", regexp.MustCompile(`^/knowledgebases/([^/]+)/datasources/([^/]+)/ingestionjobs/$`), "StartIngestionJob",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService) (any, error) {
+			return StartIngestionJob(ctx, acct, kb, ds, vector, &bedrockagent.StartIngestionJobInput{KnowledgeBaseId: aws.String(p[0]), DataSourceId: aws.String(p[1])})
+		}},
+	{"POST", regexp.MustCompile(`^/knowledgebases/([^/]+)/datasources/([^/]+)/ingestionjobs/$`), "ListIngestionJobs",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService) (any, error) {
+			return ListIngestionJobs(ctx, acct, kb, ds, vector, &bedrockagent.ListIngestionJobsInput{KnowledgeBaseId: aws.String(p[0]), DataSourceId: aws.String(p[1])})
+		}},
+	{"GET", regexp.MustCompile(`^/knowledgebases/([^/]+)/datasources/([^/]+)/ingestionjobs/([^/]+)$`), "GetIngestionJob",
+		func(ctx context.Context, acct, region string, p []string, b []byte, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService) (any, error) {
+			return GetIngestionJob(ctx, acct, kb, ds, vector, &bedrockagent.GetIngestionJobInput{KnowledgeBaseId: aws.String(p[0]), DataSourceId: aws.String(p[1]), IngestionJobId: aws.String(p[2])})
+		}},
+}
+
+// lookupBedrockAgentAction matches method+path against bedrockAgentRoutes,
+// returning the action, path params, and handler, or ("", nil, nil, false) on
+// no match. path must be r.URL.EscapedPath(): captured params are
+// PathUnescape'd before returning, mirroring lookupBedrockAction.
+func lookupBedrockAgentAction(method, path string) (string, []string, bedrockAgentRouteHandler, bool) {
+	for _, route := range bedrockAgentRoutes {
+		if route.method != method {
+			continue
+		}
+		m := route.pattern.FindStringSubmatch(path)
+		if m == nil {
+			continue
+		}
+		var params []string
+		if len(m) > 1 {
+			params = make([]string, 0, len(m)-1)
+			for _, raw := range m[1:] {
+				decoded, err := url.PathUnescape(raw)
+				if err != nil {
+					slog.Debug("bedrock-agent: bad percent-encoding in path param", "param", raw, "err", err)
+					decoded = raw
+				}
+				params = append(params, decoded)
+			}
+		}
+		return route.action, params, route.handler, true
+	}
+	return "", nil, nil, false
+}
+
+// BedrockAgent_Request dispatches bedrock-agent (control-plane) REST-JSON
+// requests: resolves method+path to an action, reads the body, calls the
+// handler, and serialises the output as JSON, mirroring Bedrock_Request.
+func (gw *GatewayConfig) BedrockAgent_Request(w http.ResponseWriter, r *http.Request) error {
+	action, params, handler, ok := lookupBedrockAgentAction(r.Method, r.URL.EscapedPath())
+	if !ok {
+		slog.DebugContext(r.Context(), "bedrock-agent: no route for request", "method", r.Method, "path", r.URL.Path)
+		return errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	if err := gw.checkPolicy(r, "bedrock-agent", action); err != nil {
+		return err
+	}
+
+	if gw.BedrockAgentVector == nil || gw.BedrockAgentKB == nil || gw.BedrockAgentDataSources == nil {
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.ErrorContext(r.Context(), "BedrockAgent_Request: no account ID in auth context")
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "BedrockAgent_Request: failed to read body", "err", err)
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	output, err := handler(r.Context(), accountID, gw.Region, params, body, gw.BedrockAgentKB, gw.BedrockAgentDataSources, gw.BedrockAgentVector)
+	if err != nil {
+		return err
+	}
+
+	gateway_bedrock.WriteJSONResponse(w, output)
+	return nil
+}
+
+// bedrockAgentKnowledgeBaseResourceType is the ARN resource-type segment a
+// knowledge base renders under. DataSource carries no ARN field in AWS's own
+// shape (only KnowledgeBase does), so there is no data-source counterpart.
+const bedrockAgentKnowledgeBaseResourceType = "knowledge-base"
+
+// formatKnowledgeBaseARN builds the ARN a CreateKnowledgeBase call returns,
+// mirroring gateway_bedrock.FormatGuardrailARN's shape.
+func formatKnowledgeBaseARN(region, accountID, id string) string {
+	return fmt.Sprintf("arn:aws:bedrock:%s:%s:%s/%s", region, accountID, bedrockAgentKnowledgeBaseResourceType, id)
+}
+
+// nonEmptyStringPtr returns nil for an empty string, so an optional field
+// AWS omits when unset stays omitted here too, mirroring
+// gateway_bedrock.nonEmptyStringPtr (unexported there, so not reusable).
+func nonEmptyStringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return aws.String(s)
+}
+
+// embeddingModelIDFromARN extracts the bare foundation-model id from an
+// embeddingModelArn ("arn:aws:bedrock:region::foundation-model/id" ->
+// "id"), the identifier .9's CreateIndexRequest.EmbeddingModel and its
+// embedder key on. An arn that is not shaped that way is used verbatim, so a
+// caller-supplied plain model id still works.
+func embeddingModelIDFromARN(arn string) string {
+	const marker = "foundation-model/"
+	if idx := strings.LastIndex(arn, marker); idx != -1 {
+		return arn[idx+len(marker):]
+	}
+	return arn
+}
+
+// bucketNameFromS3ARN extracts the bucket name from an S3 bucket ARN
+// ("arn:aws:s3:::bucket-name" -> "bucket-name"). A value that is not shaped
+// like an ARN is used verbatim, so a bare bucket name still works.
+func bucketNameFromS3ARN(arn string) string {
+	const prefix = "arn:aws:s3:::"
+	if after, ok := strings.CutPrefix(arn, prefix); ok {
+		return after
+	}
+	return arn
+}
+
+// formatS3BucketARN is bucketNameFromS3ARN's inverse, used to render
+// SourceSpec.Bucket back into the AWS bucketArn shape on read.
+func formatS3BucketARN(bucket string) string {
+	return "arn:aws:s3:::" + bucket
+}
+
+// kbStatusToAWS translates .9's internal index lifecycle state (registry.go)
+// to AWS's KnowledgeBaseStatus wire values. CreateKnowledgeBase is
+// synchronous end-to-end (Service.CreateIndex blocks until READY or rolls
+// back on error, like CreateGuardrail's own no-async-transition contract),
+// so only StateReady is ever actually persisted here in Pass 1.
+func kbStatusToAWS(status string) string {
+	switch status {
+	case handlers_ochrevector.StateReady:
+		return bedrockagent.KnowledgeBaseStatusActive
+	case handlers_ochrevector.StateCreating:
+		return bedrockagent.KnowledgeBaseStatusCreating
+	case handlers_ochrevector.StateDeleting:
+		return bedrockagent.KnowledgeBaseStatusDeleting
+	default:
+		return bedrockagent.KnowledgeBaseStatusFailed
+	}
+}
+
+// dataSourceStatusToAWS is kbStatusToAWS's sibling for DataSourceStatus.
+func dataSourceStatusToAWS(status string) string {
+	switch status {
+	case handlers_ochrevector.StateDeleting:
+		return bedrockagent.DataSourceStatusDeleting
+	default:
+		return bedrockagent.DataSourceStatusAvailable
+	}
+}
+
+// jobStateToAWS translates .9's JobRecord.State to AWS's IngestionJobStatus
+// wire values.
+func jobStateToAWS(state string) string {
+	switch state {
+	case handlers_ochrevector.JobStatePending:
+		return bedrockagent.IngestionJobStatusStarting
+	case handlers_ochrevector.JobStateRunning:
+		return bedrockagent.IngestionJobStatusInProgress
+	case handlers_ochrevector.JobStateReady:
+		return bedrockagent.IngestionJobStatusComplete
+	default:
+		return bedrockagent.IngestionJobStatusFailed
+	}
+}
+
+// errKBNotFound reports a knowledge-base-specific ResourceNotFoundException.
+func errKBNotFound(id string) error {
+	return awserrors.Errorf(awserrors.ErrorResourceNotFoundException, "knowledge base %q not found", id)
+}
+
+// errDataSourceNotFound reports a data-source-specific ResourceNotFoundException.
+func errDataSourceNotFound(id string) error {
+	return awserrors.Errorf(awserrors.ErrorResourceNotFoundException, "data source %q not found", id)
+}
+
+// errIngestionJobNotFound reports an ingestion-job-specific ResourceNotFoundException.
+func errIngestionJobNotFound(id string) error {
+	return awserrors.Errorf(awserrors.ErrorResourceNotFoundException, "ingestion job %q not found", id)
+}
+
+// translateVectorErr maps .9's ochrevector domain errors onto AWS error
+// codes; any other error (a transport failure, an unwrapped internal error)
+// passes through unchanged so ErrorHandler's ResolveErrorDetail sanitizes it
+// to ServerInternal rather than mis-reporting it as a client error.
+func translateVectorErr(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, handlers_ochrevector.ErrIndexNotFound), errors.Is(err, handlers_ochrevector.ErrJobNotFound):
+		return errors.New(awserrors.ErrorResourceNotFoundException)
+	case errors.Is(err, handlers_ochrevector.ErrIndexExists):
+		return errors.New(awserrors.ErrorConflictException)
+	default:
+		return err
+	}
+}
+
+// kbRecordToOutput builds the AWS KnowledgeBase shape from rec. The stored
+// StorageConfigJSON blob is decoded back into the typed AWS struct so
+// Get/List echo exactly what CreateKnowledgeBase accepted (D5: accepted and
+// stubbed, never acted on).
+func kbRecordToOutput(region, accountID string, rec handlers_ochrevector.KBRecord) (*bedrockagent.KnowledgeBase, error) {
+	storageConfig := new(bedrockagent.StorageConfiguration)
+	if len(rec.StorageConfigJSON) > 0 {
+		if err := json.Unmarshal(rec.StorageConfigJSON, storageConfig); err != nil {
+			return nil, fmt.Errorf("bedrock-agent: decode stored storage configuration for %s: %w", rec.ID, err)
+		}
+	}
+	embeddingModelArn := rec.EmbeddingModelArn
+	if embeddingModelArn == "" {
+		embeddingModelArn = rec.EmbeddingModel
+	}
+	return &bedrockagent.KnowledgeBase{
+		CreatedAt:        aws.Time(rec.CreatedAt),
+		Description:      nonEmptyStringPtr(rec.Description),
+		KnowledgeBaseArn: aws.String(formatKnowledgeBaseARN(region, accountID, rec.ID)),
+		KnowledgeBaseConfiguration: &bedrockagent.KnowledgeBaseConfiguration{
+			Type: aws.String(bedrockagent.KnowledgeBaseTypeVector),
+			VectorKnowledgeBaseConfiguration: &bedrockagent.VectorKnowledgeBaseConfiguration{
+				EmbeddingModelArn: aws.String(embeddingModelArn),
+				EmbeddingModelConfiguration: &bedrockagent.EmbeddingModelConfiguration{
+					BedrockEmbeddingModelConfiguration: &bedrockagent.BedrockEmbeddingModelConfiguration{
+						Dimensions: aws.Int64(int64(rec.Dimension)),
+					},
+				},
+			},
+		},
+		KnowledgeBaseId:      aws.String(rec.ID),
+		Name:                 aws.String(rec.Name),
+		RoleArn:              aws.String(rec.RoleArn),
+		Status:               aws.String(kbStatusToAWS(rec.Status)),
+		StorageConfiguration: storageConfig,
+		UpdatedAt:            aws.Time(rec.UpdatedAt),
+	}, nil
+}
+
+// CreateKnowledgeBase maps CreateKnowledgeBaseInput onto
+// VectorService.CreateIndex (D1: one KB binds exactly one index,
+// embeddingModelArn -> EmbeddingModel+Dimension) and persists a KBRecord.
+// storageConfiguration and roleArn are accepted and stored verbatim for
+// round-trip echo but never honored (D5). A KBStore.Create collision (id
+// reuse) rolls the just-created index back, so no orphan index survives a
+// failed claim.
+func CreateKnowledgeBase(ctx context.Context, accountID, region string, kb *handlers_ochrevector.KBStore, vector handlers_ochrevector.VectorService, input *bedrockagent.CreateKnowledgeBaseInput) (*bedrockagent.CreateKnowledgeBaseOutput, error) {
+	if input == nil || aws.StringValue(input.Name) == "" || aws.StringValue(input.RoleArn) == "" ||
+		input.StorageConfiguration == nil || input.KnowledgeBaseConfiguration == nil {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	kbConfig := input.KnowledgeBaseConfiguration
+	if aws.StringValue(kbConfig.Type) != bedrockagent.KnowledgeBaseTypeVector || kbConfig.VectorKnowledgeBaseConfiguration == nil {
+		return nil, awserrors.Errorf(awserrors.ErrorValidationException, "bedrock-agent: only VECTOR knowledge bases are supported")
+	}
+	vecConfig := kbConfig.VectorKnowledgeBaseConfiguration
+	embeddingModelArn := aws.StringValue(vecConfig.EmbeddingModelArn)
+	if embeddingModelArn == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	embeddingModel := embeddingModelIDFromARN(embeddingModelArn)
+
+	dimension := 0
+	if vecConfig.EmbeddingModelConfiguration != nil && vecConfig.EmbeddingModelConfiguration.BedrockEmbeddingModelConfiguration != nil {
+		dimension = int(aws.Int64Value(vecConfig.EmbeddingModelConfiguration.BedrockEmbeddingModelConfiguration.Dimensions))
+	}
+	if dimension <= 0 {
+		return nil, awserrors.Errorf(awserrors.ErrorValidationException,
+			"bedrock-agent: embeddingModelConfiguration.bedrockEmbeddingModelConfiguration.dimensions is required")
+	}
+
+	id := uuid.NewString()
+	indexResp, err := vector.CreateIndex(ctx, &handlers_ochrevector.CreateIndexRequest{
+		IndexID:        id,
+		Name:           aws.StringValue(input.Name),
+		Dimension:      dimension,
+		EmbeddingModel: embeddingModel,
+	}, accountID)
+	if err != nil {
+		return nil, translateVectorErr(err)
+	}
+
+	storageJSON, err := json.Marshal(input.StorageConfiguration)
+	if err != nil {
+		return nil, fmt.Errorf("bedrock-agent: encode storage configuration: %w", err)
+	}
+
+	now := time.Now().UTC()
+	rec := handlers_ochrevector.KBRecord{
+		ID:                id,
+		Name:              aws.StringValue(input.Name),
+		Description:       aws.StringValue(input.Description),
+		Status:            handlers_ochrevector.StateReady,
+		EmbeddingModel:    embeddingModel,
+		EmbeddingModelArn: embeddingModelArn,
+		Dimension:         dimension,
+		IndexID:           indexResp.Index.ID,
+		RoleArn:           aws.StringValue(input.RoleArn),
+		StorageConfigJSON: storageJSON,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if err := kb.Create(ctx, accountID, rec); err != nil {
+		if _, delErr := vector.DeleteIndex(ctx, &handlers_ochrevector.DeleteIndexRequest{IndexID: id}, accountID); delErr != nil {
+			slog.WarnContext(ctx, "bedrock-agent: rollback delete index after knowledge base claim failure", "index", id, "err", delErr)
+		}
+		if errors.Is(err, handlers_ochrevector.ErrKBExists) {
+			return nil, errors.New(awserrors.ErrorConflictException)
+		}
+		return nil, err
+	}
+
+	out, err := kbRecordToOutput(region, accountID, rec)
+	if err != nil {
+		return nil, err
+	}
+	return &bedrockagent.CreateKnowledgeBaseOutput{KnowledgeBase: out}, nil
+}
+
+// GetKnowledgeBase looks up id in kb, returning ResourceNotFoundException for
+// a foreign account or an unknown id alike so a caller cannot distinguish
+// "not yours" from "does not exist".
+func GetKnowledgeBase(ctx context.Context, accountID, region string, kb *handlers_ochrevector.KBStore, input *bedrockagent.GetKnowledgeBaseInput) (*bedrockagent.GetKnowledgeBaseOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id := aws.StringValue(input.KnowledgeBaseId)
+	rec, err := kb.Get(ctx, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil {
+		return nil, errKBNotFound(id)
+	}
+	out, err := kbRecordToOutput(region, accountID, *rec)
+	if err != nil {
+		return nil, err
+	}
+	return &bedrockagent.GetKnowledgeBaseOutput{KnowledgeBase: out}, nil
+}
+
+// ListKnowledgeBases returns the caller account's own knowledge bases,
+// sorted by creation time (id as a deterministic tie-breaker), mirroring
+// gateway_bedrock.ListGuardrails.
+func ListKnowledgeBases(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, _ *bedrockagent.ListKnowledgeBasesInput) (*bedrockagent.ListKnowledgeBasesOutput, error) {
+	recs, err := kb.List(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(recs, func(a, b handlers_ochrevector.KBRecord) int {
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+	summaries := make([]*bedrockagent.KnowledgeBaseSummary, 0, len(recs))
+	for _, rec := range recs {
+		summaries = append(summaries, &bedrockagent.KnowledgeBaseSummary{
+			Description:     nonEmptyStringPtr(rec.Description),
+			KnowledgeBaseId: aws.String(rec.ID),
+			Name:            aws.String(rec.Name),
+			Status:          aws.String(kbStatusToAWS(rec.Status)),
+			UpdatedAt:       aws.Time(rec.UpdatedAt),
+		})
+	}
+	return &bedrockagent.ListKnowledgeBasesOutput{KnowledgeBaseSummaries: summaries}, nil
+}
+
+// DeleteKnowledgeBase drops id's bound index, cascades to every data source
+// under it (D-arch: the gateway owns bedrock-agent resource metadata, so the
+// cascade lives here rather than in a daemon-side operator), then removes the
+// KB record itself. Not idempotent on a foreign/unknown id (reports
+// ResourceNotFoundException), unlike gateway_bedrock.DeleteGuardrail's
+// idempotent-delete contract, because AWS's own DeleteKnowledgeBase does the
+// same.
+func DeleteKnowledgeBase(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.DeleteKnowledgeBaseInput) (*bedrockagent.DeleteKnowledgeBaseOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id := aws.StringValue(input.KnowledgeBaseId)
+	rec, err := kb.Get(ctx, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil {
+		return nil, errKBNotFound(id)
+	}
+
+	sources, err := ds.ListByKnowledgeBase(ctx, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	for _, src := range sources {
+		if err := ds.Delete(ctx, accountID, src.ID); err != nil {
+			return nil, fmt.Errorf("bedrock-agent: delete cascaded data source %s: %w", src.ID, err)
+		}
+	}
+
+	if _, err := vector.DeleteIndex(ctx, &handlers_ochrevector.DeleteIndexRequest{IndexID: rec.IndexID}, accountID); err != nil {
+		return nil, translateVectorErr(err)
+	}
+	if err := kb.Delete(ctx, accountID, id); err != nil {
+		return nil, err
+	}
+	return &bedrockagent.DeleteKnowledgeBaseOutput{
+		KnowledgeBaseId: aws.String(id),
+		Status:          aws.String(bedrockagent.KnowledgeBaseStatusDeleting),
+	}, nil
+}
+
+// dataSourceRecordToOutput builds the AWS DataSource shape from rec. Only S3
+// data sources are supported (CreateDataSource rejects any other type), so
+// this always renders an S3Configuration.
+func dataSourceRecordToOutput(rec handlers_ochrevector.DataSourceRecord) *bedrockagent.DataSource {
+	var inclusionPrefixes []*string
+	if rec.Source.Prefix != "" {
+		inclusionPrefixes = []*string{aws.String(rec.Source.Prefix)}
+	}
+	return &bedrockagent.DataSource{
+		CreatedAt: aws.Time(rec.CreatedAt),
+		DataSourceConfiguration: &bedrockagent.DataSourceConfiguration{
+			Type: aws.String(bedrockagent.DataSourceTypeS3),
+			S3Configuration: &bedrockagent.S3DataSourceConfiguration{
+				BucketArn:         aws.String(formatS3BucketARN(rec.Source.Bucket)),
+				InclusionPrefixes: inclusionPrefixes,
+			},
+		},
+		DataSourceId:    aws.String(rec.ID),
+		Description:     nonEmptyStringPtr(rec.Description),
+		KnowledgeBaseId: aws.String(rec.KnowledgeBaseID),
+		Name:            aws.String(rec.Name),
+		Status:          aws.String(dataSourceStatusToAWS(rec.Status)),
+		UpdatedAt:       aws.Time(rec.UpdatedAt),
+	}
+}
+
+// CreateDataSource maps CreateDataSourceInput's S3 + chunking config onto a
+// SourceSpec and persists a DataSourceRecord under kbID. Only S3 data
+// sources are supported (WEB/CONFLUENCE/SALESFORCE/SHAREPOINT are not
+// stubbed -- there is no engine behind them to accept-and-ignore against, so
+// they are rejected rather than silently accepted and never ingested).
+// ChunkSize/ChunkOverlap are left zero when fixedSizeChunkingConfiguration is
+// omitted, so .9's own ingest path applies DefaultChunkSize/
+// DefaultChunkOverlap (D3). Data-source-level Metadata is left empty: AWS's
+// CreateDataSourceInput carries no arbitrary metadata map to source it from
+// (real per-document metadata comes from S3 .metadata.json sidecar files at
+// ingest time, out of scope for Pass 1).
+func CreateDataSource(ctx context.Context, accountID, region string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, input *bedrockagent.CreateDataSourceInput) (*bedrockagent.CreateDataSourceOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.Name) == "" || input.DataSourceConfiguration == nil {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	kbID := aws.StringValue(input.KnowledgeBaseId)
+	kbRec, err := kb.Get(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if kbRec == nil {
+		return nil, errKBNotFound(kbID)
+	}
+
+	dsConfig := input.DataSourceConfiguration
+	if aws.StringValue(dsConfig.Type) != bedrockagent.DataSourceTypeS3 || dsConfig.S3Configuration == nil {
+		return nil, awserrors.Errorf(awserrors.ErrorValidationException, "bedrock-agent: only S3 data sources are supported")
+	}
+	s3Config := dsConfig.S3Configuration
+	bucketArn := aws.StringValue(s3Config.BucketArn)
+	if bucketArn == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	prefix := ""
+	if len(s3Config.InclusionPrefixes) > 0 {
+		prefix = aws.StringValue(s3Config.InclusionPrefixes[0])
+	}
+
+	var chunkSize, chunkOverlap int
+	if input.VectorIngestionConfiguration != nil && input.VectorIngestionConfiguration.ChunkingConfiguration != nil {
+		cc := input.VectorIngestionConfiguration.ChunkingConfiguration
+		if aws.StringValue(cc.ChunkingStrategy) == bedrockagent.ChunkingStrategyFixedSize && cc.FixedSizeChunkingConfiguration != nil {
+			maxTokens := aws.Int64Value(cc.FixedSizeChunkingConfiguration.MaxTokens)
+			overlapPct := aws.Int64Value(cc.FixedSizeChunkingConfiguration.OverlapPercentage)
+			chunkSize = int(maxTokens)
+			// D3: ChunkOverlap = round(maxTokens * overlapPercentage/100).
+			chunkOverlap = int(math.Round(float64(maxTokens) * float64(overlapPct) / 100))
+		}
+	}
+
+	id := uuid.NewString()
+	now := time.Now().UTC()
+	rec := handlers_ochrevector.DataSourceRecord{
+		ID:              id,
+		KnowledgeBaseID: kbID,
+		Name:            aws.StringValue(input.Name),
+		Description:     aws.StringValue(input.Description),
+		Status:          handlers_ochrevector.StateReady,
+		Source: handlers_ochrevector.SourceSpec{
+			Bucket:         bucketNameFromS3ARN(bucketArn),
+			Prefix:         prefix,
+			ChunkSize:      chunkSize,
+			ChunkOverlap:   chunkOverlap,
+			EmbeddingModel: kbRec.EmbeddingModel,
+			Dimension:      kbRec.Dimension,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := ds.Create(ctx, accountID, rec); err != nil {
+		if errors.Is(err, handlers_ochrevector.ErrDataSourceExists) {
+			return nil, errors.New(awserrors.ErrorConflictException)
+		}
+		return nil, err
+	}
+	return &bedrockagent.CreateDataSourceOutput{DataSource: dataSourceRecordToOutput(rec)}, nil
+}
+
+// GetDataSource looks up dataSourceId scoped to knowledgeBaseId: a data
+// source that exists but belongs to a different knowledge base reports
+// ResourceNotFoundException, the same as one that does not exist at all.
+func GetDataSource(ctx context.Context, accountID, region string, ds *handlers_ochrevector.DataSourceStore, input *bedrockagent.GetDataSourceInput) (*bedrockagent.GetDataSourceOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id := aws.StringValue(input.DataSourceId)
+	rec, err := ds.Get(ctx, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil || rec.KnowledgeBaseID != aws.StringValue(input.KnowledgeBaseId) {
+		return nil, errDataSourceNotFound(id)
+	}
+	return &bedrockagent.GetDataSourceOutput{DataSource: dataSourceRecordToOutput(*rec)}, nil
+}
+
+// ListDataSources returns knowledgeBaseId's data sources, sorted by creation
+// time (id as a deterministic tie-breaker), mirroring ListKnowledgeBases.
+func ListDataSources(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, input *bedrockagent.ListDataSourcesInput) (*bedrockagent.ListDataSourcesOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	kbID := aws.StringValue(input.KnowledgeBaseId)
+	kbRec, err := kb.Get(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if kbRec == nil {
+		return nil, errKBNotFound(kbID)
+	}
+
+	recs, err := ds.ListByKnowledgeBase(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(recs, func(a, b handlers_ochrevector.DataSourceRecord) int {
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+	summaries := make([]*bedrockagent.DataSourceSummary, 0, len(recs))
+	for _, rec := range recs {
+		summaries = append(summaries, &bedrockagent.DataSourceSummary{
+			DataSourceId:    aws.String(rec.ID),
+			Description:     nonEmptyStringPtr(rec.Description),
+			KnowledgeBaseId: aws.String(rec.KnowledgeBaseID),
+			Name:            aws.String(rec.Name),
+			Status:          aws.String(dataSourceStatusToAWS(rec.Status)),
+			UpdatedAt:       aws.Time(rec.UpdatedAt),
+		})
+	}
+	return &bedrockagent.ListDataSourcesOutput{DataSourceSummaries: summaries}, nil
+}
+
+// DeleteDataSource removes dataSourceId scoped to knowledgeBaseId. Not
+// idempotent on a foreign/unknown id (reports ResourceNotFoundException), the
+// same contract as DeleteKnowledgeBase and real AWS's own DeleteDataSource.
+func DeleteDataSource(ctx context.Context, accountID string, ds *handlers_ochrevector.DataSourceStore, input *bedrockagent.DeleteDataSourceInput) (*bedrockagent.DeleteDataSourceOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id := aws.StringValue(input.DataSourceId)
+	rec, err := ds.Get(ctx, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil || rec.KnowledgeBaseID != aws.StringValue(input.KnowledgeBaseId) {
+		return nil, errDataSourceNotFound(id)
+	}
+	if err := ds.Delete(ctx, accountID, id); err != nil {
+		return nil, err
+	}
+	return &bedrockagent.DeleteDataSourceOutput{
+		DataSourceId:    aws.String(id),
+		KnowledgeBaseId: input.KnowledgeBaseId,
+		Status:          aws.String(bedrockagent.DataSourceStatusDeleting),
+	}, nil
+}
+
+// jobRecordToOutput builds the AWS IngestionJob shape from job, scoped to the
+// addressed kbID/dsID (JobRecord itself carries only IndexID, not an
+// AWS-shaped knowledge-base/data-source id pair).
+func jobRecordToOutput(kbID, dsID string, job handlers_ochrevector.JobRecord) *bedrockagent.IngestionJob {
+	var failureReasons []*string
+	for _, fd := range job.FailedDocuments {
+		failureReasons = append(failureReasons, aws.String(fmt.Sprintf("%s: %s", fd.SourceKey, fd.Reason)))
+	}
+	if job.Error != "" {
+		failureReasons = append(failureReasons, aws.String(job.Error))
+	}
+	return &bedrockagent.IngestionJob{
+		DataSourceId:    aws.String(dsID),
+		FailureReasons:  failureReasons,
+		IngestionJobId:  aws.String(job.ID),
+		KnowledgeBaseId: aws.String(kbID),
+		StartedAt:       aws.Time(job.CreatedAt),
+		Statistics: &bedrockagent.IngestionJobStatistics{
+			NumberOfDocumentsFailed:          aws.Int64(int64(len(job.FailedDocuments))),
+			NumberOfDocumentsScanned:         aws.Int64(int64(job.DocumentsTotal)),
+			NumberOfNewDocumentsIndexed:      aws.Int64(int64(job.DocumentsDone)),
+			NumberOfModifiedDocumentsIndexed: aws.Int64(0),
+			NumberOfDocumentsDeleted:         aws.Int64(0),
+		},
+		Status:    aws.String(jobStateToAWS(job.State)),
+		UpdatedAt: aws.Time(job.UpdatedAt),
+	}
+}
+
+// StartIngestionJob builds an IngestRequest from dataSourceId's stored
+// SourceSpec, targets knowledgeBaseId's bound index, and calls
+// VectorService.Ingest.
+func StartIngestionJob(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.StartIngestionJobInput) (*bedrockagent.StartIngestionJobOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	kbID := aws.StringValue(input.KnowledgeBaseId)
+	dsID := aws.StringValue(input.DataSourceId)
+
+	kbRec, err := kb.Get(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if kbRec == nil {
+		return nil, errKBNotFound(kbID)
+	}
+
+	dsRec, err := ds.Get(ctx, accountID, dsID)
+	if err != nil {
+		return nil, err
+	}
+	if dsRec == nil || dsRec.KnowledgeBaseID != kbID {
+		return nil, errDataSourceNotFound(dsID)
+	}
+
+	resp, err := vector.Ingest(ctx, &handlers_ochrevector.IngestRequest{IndexID: kbRec.IndexID, Source: dsRec.Source}, accountID)
+	if err != nil {
+		return nil, translateVectorErr(err)
+	}
+
+	return &bedrockagent.StartIngestionJobOutput{IngestionJob: jobRecordToOutput(kbID, dsID, resp.Job)}, nil
+}
+
+// GetIngestionJob resolves jobId via VectorService.DescribeJob, then verifies
+// it belongs to the addressed knowledge base (its IndexID matches the KB's
+// bound index) before returning it, so a foreign/mismatched knowledgeBaseId
+// in the path cannot be used to read another KB's job by guessing its id.
+func GetIngestionJob(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.GetIngestionJobInput) (*bedrockagent.GetIngestionJobOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" || aws.StringValue(input.IngestionJobId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	kbID := aws.StringValue(input.KnowledgeBaseId)
+	dsID := aws.StringValue(input.DataSourceId)
+	jobID := aws.StringValue(input.IngestionJobId)
+
+	kbRec, err := kb.Get(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if kbRec == nil {
+		return nil, errKBNotFound(kbID)
+	}
+
+	resp, err := vector.DescribeJob(ctx, &handlers_ochrevector.DescribeJobRequest{JobID: jobID}, accountID)
+	if err != nil {
+		return nil, translateVectorErr(err)
+	}
+	if resp.Job.IndexID != kbRec.IndexID {
+		return nil, errIngestionJobNotFound(jobID)
+	}
+
+	return &bedrockagent.GetIngestionJobOutput{IngestionJob: jobRecordToOutput(kbID, dsID, resp.Job)}, nil
+}
+
+// sourceSpecMatchesDataSource reports whether an ingestion job's stored
+// SourceSpec was built from ds's own SourceSpec (StartIngestionJob always
+// builds the job's Source from the data source's Source verbatim, see
+// StartIngestionJob above). Matched on Bucket+Prefix, the two fields that
+// identify which documents a data source covers: JobRecord itself carries no
+// DataSourceID (.9 has no such concept), so this is ListIngestionJobs' only
+// way to scope a KB-wide job list down to one data source.
+func sourceSpecMatchesDataSource(job, ds handlers_ochrevector.SourceSpec) bool {
+	return job.Bucket == ds.Bucket && job.Prefix == ds.Prefix
+}
+
+// ListIngestionJobs lists knowledgeBaseId's jobs via the new
+// VectorService.ListJobs, filtered to dataSourceId's own SourceSpec (see
+// sourceSpecMatchesDataSource) and sorted by start time.
+func ListIngestionJobs(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.ListIngestionJobsInput) (*bedrockagent.ListIngestionJobsOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	kbID := aws.StringValue(input.KnowledgeBaseId)
+	dsID := aws.StringValue(input.DataSourceId)
+
+	kbRec, err := kb.Get(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if kbRec == nil {
+		return nil, errKBNotFound(kbID)
+	}
+
+	dsRec, err := ds.Get(ctx, accountID, dsID)
+	if err != nil {
+		return nil, err
+	}
+	if dsRec == nil || dsRec.KnowledgeBaseID != kbID {
+		return nil, errDataSourceNotFound(dsID)
+	}
+
+	resp, err := vector.ListJobs(ctx, &handlers_ochrevector.ListJobsRequest{}, accountID)
+	if err != nil {
+		return nil, translateVectorErr(err)
+	}
+
+	summaries := make([]*bedrockagent.IngestionJobSummary, 0)
+	for _, job := range resp.Jobs {
+		if job.IndexID != kbRec.IndexID || !sourceSpecMatchesDataSource(job.Source, dsRec.Source) {
+			continue
+		}
+		out := jobRecordToOutput(kbID, dsID, job)
+		summaries = append(summaries, &bedrockagent.IngestionJobSummary{
+			DataSourceId:    out.DataSourceId,
+			IngestionJobId:  out.IngestionJobId,
+			KnowledgeBaseId: out.KnowledgeBaseId,
+			StartedAt:       out.StartedAt,
+			Statistics:      out.Statistics,
+			Status:          out.Status,
+			UpdatedAt:       out.UpdatedAt,
+		})
+	}
+	slices.SortFunc(summaries, func(a, b *bedrockagent.IngestionJobSummary) int {
+		return a.StartedAt.Compare(*b.StartedAt)
+	})
+	return &bedrockagent.ListIngestionJobsOutput{IngestionJobSummaries: summaries}, nil
+}

--- a/spinifex/gateway/bedrockagent.go
+++ b/spinifex/gateway/bedrockagent.go
@@ -705,8 +705,9 @@ func DeleteDataSource(ctx context.Context, accountID string, ds *handlers_ochrev
 }
 
 // jobRecordToOutput builds the AWS IngestionJob shape from job, scoped to the
-// addressed kbID/dsID (JobRecord itself carries only IndexID, not an
-// AWS-shaped knowledge-base/data-source id pair).
+// addressed kbID/dsID (the caller's own resolved ids, not necessarily rebuilt
+// from job.IndexID/job.DataSourceID, since AWS's IngestionJob always renders
+// under the path it was requested through).
 func jobRecordToOutput(kbID, dsID string, job handlers_ochrevector.JobRecord) *bedrockagent.IngestionJob {
 	var failureReasons []*string
 	for _, fd := range job.FailedDocuments {
@@ -735,7 +736,9 @@ func jobRecordToOutput(kbID, dsID string, job handlers_ochrevector.JobRecord) *b
 
 // StartIngestionJob builds an IngestRequest from dataSourceId's stored
 // SourceSpec, targets knowledgeBaseId's bound index, and calls
-// VectorService.Ingest.
+// VectorService.Ingest. dsRec.ID is stamped onto the request as DataSourceID,
+// so the resulting job carries an exact link back to the data source that
+// started it.
 func StartIngestionJob(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.StartIngestionJobInput) (*bedrockagent.StartIngestionJobOutput, error) {
 	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" {
 		return nil, errors.New(awserrors.ErrorValidationException)
@@ -759,7 +762,7 @@ func StartIngestionJob(ctx context.Context, accountID string, kb *handlers_ochre
 		return nil, errDataSourceNotFound(dsID)
 	}
 
-	resp, err := vector.Ingest(ctx, &handlers_ochrevector.IngestRequest{IndexID: kbRec.IndexID, Source: dsRec.Source}, accountID)
+	resp, err := vector.Ingest(ctx, &handlers_ochrevector.IngestRequest{IndexID: kbRec.IndexID, Source: dsRec.Source, DataSourceID: dsRec.ID}, accountID)
 	if err != nil {
 		return nil, translateVectorErr(err)
 	}
@@ -769,15 +772,12 @@ func StartIngestionJob(ctx context.Context, accountID string, kb *handlers_ochre
 
 // GetIngestionJob resolves jobId via VectorService.DescribeJob, then verifies
 // it belongs to both the addressed knowledge base (its IndexID matches the
-// KB's bound index) and the addressed data source (its Source matches the
-// data source's own Source, see sourceSpecMatchesDataSource) before
-// returning it, so a foreign/mismatched knowledgeBaseId or dataSourceId in
-// the path cannot be used to read another KB/data source's job by guessing
-// its id. The data-source check is the same Bucket+Prefix best-effort match
-// ListIngestionJobs uses -- JobRecord carries no DataSourceID (see
-// sourceSpecMatchesDataSource) -- so a real DataSourceID on JobRecord would
-// close this exactly, but that crosses into the .9 ingest path and is left
-// as a follow-up.
+// KB's bound index) and the addressed data source (its DataSourceID matches
+// dataSourceId exactly) before returning it, so a foreign/mismatched
+// knowledgeBaseId or dataSourceId in the path cannot be used to read another
+// KB/data source's job by guessing its id. A job with an empty DataSourceID
+// (started directly against ochre.vector.ingest, with no bedrock-agent data
+// source involved) never matches any dataSourceId here.
 func GetIngestionJob(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.GetIngestionJobInput) (*bedrockagent.GetIngestionJobOutput, error) {
 	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" || aws.StringValue(input.IngestionJobId) == "" {
 		return nil, errors.New(awserrors.ErrorValidationException)
@@ -806,27 +806,16 @@ func GetIngestionJob(ctx context.Context, accountID string, kb *handlers_ochreve
 	if err != nil {
 		return nil, translateVectorErr(err)
 	}
-	if resp.Job.IndexID != kbRec.IndexID || !sourceSpecMatchesDataSource(resp.Job.Source, dsRec.Source) {
+	if resp.Job.IndexID != kbRec.IndexID || resp.Job.DataSourceID != dsID {
 		return nil, errIngestionJobNotFound(jobID)
 	}
 
 	return &bedrockagent.GetIngestionJobOutput{IngestionJob: jobRecordToOutput(kbID, dsID, resp.Job)}, nil
 }
 
-// sourceSpecMatchesDataSource reports whether an ingestion job's stored
-// SourceSpec was built from ds's own SourceSpec (StartIngestionJob always
-// builds the job's Source from the data source's Source verbatim, see
-// StartIngestionJob above). Matched on Bucket+Prefix, the two fields that
-// identify which documents a data source covers: JobRecord itself carries no
-// DataSourceID (.9 has no such concept), so this is ListIngestionJobs' only
-// way to scope a KB-wide job list down to one data source.
-func sourceSpecMatchesDataSource(job, ds handlers_ochrevector.SourceSpec) bool {
-	return job.Bucket == ds.Bucket && job.Prefix == ds.Prefix
-}
-
 // ListIngestionJobs lists knowledgeBaseId's jobs via the new
-// VectorService.ListJobs, filtered to dataSourceId's own SourceSpec (see
-// sourceSpecMatchesDataSource) and sorted by start time.
+// VectorService.ListJobs, filtered to dataSourceId's own bound index and
+// exact DataSourceID, and sorted by start time.
 func ListIngestionJobs(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.ListIngestionJobsInput) (*bedrockagent.ListIngestionJobsOutput, error) {
 	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" {
 		return nil, errors.New(awserrors.ErrorValidationException)
@@ -857,7 +846,7 @@ func ListIngestionJobs(ctx context.Context, accountID string, kb *handlers_ochre
 
 	summaries := make([]*bedrockagent.IngestionJobSummary, 0)
 	for _, job := range resp.Jobs {
-		if job.IndexID != kbRec.IndexID || !sourceSpecMatchesDataSource(job.Source, dsRec.Source) {
+		if job.IndexID != kbRec.IndexID || job.DataSourceID != dsID {
 			continue
 		}
 		out := jobRecordToOutput(kbID, dsID, job)

--- a/spinifex/gateway/bedrockagent.go
+++ b/spinifex/gateway/bedrockagent.go
@@ -401,8 +401,13 @@ func CreateKnowledgeBase(ctx context.Context, accountID, region string, kb *hand
 		UpdatedAt:         now,
 	}
 	if err := kb.Create(ctx, accountID, rec); err != nil {
+		// The KB claim failed, but the index it would have bound to already
+		// exists: kb.Create's error is still the operation result returned
+		// below, so a rollback failure here must not be swallowed -- log it
+		// at Error with the orphaned index id so it stays observable even
+		// though the caller never sees it.
 		if _, delErr := vector.DeleteIndex(ctx, &handlers_ochrevector.DeleteIndexRequest{IndexID: id}, accountID); delErr != nil {
-			slog.WarnContext(ctx, "bedrock-agent: rollback delete index after knowledge base claim failure", "index", id, "err", delErr)
+			slog.ErrorContext(ctx, "bedrock-agent: rollback delete index after knowledge base claim failure left an orphaned index", "index", id, "err", delErr)
 		}
 		if errors.Is(err, handlers_ochrevector.ErrKBExists) {
 			return nil, errors.New(awserrors.ErrorConflictException)
@@ -496,7 +501,12 @@ func DeleteKnowledgeBase(ctx context.Context, accountID string, kb *handlers_och
 		}
 	}
 
-	if _, err := vector.DeleteIndex(ctx, &handlers_ochrevector.DeleteIndexRequest{IndexID: rec.IndexID}, accountID); err != nil {
+	// A missing bound index is treated as already deleted, not a failure:
+	// the KB record must not be left dangling with no way to retry the
+	// delete just because its index is already gone (Delete is idempotent
+	// w.r.t. the index). Any other error still aborts before the record
+	// itself is removed.
+	if _, err := vector.DeleteIndex(ctx, &handlers_ochrevector.DeleteIndexRequest{IndexID: rec.IndexID}, accountID); err != nil && !errors.Is(err, handlers_ochrevector.ErrIndexNotFound) {
 		return nil, translateVectorErr(err)
 	}
 	if err := kb.Delete(ctx, accountID, id); err != nil {
@@ -758,9 +768,16 @@ func StartIngestionJob(ctx context.Context, accountID string, kb *handlers_ochre
 }
 
 // GetIngestionJob resolves jobId via VectorService.DescribeJob, then verifies
-// it belongs to the addressed knowledge base (its IndexID matches the KB's
-// bound index) before returning it, so a foreign/mismatched knowledgeBaseId
-// in the path cannot be used to read another KB's job by guessing its id.
+// it belongs to both the addressed knowledge base (its IndexID matches the
+// KB's bound index) and the addressed data source (its Source matches the
+// data source's own Source, see sourceSpecMatchesDataSource) before
+// returning it, so a foreign/mismatched knowledgeBaseId or dataSourceId in
+// the path cannot be used to read another KB/data source's job by guessing
+// its id. The data-source check is the same Bucket+Prefix best-effort match
+// ListIngestionJobs uses -- JobRecord carries no DataSourceID (see
+// sourceSpecMatchesDataSource) -- so a real DataSourceID on JobRecord would
+// close this exactly, but that crosses into the .9 ingest path and is left
+// as a follow-up.
 func GetIngestionJob(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, ds *handlers_ochrevector.DataSourceStore, vector handlers_ochrevector.VectorService, input *bedrockagent.GetIngestionJobInput) (*bedrockagent.GetIngestionJobOutput, error) {
 	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || aws.StringValue(input.DataSourceId) == "" || aws.StringValue(input.IngestionJobId) == "" {
 		return nil, errors.New(awserrors.ErrorValidationException)
@@ -777,11 +794,19 @@ func GetIngestionJob(ctx context.Context, accountID string, kb *handlers_ochreve
 		return nil, errKBNotFound(kbID)
 	}
 
+	dsRec, err := ds.Get(ctx, accountID, dsID)
+	if err != nil {
+		return nil, err
+	}
+	if dsRec == nil || dsRec.KnowledgeBaseID != kbID {
+		return nil, errDataSourceNotFound(dsID)
+	}
+
 	resp, err := vector.DescribeJob(ctx, &handlers_ochrevector.DescribeJobRequest{JobID: jobID}, accountID)
 	if err != nil {
 		return nil, translateVectorErr(err)
 	}
-	if resp.Job.IndexID != kbRec.IndexID {
+	if resp.Job.IndexID != kbRec.IndexID || !sourceSpecMatchesDataSource(resp.Job.Source, dsRec.Source) {
 		return nil, errIngestionJobNotFound(jobID)
 	}
 

--- a/spinifex/gateway/bedrockagent_request_test.go
+++ b/spinifex/gateway/bedrockagent_request_test.go
@@ -263,17 +263,18 @@ func TestBedrockAgentRequest_StartAndListAndGetIngestionJob(t *testing.T) {
 	kbID := createTestKnowledgeBase(t, gw)
 	dsID := createTestDataSource(t, gw, kbID)
 
-	// vector.Ingest doesn't stamp IndexID/Source on the returned job itself
-	// (that's jobRecordToOutput's job, driven by the KB's own bound index),
-	// but ListJobs/GetIngestionJob key off the fake's own scripted response,
-	// so both are seeded from the stores' own records here: IndexID from the
-	// KB, Source from the data source (sourceSpecMatchesDataSource's match key).
+	// vector.Ingest doesn't stamp IndexID/DataSourceID on the returned job
+	// itself (that's jobRecordToOutput's job, driven by the KB's own bound
+	// index), but ListJobs/GetIngestionJob key off the fake's own scripted
+	// response, so both are seeded from the stores' own records here: IndexID
+	// from the KB, DataSourceID from the data source's own id (the exact
+	// ownership match key GetIngestionJob/ListIngestionJobs use).
 	kbRec, err := gw.BedrockAgentKB.Get(context.Background(), bedrockAgentTestAccount, kbID)
 	require.NoError(t, err)
 	dsRec, err := gw.BedrockAgentDataSources.Get(context.Background(), bedrockAgentTestAccount, dsID)
 	require.NoError(t, err)
 	vector.ingestResp.Job.IndexID = kbRec.IndexID
-	vector.ingestResp.Job.Source = dsRec.Source
+	vector.ingestResp.Job.DataSourceID = dsRec.ID
 	vector.describeJobResp = handlers_ochrevector.DescribeJobResponse{Job: vector.ingestResp.Job}
 	vector.listJobsResp = handlers_ochrevector.ListJobsResponse{Jobs: []handlers_ochrevector.JobRecord{vector.ingestResp.Job}}
 

--- a/spinifex/gateway/bedrockagent_request_test.go
+++ b/spinifex/gateway/bedrockagent_request_test.go
@@ -1,0 +1,336 @@
+// In-package: exercises BedrockAgent_Request's route table, dispatcher, and
+// the per-route handler closures in bedrockAgentRoutes end-to-end over real
+// HTTP requests, mirroring bedrock_request_test.go's harness for the sibling
+// bedrock/bedrock-runtime services.
+//
+//test:in-package
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/bedrockagent"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newBedrockAgentRequestGateway builds a GatewayConfig with fresh
+// gateway-owned KB/DataSource stores over a real (embedded) JetStream and an
+// allow-everything IAMService, so the policy gate passes on a real evaluation
+// rather than a bypass, mirroring newBedrockRequestGateway.
+func newBedrockAgentRequestGateway(t *testing.T, vector handlers_ochrevector.VectorService) *GatewayConfig {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	return &GatewayConfig{
+		IAMService:              allowAllIAMService(),
+		BedrockAgentKB:          handlers_ochrevector.NewKBStore(js),
+		BedrockAgentDataSources: handlers_ochrevector.NewDataSourceStore(js),
+		BedrockAgentVector:      vector,
+	}
+}
+
+func bedrockAgentRequestWithAccount(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), ctxAccountID, bedrockAgentTestAccount)
+	ctx = context.WithValue(ctx, ctxIdentity, "alice")
+	ctx = context.WithValue(ctx, ctxPrincipalType, principalTypeUser)
+	return req.WithContext(ctx)
+}
+
+const createKnowledgeBaseRequestBody = `{
+	"name": "docs",
+	"roleArn": "arn:aws:iam::111111111111:role/kb-role",
+	"storageConfiguration": {"type": "OPENSEARCH_SERVERLESS"},
+	"knowledgeBaseConfiguration": {
+		"type": "VECTOR",
+		"vectorKnowledgeBaseConfiguration": {
+			"embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v2:0",
+			"embeddingModelConfiguration": {
+				"bedrockEmbeddingModelConfiguration": {"dimensions": 1024}
+			}
+		}
+	}
+}`
+
+// createTestKnowledgeBase drives CreateKnowledgeBase through the HTTP route
+// so tests that need an existing knowledge base don't have to hand-build a
+// KBRecord, and returns its generated id.
+func createTestKnowledgeBase(t *testing.T, gw *GatewayConfig) string {
+	t.Helper()
+	req := bedrockAgentRequestWithAccount(http.MethodPut, "/knowledgebases/", createKnowledgeBaseRequestBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+	var out bedrockagent.CreateKnowledgeBaseOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	return *out.KnowledgeBase.KnowledgeBaseId
+}
+
+func TestBedrockAgentRequest_CreateKnowledgeBase(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+
+	req := bedrockAgentRequestWithAccount(http.MethodPut, "/knowledgebases/", createKnowledgeBaseRequestBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagent.CreateKnowledgeBaseOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, "docs", *out.KnowledgeBase.Name)
+	assert.Equal(t, bedrockagent.KnowledgeBaseStatusActive, *out.KnowledgeBase.Status)
+}
+
+func TestBedrockAgentRequest_CreateKnowledgeBase_MalformedBodyReturnsValidationException(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+
+	req := bedrockAgentRequestWithAccount(http.MethodPut, "/knowledgebases/", "{not-json")
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgent_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
+}
+
+func TestBedrockAgentRequest_GetKnowledgeBase(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+	id := createTestKnowledgeBase(t, gw)
+
+	req := bedrockAgentRequestWithAccount(http.MethodGet, "/knowledgebases/"+id, "")
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagent.GetKnowledgeBaseOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, id, *out.KnowledgeBase.KnowledgeBaseId)
+}
+
+func TestBedrockAgentRequest_GetKnowledgeBase_NotFound(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+
+	req := bedrockAgentRequestWithAccount(http.MethodGet, "/knowledgebases/does-not-exist", "")
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgent_Request(w, req)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestBedrockAgentRequest_ListKnowledgeBases(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+	id := createTestKnowledgeBase(t, gw)
+
+	req := bedrockAgentRequestWithAccount(http.MethodPost, "/knowledgebases/", "")
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagent.ListKnowledgeBasesOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	require.Len(t, out.KnowledgeBaseSummaries, 1)
+	assert.Equal(t, id, *out.KnowledgeBaseSummaries[0].KnowledgeBaseId)
+}
+
+const createDataSourceRequestBody = `{
+	"name": "s3-docs",
+	"dataSourceConfiguration": {
+		"type": "S3",
+		"s3Configuration": {
+			"bucketArn": "arn:aws:s3:::my-bucket",
+			"inclusionPrefixes": ["docs/"]
+		}
+	},
+	"vectorIngestionConfiguration": {
+		"chunkingConfiguration": {
+			"chunkingStrategy": "FIXED_SIZE",
+			"fixedSizeChunkingConfiguration": {"maxTokens": 300, "overlapPercentage": 20}
+		}
+	}
+}`
+
+func createTestDataSource(t *testing.T, gw *GatewayConfig, kbID string) string {
+	t.Helper()
+	req := bedrockAgentRequestWithAccount(http.MethodPut, "/knowledgebases/"+kbID+"/datasources/", createDataSourceRequestBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+	var out bedrockagent.CreateDataSourceOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	return *out.DataSource.DataSourceId
+}
+
+func TestBedrockAgentRequest_CreateDataSource(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+	kbID := createTestKnowledgeBase(t, gw)
+
+	req := bedrockAgentRequestWithAccount(http.MethodPut, "/knowledgebases/"+kbID+"/datasources/", createDataSourceRequestBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagent.CreateDataSourceOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, "s3-docs", *out.DataSource.Name)
+	assert.Equal(t, "arn:aws:s3:::my-bucket", *out.DataSource.DataSourceConfiguration.S3Configuration.BucketArn)
+}
+
+func TestBedrockAgentRequest_CreateDataSource_UnknownKnowledgeBaseNotFound(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+
+	req := bedrockAgentRequestWithAccount(http.MethodPut, "/knowledgebases/does-not-exist/datasources/", createDataSourceRequestBody)
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgent_Request(w, req)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestBedrockAgentRequest_GetDataSource(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+	kbID := createTestKnowledgeBase(t, gw)
+	dsID := createTestDataSource(t, gw, kbID)
+
+	req := bedrockAgentRequestWithAccount(http.MethodGet, "/knowledgebases/"+kbID+"/datasources/"+dsID, "")
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagent.GetDataSourceOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, dsID, *out.DataSource.DataSourceId)
+}
+
+func TestBedrockAgentRequest_ListDataSources(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+	kbID := createTestKnowledgeBase(t, gw)
+	dsID := createTestDataSource(t, gw, kbID)
+
+	req := bedrockAgentRequestWithAccount(http.MethodPost, "/knowledgebases/"+kbID+"/datasources/", "")
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagent.ListDataSourcesOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	require.Len(t, out.DataSourceSummaries, 1)
+	assert.Equal(t, dsID, *out.DataSourceSummaries[0].DataSourceId)
+}
+
+func TestBedrockAgentRequest_DeleteDataSource(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+	kbID := createTestKnowledgeBase(t, gw)
+	dsID := createTestDataSource(t, gw, kbID)
+
+	req := bedrockAgentRequestWithAccount(http.MethodDelete, "/knowledgebases/"+kbID+"/datasources/"+dsID, "")
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	getReq := bedrockAgentRequestWithAccount(http.MethodGet, "/knowledgebases/"+kbID+"/datasources/"+dsID, "")
+	w2 := httptest.NewRecorder()
+	err := gw.BedrockAgent_Request(w2, getReq)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestBedrockAgentRequest_DeleteKnowledgeBase(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+	kbID := createTestKnowledgeBase(t, gw)
+	createTestDataSource(t, gw, kbID)
+
+	req := bedrockAgentRequestWithAccount(http.MethodDelete, "/knowledgebases/"+kbID, "")
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	getReq := bedrockAgentRequestWithAccount(http.MethodGet, "/knowledgebases/"+kbID, "")
+	w2 := httptest.NewRecorder()
+	err := gw.BedrockAgent_Request(w2, getReq)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestBedrockAgentRequest_StartAndListAndGetIngestionJob(t *testing.T) {
+	vector := &fakeBedrockAgentVectorService{ingestResp: handlers_ochrevector.IngestResponse{
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", State: handlers_ochrevector.JobStatePending},
+	}}
+	gw := newBedrockAgentRequestGateway(t, vector)
+	kbID := createTestKnowledgeBase(t, gw)
+	dsID := createTestDataSource(t, gw, kbID)
+
+	// vector.Ingest doesn't stamp IndexID/Source on the returned job itself
+	// (that's jobRecordToOutput's job, driven by the KB's own bound index),
+	// but ListJobs/GetIngestionJob key off the fake's own scripted response,
+	// so both are seeded from the stores' own records here: IndexID from the
+	// KB, Source from the data source (sourceSpecMatchesDataSource's match key).
+	kbRec, err := gw.BedrockAgentKB.Get(context.Background(), bedrockAgentTestAccount, kbID)
+	require.NoError(t, err)
+	dsRec, err := gw.BedrockAgentDataSources.Get(context.Background(), bedrockAgentTestAccount, dsID)
+	require.NoError(t, err)
+	vector.ingestResp.Job.IndexID = kbRec.IndexID
+	vector.ingestResp.Job.Source = dsRec.Source
+	vector.describeJobResp = handlers_ochrevector.DescribeJobResponse{Job: vector.ingestResp.Job}
+	vector.listJobsResp = handlers_ochrevector.ListJobsResponse{Jobs: []handlers_ochrevector.JobRecord{vector.ingestResp.Job}}
+
+	startReq := bedrockAgentRequestWithAccount(http.MethodPut, "/knowledgebases/"+kbID+"/datasources/"+dsID+"/ingestionjobs/", "")
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w, startReq))
+	require.Equal(t, http.StatusOK, w.Code)
+	var startOut bedrockagent.StartIngestionJobOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &startOut))
+	assert.Equal(t, "job-1", *startOut.IngestionJob.IngestionJobId)
+
+	listReq := bedrockAgentRequestWithAccount(http.MethodPost, "/knowledgebases/"+kbID+"/datasources/"+dsID+"/ingestionjobs/", "")
+	w2 := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w2, listReq))
+	require.Equal(t, http.StatusOK, w2.Code)
+	var listOut bedrockagent.ListIngestionJobsOutput
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &listOut))
+	require.Len(t, listOut.IngestionJobSummaries, 1)
+	assert.Equal(t, "job-1", *listOut.IngestionJobSummaries[0].IngestionJobId)
+
+	getReq := bedrockAgentRequestWithAccount(http.MethodGet, "/knowledgebases/"+kbID+"/datasources/"+dsID+"/ingestionjobs/job-1", "")
+	w3 := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgent_Request(w3, getReq))
+	require.Equal(t, http.StatusOK, w3.Code)
+	var getOut bedrockagent.GetIngestionJobOutput
+	require.NoError(t, json.Unmarshal(w3.Body.Bytes(), &getOut))
+	assert.Equal(t, "job-1", *getOut.IngestionJob.IngestionJobId)
+}
+
+func TestBedrockAgentRequest_UnknownRouteReturnsInvalidAction(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+
+	req := bedrockAgentRequestWithAccount(http.MethodPatch, "/knowledgebases/", "")
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgent_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidAction, err.Error())
+}
+
+func TestBedrockAgentRequest_MissingAccountIDReturnsInternalError(t *testing.T) {
+	gw := newBedrockAgentRequestGateway(t, &fakeBedrockAgentVectorService{})
+
+	req := withTestIdentity(httptest.NewRequest(http.MethodPost, "/knowledgebases/", nil))
+	w := httptest.NewRecorder()
+	// Account-less requests are rejected by the policy gate, which runs ahead
+	// of the handler's own account guard.
+	err := gw.BedrockAgent_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
+}
+
+func TestBedrockAgentRequest_NilDependenciesReturnServerInternal(t *testing.T) {
+	gw := &GatewayConfig{IAMService: allowAllIAMService()}
+
+	req := bedrockAgentRequestWithAccount(http.MethodPost, "/knowledgebases/", "")
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgent_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+}

--- a/spinifex/gateway/bedrockagent_test.go
+++ b/spinifex/gateway/bedrockagent_test.go
@@ -8,6 +8,9 @@ package gateway
 
 import (
 	"context"
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -221,6 +224,39 @@ func TestCreateKnowledgeBase_MissingDimensionsIsValidationException(t *testing.T
 	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorValidationException))
 }
 
+// TestCreateKnowledgeBase_RollbackFailureIsLoggedNotSwallowed proves that
+// when kb.Create fails (forcing the just-created index's rollback delete)
+// and that rollback delete itself also fails, the caller still sees kb.Create's
+// own error unchanged -- not the rollback's -- while the rollback failure is
+// logged at Error level with the orphaned index id, so an orphan stays
+// observable instead of vanishing silently.
+func TestCreateKnowledgeBase_RollbackFailureIsLoggedNotSwallowed(t *testing.T) {
+	var buf strings.Builder
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(slog.New(slog.DiscardHandler)) })
+
+	// A KBStore with no JetStream client makes kb.Create fail deterministically
+	// (independent of the randomly generated knowledge base id), so the
+	// rollback path is reached without needing to force a real id collision.
+	kb := handlers_ochrevector.NewKBStore(nil)
+	vector := &fakeBedrockAgentVectorService{deleteIndexErr: errors.New("rollback backend unavailable")}
+
+	_, err := CreateKnowledgeBase(context.Background(), bedrockAgentTestAccount, "us-east-1", kb, vector, validCreateKBInput())
+	require.Error(t, err)
+	// The caller-visible error is kb.Create's own failure, not the rollback's.
+	assert.Contains(t, err.Error(), "knowledge base store has no JetStream client configured")
+	assert.NotContains(t, err.Error(), "rollback backend unavailable")
+
+	require.Len(t, vector.deletedIndexIDs, 1, "rollback delete must still be attempted")
+	orphanedIndexID := vector.deletedIndexIDs[0]
+
+	logOutput := buf.String()
+	assert.Contains(t, logOutput, "level=ERROR")
+	assert.Contains(t, logOutput, "orphaned index")
+	assert.Contains(t, logOutput, orphanedIndexID)
+	assert.Contains(t, logOutput, "rollback backend unavailable")
+}
+
 func TestDeleteKnowledgeBase_CascadesDataSourcesAndDeletesBoundIndex(t *testing.T) {
 	kb, ds := newBedrockAgentTestStores(t)
 	ctx := context.Background()
@@ -250,6 +286,45 @@ func TestDeleteKnowledgeBase_UnknownIDReturnsNotFound(t *testing.T) {
 	_, err := DeleteKnowledgeBase(context.Background(), bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.DeleteKnowledgeBaseInput{KnowledgeBaseId: aws.String("does-not-exist")})
 	require.Error(t, err)
 	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+// TestDeleteKnowledgeBase_TreatsMissingIndexAsAlreadyDeleted proves a bound
+// index that is already gone (ErrIndexNotFound) does not abort the delete
+// before KBStore.Delete runs: a KB record must never be left dangling,
+// pointing at an index that no longer exists, just because that index
+// happened to be deleted (or never provisioned) out from under it. Delete is
+// idempotent w.r.t. a missing index, mirroring KBStore.Delete's own
+// idempotent contract.
+func TestDeleteKnowledgeBase_TreatsMissingIndexAsAlreadyDeleted(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-gone", Status: handlers_ochrevector.StateReady}))
+
+	vector := &fakeBedrockAgentVectorService{deleteIndexErr: handlers_ochrevector.ErrIndexNotFound}
+	_, err := DeleteKnowledgeBase(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.DeleteKnowledgeBaseInput{KnowledgeBaseId: aws.String("kb-1")})
+	require.NoError(t, err)
+
+	got, err := kb.Get(ctx, bedrockAgentTestAccount, "kb-1")
+	require.NoError(t, err)
+	assert.Nil(t, got, "the KB record must not dangle once its bound index is confirmed gone")
+}
+
+// TestDeleteKnowledgeBase_GenuineIndexDeleteErrorStillAborts proves the
+// ErrIndexNotFound tolerance above is narrow: any other DeleteIndex failure
+// must still abort before KBStore.Delete runs, so the KB record survives to
+// be retried.
+func TestDeleteKnowledgeBase_GenuineIndexDeleteErrorStillAborts(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1", Status: handlers_ochrevector.StateReady}))
+
+	vector := &fakeBedrockAgentVectorService{deleteIndexErr: errors.New("backend unavailable")}
+	_, err := DeleteKnowledgeBase(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.DeleteKnowledgeBaseInput{KnowledgeBaseId: aws.String("kb-1")})
+	require.Error(t, err)
+
+	got, err := kb.Get(ctx, bedrockAgentTestAccount, "kb-1")
+	require.NoError(t, err)
+	assert.NotNil(t, got, "a genuine index-delete failure must leave the KB record in place for retry")
 }
 
 func createDataSourceInput(chunking *bedrockagent.VectorIngestionConfiguration) *bedrockagent.CreateDataSourceInput {
@@ -369,15 +444,57 @@ func TestGetIngestionJob_RejectsJobFromForeignIndex(t *testing.T) {
 	kb, ds := newBedrockAgentTestStores(t)
 	ctx := context.Background()
 	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
+		ID: "ds-1", KnowledgeBaseID: "kb-1",
+		Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"},
+	}))
 
 	vector := &fakeBedrockAgentVectorService{describeJobResp: handlers_ochrevector.DescribeJobResponse{
-		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-other"},
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-other", Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"}},
 	}}
 	_, err := GetIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.GetIngestionJobInput{
 		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-1"), IngestionJobId: aws.String("job-1"),
 	})
 	require.Error(t, err)
 	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+// TestGetIngestionJob_RejectsWrongDataSource proves a job addressed through
+// the wrong dataSourceId path segment is rejected even when its IndexID
+// matches the knowledge base: a job that really belongs to one data source
+// must not be readable by guessing a second, unrelated data source's id
+// under the same KB. Regression test for the ownership check ListIngestionJobs
+// already had but GetIngestionJob was missing.
+func TestGetIngestionJob_RejectsWrongDataSource(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
+		ID: "ds-a", KnowledgeBaseID: "kb-1",
+		Source: handlers_ochrevector.SourceSpec{Bucket: "bucket-a", Prefix: "a/"},
+	}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
+		ID: "ds-b", KnowledgeBaseID: "kb-1",
+		Source: handlers_ochrevector.SourceSpec{Bucket: "bucket-b", Prefix: "b/"},
+	}))
+
+	// job-1 really belongs to ds-a (matching Bucket+Prefix), but the request
+	// below addresses it through ds-b's path.
+	vector := &fakeBedrockAgentVectorService{describeJobResp: handlers_ochrevector.DescribeJobResponse{
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-1", Source: handlers_ochrevector.SourceSpec{Bucket: "bucket-a", Prefix: "a/"}},
+	}}
+	_, err := GetIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.GetIngestionJobInput{
+		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-b"), IngestionJobId: aws.String("job-1"),
+	})
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+
+	// Addressed through its real data source, the same job resolves fine.
+	out, err := GetIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.GetIngestionJobInput{
+		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-a"), IngestionJobId: aws.String("job-1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "job-1", aws.StringValue(out.IngestionJob.IngestionJobId))
 }
 
 func TestListIngestionJobs_FiltersToBoundIndexAndDataSourceSourceSpec(t *testing.T) {

--- a/spinifex/gateway/bedrockagent_test.go
+++ b/spinifex/gateway/bedrockagent_test.go
@@ -1,0 +1,397 @@
+// In-package: exercises the unexported AWS<->internal mapper helpers
+// (kbStatusToAWS, embeddingModelIDFromARN, sourceSpecMatchesDataSource, ...)
+// directly, alongside the operation-level tests through the exported
+// Create/Get/List/Delete functions.
+//
+//test:in-package
+package gateway
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrockagent"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const bedrockAgentTestAccount = "111111111111"
+
+// fakeBedrockAgentVectorService serves scripted responses so bedrockagent.go's
+// mapping logic can be exercised without a daemon or a live NATS connection,
+// mirroring cmd/spinifex/cmd's fakeVectorService for this package.
+type fakeBedrockAgentVectorService struct {
+	createIndexReq *handlers_ochrevector.CreateIndexRequest
+	createIndexErr error
+
+	deletedIndexIDs []string
+	deleteIndexErr  error
+
+	ingestReq  *handlers_ochrevector.IngestRequest
+	ingestResp handlers_ochrevector.IngestResponse
+	ingestErr  error
+
+	describeJobResp handlers_ochrevector.DescribeJobResponse
+	describeJobErr  error
+
+	listJobsResp handlers_ochrevector.ListJobsResponse
+	listJobsErr  error
+}
+
+func (f *fakeBedrockAgentVectorService) CreateIndex(_ context.Context, req *handlers_ochrevector.CreateIndexRequest, _ string) (*handlers_ochrevector.CreateIndexResponse, error) {
+	f.createIndexReq = req
+	if f.createIndexErr != nil {
+		return nil, f.createIndexErr
+	}
+	return &handlers_ochrevector.CreateIndexResponse{Index: handlers_ochrevector.Record{
+		ID: req.IndexID, Name: req.Name, Dimension: req.Dimension,
+		EmbeddingModel: req.EmbeddingModel, State: handlers_ochrevector.StateReady,
+	}}, nil
+}
+
+func (f *fakeBedrockAgentVectorService) DeleteIndex(_ context.Context, req *handlers_ochrevector.DeleteIndexRequest, _ string) (*handlers_ochrevector.DeleteIndexResponse, error) {
+	f.deletedIndexIDs = append(f.deletedIndexIDs, req.IndexID)
+	if f.deleteIndexErr != nil {
+		return nil, f.deleteIndexErr
+	}
+	return &handlers_ochrevector.DeleteIndexResponse{}, nil
+}
+
+func (f *fakeBedrockAgentVectorService) ListIndexes(_ context.Context, _ *handlers_ochrevector.ListIndexesRequest, _ string) (*handlers_ochrevector.ListIndexesResponse, error) {
+	return &handlers_ochrevector.ListIndexesResponse{}, nil
+}
+
+func (f *fakeBedrockAgentVectorService) Ingest(_ context.Context, req *handlers_ochrevector.IngestRequest, _ string) (*handlers_ochrevector.IngestResponse, error) {
+	f.ingestReq = req
+	if f.ingestErr != nil {
+		return nil, f.ingestErr
+	}
+	resp := f.ingestResp
+	return &resp, nil
+}
+
+func (f *fakeBedrockAgentVectorService) DescribeJob(_ context.Context, _ *handlers_ochrevector.DescribeJobRequest, _ string) (*handlers_ochrevector.DescribeJobResponse, error) {
+	if f.describeJobErr != nil {
+		return nil, f.describeJobErr
+	}
+	resp := f.describeJobResp
+	return &resp, nil
+}
+
+func (f *fakeBedrockAgentVectorService) ListJobs(_ context.Context, _ *handlers_ochrevector.ListJobsRequest, _ string) (*handlers_ochrevector.ListJobsResponse, error) {
+	if f.listJobsErr != nil {
+		return nil, f.listJobsErr
+	}
+	resp := f.listJobsResp
+	return &resp, nil
+}
+
+func (f *fakeBedrockAgentVectorService) Query(_ context.Context, _ *handlers_ochrevector.QueryRequest, _ string) (*handlers_ochrevector.QueryResponse, error) {
+	return &handlers_ochrevector.QueryResponse{}, nil
+}
+
+var _ handlers_ochrevector.VectorService = (*fakeBedrockAgentVectorService)(nil)
+
+func newBedrockAgentTestStores(t *testing.T) (*handlers_ochrevector.KBStore, *handlers_ochrevector.DataSourceStore) {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	return handlers_ochrevector.NewKBStore(js), handlers_ochrevector.NewDataSourceStore(js)
+}
+
+func TestEmbeddingModelIDFromARN(t *testing.T) {
+	cases := []struct{ arn, want string }{
+		{"arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v2:0", "amazon.titan-embed-text-v2:0"},
+		{"amazon.titan-embed-text-v2:0", "amazon.titan-embed-text-v2:0"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, embeddingModelIDFromARN(tc.arn))
+	}
+}
+
+func TestBucketNameFromS3ARN_And_FormatS3BucketARN_RoundTrip(t *testing.T) {
+	assert.Equal(t, "my-bucket", bucketNameFromS3ARN("arn:aws:s3:::my-bucket"))
+	assert.Equal(t, "my-bucket", bucketNameFromS3ARN("my-bucket"))
+	assert.Equal(t, "arn:aws:s3:::my-bucket", formatS3BucketARN("my-bucket"))
+	assert.Equal(t, "my-bucket", bucketNameFromS3ARN(formatS3BucketARN("my-bucket")))
+}
+
+func TestKBStatusToAWS(t *testing.T) {
+	cases := []struct{ status, want string }{
+		{handlers_ochrevector.StateReady, bedrockagent.KnowledgeBaseStatusActive},
+		{handlers_ochrevector.StateCreating, bedrockagent.KnowledgeBaseStatusCreating},
+		{handlers_ochrevector.StateDeleting, bedrockagent.KnowledgeBaseStatusDeleting},
+		{handlers_ochrevector.StateStale, bedrockagent.KnowledgeBaseStatusFailed},
+		{"unknown", bedrockagent.KnowledgeBaseStatusFailed},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, kbStatusToAWS(tc.status))
+	}
+}
+
+func TestDataSourceStatusToAWS(t *testing.T) {
+	assert.Equal(t, bedrockagent.DataSourceStatusDeleting, dataSourceStatusToAWS(handlers_ochrevector.StateDeleting))
+	assert.Equal(t, bedrockagent.DataSourceStatusAvailable, dataSourceStatusToAWS(handlers_ochrevector.StateReady))
+}
+
+func TestJobStateToAWS(t *testing.T) {
+	cases := []struct{ state, want string }{
+		{handlers_ochrevector.JobStatePending, bedrockagent.IngestionJobStatusStarting},
+		{handlers_ochrevector.JobStateRunning, bedrockagent.IngestionJobStatusInProgress},
+		{handlers_ochrevector.JobStateReady, bedrockagent.IngestionJobStatusComplete},
+		{handlers_ochrevector.JobStateFailed, bedrockagent.IngestionJobStatusFailed},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, jobStateToAWS(tc.state))
+	}
+}
+
+func TestTranslateVectorErr(t *testing.T) {
+	assert.NoError(t, translateVectorErr(nil))
+	assert.True(t, awserrors.IsErrorCode(translateVectorErr(handlers_ochrevector.ErrIndexNotFound), awserrors.ErrorResourceNotFoundException))
+	assert.True(t, awserrors.IsErrorCode(translateVectorErr(handlers_ochrevector.ErrJobNotFound), awserrors.ErrorResourceNotFoundException))
+	assert.True(t, awserrors.IsErrorCode(translateVectorErr(handlers_ochrevector.ErrIndexExists), awserrors.ErrorConflictException))
+}
+
+func TestSourceSpecMatchesDataSource(t *testing.T) {
+	ds := handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "docs/"}
+	assert.True(t, sourceSpecMatchesDataSource(handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "docs/"}, ds))
+	assert.False(t, sourceSpecMatchesDataSource(handlers_ochrevector.SourceSpec{Bucket: "other", Prefix: "docs/"}, ds))
+	assert.False(t, sourceSpecMatchesDataSource(handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "other/"}, ds))
+}
+
+func validCreateKBInput() *bedrockagent.CreateKnowledgeBaseInput {
+	return &bedrockagent.CreateKnowledgeBaseInput{
+		Name:                 aws.String("docs"),
+		RoleArn:              aws.String("arn:aws:iam::111111111111:role/kb-role"),
+		StorageConfiguration: &bedrockagent.StorageConfiguration{Type: aws.String("OPENSEARCH_SERVERLESS")},
+		KnowledgeBaseConfiguration: &bedrockagent.KnowledgeBaseConfiguration{
+			Type: aws.String(bedrockagent.KnowledgeBaseTypeVector),
+			VectorKnowledgeBaseConfiguration: &bedrockagent.VectorKnowledgeBaseConfiguration{
+				EmbeddingModelArn: aws.String("arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v2:0"),
+				EmbeddingModelConfiguration: &bedrockagent.EmbeddingModelConfiguration{
+					BedrockEmbeddingModelConfiguration: &bedrockagent.BedrockEmbeddingModelConfiguration{Dimensions: aws.Int64(1024)},
+				},
+			},
+		},
+	}
+}
+
+func TestCreateKnowledgeBase_MapsEmbeddingModelAndDimension(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	vector := &fakeBedrockAgentVectorService{}
+	ctx := context.Background()
+
+	out, err := CreateKnowledgeBase(ctx, bedrockAgentTestAccount, "us-east-1", kb, vector, validCreateKBInput())
+	require.NoError(t, err)
+
+	require.NotNil(t, vector.createIndexReq)
+	assert.Equal(t, 1024, vector.createIndexReq.Dimension)
+	assert.Equal(t, "amazon.titan-embed-text-v2:0", vector.createIndexReq.EmbeddingModel)
+
+	assert.Equal(t, bedrockagent.KnowledgeBaseStatusActive, aws.StringValue(out.KnowledgeBase.Status))
+	assert.Equal(t, "docs", aws.StringValue(out.KnowledgeBase.Name))
+	dims := out.KnowledgeBase.KnowledgeBaseConfiguration.VectorKnowledgeBaseConfiguration.EmbeddingModelConfiguration.BedrockEmbeddingModelConfiguration.Dimensions
+	assert.Equal(t, int64(1024), aws.Int64Value(dims))
+	assert.Contains(t, aws.StringValue(out.KnowledgeBase.KnowledgeBaseArn), "knowledge-base/")
+}
+
+func TestCreateKnowledgeBase_MissingDimensionsIsValidationException(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	vector := &fakeBedrockAgentVectorService{}
+	input := validCreateKBInput()
+	input.KnowledgeBaseConfiguration.VectorKnowledgeBaseConfiguration.EmbeddingModelConfiguration = nil
+
+	_, err := CreateKnowledgeBase(context.Background(), bedrockAgentTestAccount, "us-east-1", kb, vector, input)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorValidationException))
+}
+
+func TestDeleteKnowledgeBase_CascadesDataSourcesAndDeletesBoundIndex(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1", Status: handlers_ochrevector.StateReady}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{ID: "ds-1", KnowledgeBaseID: "kb-1"}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{ID: "ds-2", KnowledgeBaseID: "kb-1"}))
+
+	vector := &fakeBedrockAgentVectorService{}
+	_, err := DeleteKnowledgeBase(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.DeleteKnowledgeBaseInput{KnowledgeBaseId: aws.String("kb-1")})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"idx-1"}, vector.deletedIndexIDs)
+
+	remaining, err := ds.ListByKnowledgeBase(ctx, bedrockAgentTestAccount, "kb-1")
+	require.NoError(t, err)
+	assert.Empty(t, remaining)
+
+	got, err := kb.Get(ctx, bedrockAgentTestAccount, "kb-1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestDeleteKnowledgeBase_UnknownIDReturnsNotFound(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	vector := &fakeBedrockAgentVectorService{}
+	_, err := DeleteKnowledgeBase(context.Background(), bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.DeleteKnowledgeBaseInput{KnowledgeBaseId: aws.String("does-not-exist")})
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func createDataSourceInput(chunking *bedrockagent.VectorIngestionConfiguration) *bedrockagent.CreateDataSourceInput {
+	return &bedrockagent.CreateDataSourceInput{
+		KnowledgeBaseId: aws.String("kb-1"),
+		Name:            aws.String("s3-docs"),
+		DataSourceConfiguration: &bedrockagent.DataSourceConfiguration{
+			Type: aws.String(bedrockagent.DataSourceTypeS3),
+			S3Configuration: &bedrockagent.S3DataSourceConfiguration{
+				BucketArn:         aws.String("arn:aws:s3:::my-bucket"),
+				InclusionPrefixes: []*string{aws.String("docs/")},
+			},
+		},
+		VectorIngestionConfiguration: chunking,
+	}
+}
+
+// D3: ChunkOverlap = round(maxTokens * overlapPercentage/100).
+func TestCreateDataSource_ChunkingUnitConversion(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{
+		ID: "kb-1", IndexID: "idx-1", Status: handlers_ochrevector.StateReady,
+		EmbeddingModel: "titan", Dimension: 1024,
+	}))
+
+	input := createDataSourceInput(&bedrockagent.VectorIngestionConfiguration{
+		ChunkingConfiguration: &bedrockagent.ChunkingConfiguration{
+			ChunkingStrategy: aws.String(bedrockagent.ChunkingStrategyFixedSize),
+			FixedSizeChunkingConfiguration: &bedrockagent.FixedSizeChunkingConfiguration{
+				MaxTokens:         aws.Int64(300),
+				OverlapPercentage: aws.Int64(20),
+			},
+		},
+	})
+
+	out, err := CreateDataSource(ctx, bedrockAgentTestAccount, "us-east-1", kb, ds, input)
+	require.NoError(t, err)
+
+	rec, err := ds.Get(ctx, bedrockAgentTestAccount, aws.StringValue(out.DataSource.DataSourceId))
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Equal(t, 300, rec.Source.ChunkSize)
+	assert.Equal(t, 60, rec.Source.ChunkOverlap)
+	assert.Equal(t, "my-bucket", rec.Source.Bucket)
+	assert.Equal(t, "docs/", rec.Source.Prefix)
+	// EmbeddingModel/Dimension are inherited from the bound knowledge base.
+	assert.Equal(t, "titan", rec.Source.EmbeddingModel)
+	assert.Equal(t, 1024, rec.Source.Dimension)
+
+	assert.Equal(t, "arn:aws:s3:::my-bucket", aws.StringValue(out.DataSource.DataSourceConfiguration.S3Configuration.BucketArn))
+}
+
+// D3: an omitted chunking block leaves ChunkSize/ChunkOverlap zero, so .9's
+// own ingest path applies its defaults rather than this layer inventing one.
+func TestCreateDataSource_OmittedChunkingLeavesZeroValues(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1", Status: handlers_ochrevector.StateReady}))
+
+	out, err := CreateDataSource(ctx, bedrockAgentTestAccount, "us-east-1", kb, ds, createDataSourceInput(nil))
+	require.NoError(t, err)
+
+	rec, err := ds.Get(ctx, bedrockAgentTestAccount, aws.StringValue(out.DataSource.DataSourceId))
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Zero(t, rec.Source.ChunkSize)
+	assert.Zero(t, rec.Source.ChunkOverlap)
+}
+
+func TestCreateDataSource_RejectsNonS3Type(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
+
+	input := createDataSourceInput(nil)
+	input.DataSourceConfiguration.Type = aws.String("WEB")
+	input.DataSourceConfiguration.S3Configuration = nil
+
+	_, err := CreateDataSource(ctx, bedrockAgentTestAccount, "us-east-1", kb, ds, input)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorValidationException))
+}
+
+func TestCreateDataSource_UnknownKnowledgeBaseIsNotFound(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	_, err := CreateDataSource(context.Background(), bedrockAgentTestAccount, "us-east-1", kb, ds, createDataSourceInput(nil))
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestStartIngestionJob_BuildsIngestRequestFromDataSourceAgainstBoundIndex(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1", Status: handlers_ochrevector.StateReady}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
+		ID: "ds-1", KnowledgeBaseID: "kb-1",
+		Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"},
+	}))
+
+	vector := &fakeBedrockAgentVectorService{ingestResp: handlers_ochrevector.IngestResponse{
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-1", State: handlers_ochrevector.JobStatePending},
+	}}
+	out, err := StartIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.StartIngestionJobInput{
+		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-1"),
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, vector.ingestReq)
+	assert.Equal(t, "idx-1", vector.ingestReq.IndexID)
+	assert.Equal(t, "b1", vector.ingestReq.Source.Bucket)
+	assert.Equal(t, "p1", vector.ingestReq.Source.Prefix)
+	assert.Equal(t, bedrockagent.IngestionJobStatusStarting, aws.StringValue(out.IngestionJob.Status))
+}
+
+func TestGetIngestionJob_RejectsJobFromForeignIndex(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
+
+	vector := &fakeBedrockAgentVectorService{describeJobResp: handlers_ochrevector.DescribeJobResponse{
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-other"},
+	}}
+	_, err := GetIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.GetIngestionJobInput{
+		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-1"), IngestionJobId: aws.String("job-1"),
+	})
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestListIngestionJobs_FiltersToBoundIndexAndDataSourceSourceSpec(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
+		ID: "ds-1", KnowledgeBaseID: "kb-1",
+		Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"},
+	}))
+
+	now := time.Now().UTC()
+	vector := &fakeBedrockAgentVectorService{listJobsResp: handlers_ochrevector.ListJobsResponse{Jobs: []handlers_ochrevector.JobRecord{
+		{ID: "job-match", IndexID: "idx-1", Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"}, State: handlers_ochrevector.JobStateReady, CreatedAt: now, UpdatedAt: now},
+		{ID: "job-wrong-index", IndexID: "idx-2", Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"}, CreatedAt: now, UpdatedAt: now},
+		{ID: "job-wrong-source", IndexID: "idx-1", Source: handlers_ochrevector.SourceSpec{Bucket: "other"}, CreatedAt: now, UpdatedAt: now},
+	}}}
+
+	out, err := ListIngestionJobs(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.ListIngestionJobsInput{
+		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-1"),
+	})
+	require.NoError(t, err)
+	require.Len(t, out.IngestionJobSummaries, 1)
+	assert.Equal(t, "job-match", aws.StringValue(out.IngestionJobSummaries[0].IngestionJobId))
+	assert.Equal(t, bedrockagent.IngestionJobStatusComplete, aws.StringValue(out.IngestionJobSummaries[0].Status))
+}

--- a/spinifex/gateway/bedrockagent_test.go
+++ b/spinifex/gateway/bedrockagent_test.go
@@ -41,6 +41,10 @@ type fakeBedrockAgentVectorService struct {
 
 	listJobsResp handlers_ochrevector.ListJobsResponse
 	listJobsErr  error
+
+	queryReq  *handlers_ochrevector.QueryRequest
+	queryResp handlers_ochrevector.QueryResponse
+	queryErr  error
 }
 
 func (f *fakeBedrockAgentVectorService) CreateIndex(_ context.Context, req *handlers_ochrevector.CreateIndexRequest, _ string) (*handlers_ochrevector.CreateIndexResponse, error) {
@@ -91,8 +95,13 @@ func (f *fakeBedrockAgentVectorService) ListJobs(_ context.Context, _ *handlers_
 	return &resp, nil
 }
 
-func (f *fakeBedrockAgentVectorService) Query(_ context.Context, _ *handlers_ochrevector.QueryRequest, _ string) (*handlers_ochrevector.QueryResponse, error) {
-	return &handlers_ochrevector.QueryResponse{}, nil
+func (f *fakeBedrockAgentVectorService) Query(_ context.Context, req *handlers_ochrevector.QueryRequest, _ string) (*handlers_ochrevector.QueryResponse, error) {
+	f.queryReq = req
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	resp := f.queryResp
+	return &resp, nil
 }
 
 var _ handlers_ochrevector.VectorService = (*fakeBedrockAgentVectorService)(nil)

--- a/spinifex/gateway/bedrockagent_test.go
+++ b/spinifex/gateway/bedrockagent_test.go
@@ -1,7 +1,7 @@
 // In-package: exercises the unexported AWS<->internal mapper helpers
-// (kbStatusToAWS, embeddingModelIDFromARN, sourceSpecMatchesDataSource, ...)
-// directly, alongside the operation-level tests through the exported
-// Create/Get/List/Delete functions.
+// (kbStatusToAWS, embeddingModelIDFromARN, ...) directly, alongside the
+// operation-level tests through the exported Create/Get/List/Delete
+// functions.
 //
 //test:in-package
 package gateway
@@ -168,13 +168,6 @@ func TestTranslateVectorErr(t *testing.T) {
 	assert.True(t, awserrors.IsErrorCode(translateVectorErr(handlers_ochrevector.ErrIndexNotFound), awserrors.ErrorResourceNotFoundException))
 	assert.True(t, awserrors.IsErrorCode(translateVectorErr(handlers_ochrevector.ErrJobNotFound), awserrors.ErrorResourceNotFoundException))
 	assert.True(t, awserrors.IsErrorCode(translateVectorErr(handlers_ochrevector.ErrIndexExists), awserrors.ErrorConflictException))
-}
-
-func TestSourceSpecMatchesDataSource(t *testing.T) {
-	ds := handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "docs/"}
-	assert.True(t, sourceSpecMatchesDataSource(handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "docs/"}, ds))
-	assert.False(t, sourceSpecMatchesDataSource(handlers_ochrevector.SourceSpec{Bucket: "other", Prefix: "docs/"}, ds))
-	assert.False(t, sourceSpecMatchesDataSource(handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "other/"}, ds))
 }
 
 func validCreateKBInput() *bedrockagent.CreateKnowledgeBaseInput {
@@ -426,7 +419,7 @@ func TestStartIngestionJob_BuildsIngestRequestFromDataSourceAgainstBoundIndex(t 
 	}))
 
 	vector := &fakeBedrockAgentVectorService{ingestResp: handlers_ochrevector.IngestResponse{
-		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-1", State: handlers_ochrevector.JobStatePending},
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-1", DataSourceID: "ds-1", State: handlers_ochrevector.JobStatePending},
 	}}
 	out, err := StartIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.StartIngestionJobInput{
 		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-1"),
@@ -435,6 +428,7 @@ func TestStartIngestionJob_BuildsIngestRequestFromDataSourceAgainstBoundIndex(t 
 
 	require.NotNil(t, vector.ingestReq)
 	assert.Equal(t, "idx-1", vector.ingestReq.IndexID)
+	assert.Equal(t, "ds-1", vector.ingestReq.DataSourceID)
 	assert.Equal(t, "b1", vector.ingestReq.Source.Bucket)
 	assert.Equal(t, "p1", vector.ingestReq.Source.Prefix)
 	assert.Equal(t, bedrockagent.IngestionJobStatusStarting, aws.StringValue(out.IngestionJob.Status))
@@ -450,7 +444,7 @@ func TestGetIngestionJob_RejectsJobFromForeignIndex(t *testing.T) {
 	}))
 
 	vector := &fakeBedrockAgentVectorService{describeJobResp: handlers_ochrevector.DescribeJobResponse{
-		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-other", Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"}},
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-other", DataSourceID: "ds-1"},
 	}}
 	_, err := GetIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.GetIngestionJobInput{
 		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-1"), IngestionJobId: aws.String("job-1"),
@@ -462,26 +456,21 @@ func TestGetIngestionJob_RejectsJobFromForeignIndex(t *testing.T) {
 // TestGetIngestionJob_RejectsWrongDataSource proves a job addressed through
 // the wrong dataSourceId path segment is rejected even when its IndexID
 // matches the knowledge base: a job that really belongs to one data source
-// must not be readable by guessing a second, unrelated data source's id
-// under the same KB. Regression test for the ownership check ListIngestionJobs
-// already had but GetIngestionJob was missing.
+// (its exact DataSourceID) must not be readable by guessing a second,
+// unrelated data source's id under the same KB. Regression test for the
+// ownership check ListIngestionJobs already had but GetIngestionJob was
+// missing.
 func TestGetIngestionJob_RejectsWrongDataSource(t *testing.T) {
 	kb, ds := newBedrockAgentTestStores(t)
 	ctx := context.Background()
 	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
-	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
-		ID: "ds-a", KnowledgeBaseID: "kb-1",
-		Source: handlers_ochrevector.SourceSpec{Bucket: "bucket-a", Prefix: "a/"},
-	}))
-	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
-		ID: "ds-b", KnowledgeBaseID: "kb-1",
-		Source: handlers_ochrevector.SourceSpec{Bucket: "bucket-b", Prefix: "b/"},
-	}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{ID: "ds-a", KnowledgeBaseID: "kb-1"}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{ID: "ds-b", KnowledgeBaseID: "kb-1"}))
 
-	// job-1 really belongs to ds-a (matching Bucket+Prefix), but the request
+	// job-1 really belongs to ds-a (its exact DataSourceID), but the request
 	// below addresses it through ds-b's path.
 	vector := &fakeBedrockAgentVectorService{describeJobResp: handlers_ochrevector.DescribeJobResponse{
-		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-1", Source: handlers_ochrevector.SourceSpec{Bucket: "bucket-a", Prefix: "a/"}},
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-1", DataSourceID: "ds-a"},
 	}}
 	_, err := GetIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.GetIngestionJobInput{
 		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-b"), IngestionJobId: aws.String("job-1"),
@@ -497,20 +486,38 @@ func TestGetIngestionJob_RejectsWrongDataSource(t *testing.T) {
 	assert.Equal(t, "job-1", aws.StringValue(out.IngestionJob.IngestionJobId))
 }
 
-func TestListIngestionJobs_FiltersToBoundIndexAndDataSourceSourceSpec(t *testing.T) {
+// TestGetIngestionJob_RejectsEmptyDataSourceID proves a job with no
+// DataSourceID at all (started directly against ochre.vector.ingest, not
+// through a bedrock-agent data source) is never returned through a
+// dataSourceId path, no matter which data source id is addressed.
+func TestGetIngestionJob_RejectsEmptyDataSourceID(t *testing.T) {
 	kb, ds := newBedrockAgentTestStores(t)
 	ctx := context.Background()
 	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
-	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{
-		ID: "ds-1", KnowledgeBaseID: "kb-1",
-		Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"},
-	}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{ID: "ds-1", KnowledgeBaseID: "kb-1"}))
+
+	vector := &fakeBedrockAgentVectorService{describeJobResp: handlers_ochrevector.DescribeJobResponse{
+		Job: handlers_ochrevector.JobRecord{ID: "job-1", IndexID: "idx-1", DataSourceID: ""},
+	}}
+	_, err := GetIngestionJob(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.GetIngestionJobInput{
+		KnowledgeBaseId: aws.String("kb-1"), DataSourceId: aws.String("ds-1"), IngestionJobId: aws.String("job-1"),
+	})
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestListIngestionJobs_FiltersToBoundIndexAndExactDataSourceID(t *testing.T) {
+	kb, ds := newBedrockAgentTestStores(t)
+	ctx := context.Background()
+	require.NoError(t, kb.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.KBRecord{ID: "kb-1", IndexID: "idx-1"}))
+	require.NoError(t, ds.Create(ctx, bedrockAgentTestAccount, handlers_ochrevector.DataSourceRecord{ID: "ds-1", KnowledgeBaseID: "kb-1"}))
 
 	now := time.Now().UTC()
 	vector := &fakeBedrockAgentVectorService{listJobsResp: handlers_ochrevector.ListJobsResponse{Jobs: []handlers_ochrevector.JobRecord{
-		{ID: "job-match", IndexID: "idx-1", Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"}, State: handlers_ochrevector.JobStateReady, CreatedAt: now, UpdatedAt: now},
-		{ID: "job-wrong-index", IndexID: "idx-2", Source: handlers_ochrevector.SourceSpec{Bucket: "b1", Prefix: "p1"}, CreatedAt: now, UpdatedAt: now},
-		{ID: "job-wrong-source", IndexID: "idx-1", Source: handlers_ochrevector.SourceSpec{Bucket: "other"}, CreatedAt: now, UpdatedAt: now},
+		{ID: "job-match", IndexID: "idx-1", DataSourceID: "ds-1", State: handlers_ochrevector.JobStateReady, CreatedAt: now, UpdatedAt: now},
+		{ID: "job-wrong-index", IndexID: "idx-2", DataSourceID: "ds-1", CreatedAt: now, UpdatedAt: now},
+		{ID: "job-wrong-datasource", IndexID: "idx-1", DataSourceID: "ds-other", CreatedAt: now, UpdatedAt: now},
+		{ID: "job-no-datasource", IndexID: "idx-1", DataSourceID: "", CreatedAt: now, UpdatedAt: now},
 	}}}
 
 	out, err := ListIngestionJobs(ctx, bedrockAgentTestAccount, kb, ds, vector, &bedrockagent.ListIngestionJobsInput{

--- a/spinifex/gateway/bedrockagentruntime.go
+++ b/spinifex/gateway/bedrockagentruntime.go
@@ -1,0 +1,602 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrockagentruntime"
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
+	"github.com/google/uuid"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
+)
+
+// converseFn is gateway_bedrock.Converse partially applied over the request's
+// resolved dependencies (credential/endpoint/access/provisioned/guardrail
+// resolvers), so a route handler needs only this one parameter to reach the
+// RetrieveAndGenerate generation step, mirroring how BedrockRuntime_Request
+// resolves the same six dependencies once per request.
+type converseFn func(ctx context.Context, accountID, modelID string, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error)
+
+// bedrockAgentRuntimeRoute maps one HTTP method + path regex to an AWS action
+// and handler, mirroring bedrockAgentRoute.
+type bedrockAgentRuntimeRoute struct {
+	method  string
+	pattern *regexp.Regexp
+	action  string
+	handler bedrockAgentRuntimeRouteHandler
+}
+
+// bedrockAgentRuntimeRouteHandler invokes a per-action bedrock-agent-runtime
+// (data-plane) gateway function. params holds the regex capture groups,
+// PathUnescape'd. body is the raw request bytes, needed alongside the typed
+// SDK input because RetrievalFilter's leaf operators must be recovered from
+// it directly (see wireFilter). kb/vector are gw.BedrockAgentKB/
+// gw.BedrockAgentVector, the same stores bedrock-agent's control plane uses.
+// converse reaches gateway_bedrock.Converse for RetrieveAndGenerate's
+// generation step.
+type bedrockAgentRuntimeRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, kb *handlers_ochrevector.KBStore, vector handlers_ochrevector.VectorService, converse converseFn) (any, error)
+
+// bedrockAgentRuntimeRoutes is the dispatch table. Real AWS HTTP paths/methods,
+// verified against the vendored aws-sdk-go bedrockagentruntime request
+// definitions (opRetrieve/opRetrieveAndGenerate).
+var bedrockAgentRuntimeRoutes = []bedrockAgentRuntimeRoute{
+	{"POST", regexp.MustCompile(`^/knowledgebases/([^/]+)/retrieve$`), "Retrieve",
+		func(ctx context.Context, acct string, p []string, b []byte, kb *handlers_ochrevector.KBStore, vector handlers_ochrevector.VectorService, _ converseFn) (any, error) {
+			input := new(bedrockagentruntime.RetrieveInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.KnowledgeBaseId = aws.String(p[0])
+			return Retrieve(ctx, acct, kb, vector, b, input)
+		}},
+	{"POST", regexp.MustCompile(`^/retrieveAndGenerate$`), "RetrieveAndGenerate",
+		func(ctx context.Context, acct string, _ []string, b []byte, kb *handlers_ochrevector.KBStore, vector handlers_ochrevector.VectorService, converse converseFn) (any, error) {
+			input := new(bedrockagentruntime.RetrieveAndGenerateInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			return RetrieveAndGenerate(ctx, acct, kb, vector, converse, b, input)
+		}},
+}
+
+// lookupBedrockAgentRuntimeAction matches method+path against
+// bedrockAgentRuntimeRoutes, mirroring lookupBedrockAgentAction.
+func lookupBedrockAgentRuntimeAction(method, path string) (string, []string, bedrockAgentRuntimeRouteHandler, bool) {
+	for _, route := range bedrockAgentRuntimeRoutes {
+		if route.method != method {
+			continue
+		}
+		m := route.pattern.FindStringSubmatch(path)
+		if m == nil {
+			continue
+		}
+		var params []string
+		if len(m) > 1 {
+			params = make([]string, 0, len(m)-1)
+			for _, raw := range m[1:] {
+				decoded, err := url.PathUnescape(raw)
+				if err != nil {
+					slog.Debug("bedrock-agent-runtime: bad percent-encoding in path param", "param", raw, "err", err)
+					decoded = raw
+				}
+				params = append(params, decoded)
+			}
+		}
+		return route.action, params, route.handler, true
+	}
+	return "", nil, nil, false
+}
+
+// BedrockAgentRuntime_Request dispatches bedrock-agent-runtime (data-plane)
+// REST-JSON requests: resolves method+path to an action, reads the body,
+// calls the handler, and serialises the output as JSON, mirroring
+// BedrockAgent_Request. RetrieveAndGenerate is metered the same way Converse
+// is on bedrock-runtime (it ends up calling gateway_bedrock.Converse
+// in-process); Retrieve never reaches a model, so it is not metered.
+func (gw *GatewayConfig) BedrockAgentRuntime_Request(w http.ResponseWriter, r *http.Request) error {
+	action, params, handler, ok := lookupBedrockAgentRuntimeAction(r.Method, r.URL.EscapedPath())
+	if !ok {
+		slog.DebugContext(r.Context(), "bedrock-agent-runtime: no route for request", "method", r.Method, "path", r.URL.Path)
+		return errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	if err := gw.checkPolicy(r, "bedrock-agent-runtime", action); err != nil {
+		return err
+	}
+
+	if gw.BedrockAgentKB == nil || gw.BedrockAgentVector == nil {
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.ErrorContext(r.Context(), "BedrockAgentRuntime_Request: no account ID in auth context")
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	if action == "RetrieveAndGenerate" {
+		if err := gw.Quota.CheckBedrockRPM(accountID); err != nil {
+			return err
+		}
+		if err := gw.Quota.CheckBedrockTokens(r.Context(), accountID); err != nil {
+			return err
+		}
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "BedrockAgentRuntime_Request: failed to read body", "err", err)
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	converse := func(ctx context.Context, acct, modelID string, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {
+		return gateway_bedrock.Converse(ctx, acct, modelID, input, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), gw.bedrockGuardrailStore())
+	}
+
+	output, err := handler(r.Context(), accountID, params, body, gw.BedrockAgentKB, gw.BedrockAgentVector, converse)
+	if err != nil {
+		return err
+	}
+
+	gateway_bedrock.WriteJSONResponse(w, output)
+	return nil
+}
+
+// wireFilterAttr is one leaf filter operator's {key, value} pair off the raw
+// request body. Value is untyped because its shape depends on the operator:
+// a scalar for equals/notEquals/greaterThan(OrEquals)/lessThan(OrEquals)/
+// startsWith/stringContains/listContains, a list for in/notIn.
+type wireFilterAttr struct {
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+}
+
+// wireFilter mirrors the full real-AWS bedrock-agent-runtime RetrievalFilter
+// wire shape's operator set (D9: equals/notEquals/greaterThan(OrEquals)/
+// lessThan(OrEquals)/in/notIn/startsWith/stringContains/listContains/andAll/
+// orAll).
+//
+// It exists because the vendored github.com/aws/aws-sdk-go v1.55.8
+// bedrockagentruntime.RetrievalFilter Go struct carries ONLY AndAll/OrAll —
+// its leaf-operator fields were never added to this SDK major version (aws-
+// sdk-go v1 is in maintenance mode and this filter shape landed after that).
+// json.Unmarshal into the vendored type silently drops every leaf condition
+// rather than erroring, which would make a caller's metadata filter silently
+// no-op instead of scoping results -- a correctness/security-relevant gap
+// (e.g. tenant- or document-class-scoping filters would silently stop
+// filtering), not just a missing echo field. This shadow type recovers the
+// full operator set directly from the raw request body instead.
+type wireFilter struct {
+	Equals              *wireFilterAttr `json:"equals,omitempty"`
+	NotEquals           *wireFilterAttr `json:"notEquals,omitempty"`
+	GreaterThan         *wireFilterAttr `json:"greaterThan,omitempty"`
+	GreaterThanOrEquals *wireFilterAttr `json:"greaterThanOrEquals,omitempty"`
+	LessThan            *wireFilterAttr `json:"lessThan,omitempty"`
+	LessThanOrEquals    *wireFilterAttr `json:"lessThanOrEquals,omitempty"`
+	In                  *wireFilterAttr `json:"in,omitempty"`
+	NotIn               *wireFilterAttr `json:"notIn,omitempty"`
+	StartsWith          *wireFilterAttr `json:"startsWith,omitempty"`
+	StringContains      *wireFilterAttr `json:"stringContains,omitempty"`
+	ListContains        *wireFilterAttr `json:"listContains,omitempty"`
+	AndAll              []wireFilter    `json:"andAll,omitempty"`
+	OrAll               []wireFilter    `json:"orAll,omitempty"`
+}
+
+// isZero reports whether f carries no operator at all, the shape an absent
+// filter or an empty JSON object ("filter":{}) decodes to.
+func (f *wireFilter) isZero() bool {
+	return f == nil || (f.Equals == nil && f.NotEquals == nil && f.GreaterThan == nil &&
+		f.GreaterThanOrEquals == nil && f.LessThan == nil && f.LessThanOrEquals == nil &&
+		f.In == nil && f.NotIn == nil && f.StartsWith == nil && f.StringContains == nil &&
+		f.ListContains == nil && len(f.AndAll) == 0 && len(f.OrAll) == 0)
+}
+
+// toFilter translates f onto ochrevector's Filter AST 1:1 by operator name
+// (D9), recursing into andAll/orAll. AWS's RetrievalFilter is a oneof (exactly
+// one operator per node); an over-specified node resolves the first non-nil
+// field in the fixed order below rather than erroring, consistent with how
+// the rest of this gateway treats an over-specified request as best-effort.
+func (f *wireFilter) toFilter() (*handlers_ochrevector.Filter, error) {
+	if f.isZero() {
+		return nil, nil
+	}
+	switch {
+	case f.Equals != nil:
+		return handlers_ochrevector.Equals(f.Equals.Key, f.Equals.Value), nil
+	case f.NotEquals != nil:
+		return handlers_ochrevector.NotEquals(f.NotEquals.Key, f.NotEquals.Value), nil
+	case f.GreaterThan != nil:
+		return handlers_ochrevector.GreaterThan(f.GreaterThan.Key, f.GreaterThan.Value), nil
+	case f.GreaterThanOrEquals != nil:
+		return handlers_ochrevector.GreaterThanOrEquals(f.GreaterThanOrEquals.Key, f.GreaterThanOrEquals.Value), nil
+	case f.LessThan != nil:
+		return handlers_ochrevector.LessThan(f.LessThan.Key, f.LessThan.Value), nil
+	case f.LessThanOrEquals != nil:
+		return handlers_ochrevector.LessThanOrEquals(f.LessThanOrEquals.Key, f.LessThanOrEquals.Value), nil
+	case f.In != nil:
+		values, err := wireFilterStringSlice(f.In.Value)
+		if err != nil {
+			return nil, fmt.Errorf("bedrock-agent-runtime: filter \"in\" on %q: %w", f.In.Key, err)
+		}
+		return handlers_ochrevector.In(f.In.Key, values), nil
+	case f.NotIn != nil:
+		values, err := wireFilterStringSlice(f.NotIn.Value)
+		if err != nil {
+			return nil, fmt.Errorf("bedrock-agent-runtime: filter \"notIn\" on %q: %w", f.NotIn.Key, err)
+		}
+		return handlers_ochrevector.NotIn(f.NotIn.Key, values), nil
+	case f.StartsWith != nil:
+		prefix, ok := f.StartsWith.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("bedrock-agent-runtime: filter \"startsWith\" on %q requires a string value", f.StartsWith.Key)
+		}
+		return handlers_ochrevector.StartsWith(f.StartsWith.Key, prefix), nil
+	case f.StringContains != nil:
+		substr, ok := f.StringContains.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("bedrock-agent-runtime: filter \"stringContains\" on %q requires a string value", f.StringContains.Key)
+		}
+		return handlers_ochrevector.StringContains(f.StringContains.Key, substr), nil
+	case f.ListContains != nil:
+		value, ok := f.ListContains.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("bedrock-agent-runtime: filter \"listContains\" on %q requires a string value", f.ListContains.Key)
+		}
+		return handlers_ochrevector.ListContains(f.ListContains.Key, value), nil
+	case len(f.AndAll) > 0:
+		children, err := wireFiltersToChildren(f.AndAll)
+		if err != nil {
+			return nil, err
+		}
+		return handlers_ochrevector.AndAll(children...), nil
+	default: // len(f.OrAll) > 0, the only remaining non-zero case.
+		children, err := wireFiltersToChildren(f.OrAll)
+		if err != nil {
+			return nil, err
+		}
+		return handlers_ochrevector.OrAll(children...), nil
+	}
+}
+
+// wireFiltersToChildren translates a combinator's child list, rejecting any
+// child that itself carries no operator (a malformed request, not a filter
+// that matches nothing).
+func wireFiltersToChildren(fs []wireFilter) ([]*handlers_ochrevector.Filter, error) {
+	children := make([]*handlers_ochrevector.Filter, 0, len(fs))
+	for i := range fs {
+		child, err := fs[i].toFilter()
+		if err != nil {
+			return nil, err
+		}
+		if child == nil {
+			return nil, errors.New("bedrock-agent-runtime: empty filter condition in combinator")
+		}
+		children = append(children, child)
+	}
+	return children, nil
+}
+
+// wireFilterStringSlice coerces a decoded JSON value (a []any of strings
+// after json.Unmarshal, since encoding/json has no []string-specific
+// decoding for an any field) to []string for in/notIn.
+func wireFilterStringSlice(v any) ([]string, error) {
+	list, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("requires a list value, got %T", v)
+	}
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("requires a list of strings, got %T element", item)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// retrieveFilterEnvelope decodes only the nested filter object from a
+// Retrieve request body, bypassing the vendored SDK's leaf-incomplete
+// RetrievalFilter type (see wireFilter's doc comment for why).
+type retrieveFilterEnvelope struct {
+	RetrievalConfiguration *struct {
+		VectorSearchConfiguration *struct {
+			Filter *wireFilter `json:"filter"`
+		} `json:"vectorSearchConfiguration"`
+	} `json:"retrievalConfiguration"`
+}
+
+// decodeRetrieveFilter extracts and translates Retrieve's filter from the raw
+// request body, returning (nil, nil) when no filter was sent.
+func decodeRetrieveFilter(body []byte) (*handlers_ochrevector.Filter, error) {
+	if len(body) == 0 {
+		return nil, nil
+	}
+	var env retrieveFilterEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, err
+	}
+	if env.RetrievalConfiguration == nil || env.RetrievalConfiguration.VectorSearchConfiguration == nil {
+		return nil, nil
+	}
+	return env.RetrievalConfiguration.VectorSearchConfiguration.Filter.toFilter()
+}
+
+// retrieveAndGenerateFilterEnvelope is decodeRetrieveFilter's sibling for
+// RetrieveAndGenerate's more deeply nested
+// retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.
+// retrievalConfiguration.vectorSearchConfiguration.filter path.
+type retrieveAndGenerateFilterEnvelope struct {
+	RetrieveAndGenerateConfiguration *struct {
+		KnowledgeBaseConfiguration *struct {
+			RetrievalConfiguration *struct {
+				VectorSearchConfiguration *struct {
+					Filter *wireFilter `json:"filter"`
+				} `json:"vectorSearchConfiguration"`
+			} `json:"retrievalConfiguration"`
+		} `json:"knowledgeBaseConfiguration"`
+	} `json:"retrieveAndGenerateConfiguration"`
+}
+
+// decodeRetrieveAndGenerateFilter is decodeRetrieveFilter's sibling for
+// RetrieveAndGenerate.
+func decodeRetrieveAndGenerateFilter(body []byte) (*handlers_ochrevector.Filter, error) {
+	if len(body) == 0 {
+		return nil, nil
+	}
+	var env retrieveAndGenerateFilterEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, err
+	}
+	cfg := env.RetrieveAndGenerateConfiguration
+	if cfg == nil || cfg.KnowledgeBaseConfiguration == nil || cfg.KnowledgeBaseConfiguration.RetrievalConfiguration == nil ||
+		cfg.KnowledgeBaseConfiguration.RetrievalConfiguration.VectorSearchConfiguration == nil {
+		return nil, nil
+	}
+	return cfg.KnowledgeBaseConfiguration.RetrievalConfiguration.VectorSearchConfiguration.Filter.toFilter()
+}
+
+// queryResultToRetrievalResult maps one ochrevector QueryResult onto AWS's
+// KnowledgeBaseRetrievalResult shape. Uri is set to SourceKey verbatim (the
+// S3 object key .9 recorded at ingest, not a bucket-qualified s3:// URI --
+// .9's QueryResult carries no bucket). Metadata is omitted: the vendored SDK's
+// KnowledgeBaseRetrievalResult, unlike real AWS's, carries no metadata field
+// to put it in (same SDK-vintage gap as wireFilter, but here it only drops an
+// echo of already-visible data rather than silently changing behaviour, so it
+// is left unset rather than worked around).
+func queryResultToRetrievalResult(r handlers_ochrevector.QueryResult) *bedrockagentruntime.KnowledgeBaseRetrievalResult {
+	return &bedrockagentruntime.KnowledgeBaseRetrievalResult{
+		Content: &bedrockagentruntime.RetrievalResultContent{Text: aws.String(r.Chunk)},
+		Location: &bedrockagentruntime.RetrievalResultLocation{
+			Type:       aws.String(bedrockagentruntime.RetrievalResultLocationTypeS3),
+			S3Location: &bedrockagentruntime.RetrievalResultS3Location{Uri: aws.String(r.SourceKey)},
+		},
+		Score: aws.Float64(float64(r.Score)),
+	}
+}
+
+// Retrieve resolves knowledgeBaseId's bound index and runs a similarity query
+// against it: retrievalQuery.text -> Text, numberOfResults -> K, filter ->
+// translate() onto .9's Filter AST. Phase 5 is single-page (D2's scope is
+// ListIngestionJobs, not Retrieve pagination): NextToken is never set on the
+// response, and an incoming NextToken is accepted and ignored rather than
+// rejected, matching how storageConfiguration/roleArn are accepted-and-
+// stubbed elsewhere in this gateway.
+func Retrieve(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, vector handlers_ochrevector.VectorService, body []byte, input *bedrockagentruntime.RetrieveInput) (*bedrockagentruntime.RetrieveOutput, error) {
+	if input == nil || aws.StringValue(input.KnowledgeBaseId) == "" || input.RetrievalQuery == nil || aws.StringValue(input.RetrievalQuery.Text) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	kbID := aws.StringValue(input.KnowledgeBaseId)
+	kbRec, err := kb.Get(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if kbRec == nil {
+		return nil, errKBNotFound(kbID)
+	}
+
+	numResults := 0
+	if input.RetrievalConfiguration != nil && input.RetrievalConfiguration.VectorSearchConfiguration != nil {
+		numResults = int(aws.Int64Value(input.RetrievalConfiguration.VectorSearchConfiguration.NumberOfResults))
+	}
+
+	filter, err := decodeRetrieveFilter(body)
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+
+	resp, err := vector.Query(ctx, &handlers_ochrevector.QueryRequest{
+		IndexID: kbRec.IndexID,
+		Text:    aws.StringValue(input.RetrievalQuery.Text),
+		K:       numResults,
+		Filter:  filter,
+	}, accountID)
+	if err != nil {
+		return nil, translateVectorErr(err)
+	}
+
+	results := make([]*bedrockagentruntime.KnowledgeBaseRetrievalResult, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		results = append(results, queryResultToRetrievalResult(r))
+	}
+	return &bedrockagentruntime.RetrieveOutput{RetrievalResults: results}, nil
+}
+
+// defaultRAGPromptTemplate is Phase 5's default prompt when the caller omits
+// generationConfiguration.promptTemplate, following AWS's own
+// $search_results$/$query$ placeholder convention (renderRAGPrompt) so a
+// caller-supplied template is a drop-in replacement.
+const defaultRAGPromptTemplate = "You are a question answering agent. I will provide you with a set of search results. " +
+	"The user will provide you with a question. Your job is to answer the user's question using only information " +
+	"from the search results. If the search results do not contain information that can answer the question, " +
+	"say that you could not find an exact answer to the question.\n\nHere are the search results:\n$search_results$\n\nQuestion: $query$"
+
+// ragSearchResultsPlaceholder and ragQueryPlaceholder are AWS's standard
+// RetrieveAndGenerate prompt-template placeholders (see the Bedrock user
+// guide's default knowledge-base prompt template).
+const (
+	ragSearchResultsPlaceholder = "$search_results$"
+	ragQueryPlaceholder         = "$query$"
+)
+
+// renderRAGPrompt substitutes AWS's standard placeholders into template,
+// concatenating chunks with a blank line between each so the model can tell
+// separate sources apart.
+func renderRAGPrompt(template, query string, chunks []string) string {
+	out := strings.ReplaceAll(template, ragSearchResultsPlaceholder, strings.Join(chunks, "\n\n"))
+	return strings.ReplaceAll(out, ragQueryPlaceholder, query)
+}
+
+// converseOutputText concatenates every text content block of out's message,
+// the shape a Converse response carrying only text (no tool use/images)
+// always reduces to.
+func converseOutputText(out *bedrockruntime.ConverseOutput) string {
+	if out == nil || out.Output == nil || out.Output.Message == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(out.Output.Message.Content))
+	for _, c := range out.Output.Message.Content {
+		if c != nil && c.Text != nil {
+			parts = append(parts, aws.StringValue(c.Text))
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// RetrieveAndGenerate runs Retrieve's own flow for top-k chunks, assembles a
+// Converse prompt (D-RAG: a system message carrying the rendered prompt
+// template + retrieved context, the raw query text as the user turn), calls
+// converse in-process for generation, and builds one aggregate citation from
+// the retrieved chunks. D6: sessionId is server-generated when the caller
+// omits it, and echoed either way -- no conversational memory is persisted,
+// so a reused sessionId has no effect on this or any later call.
+func RetrieveAndGenerate(ctx context.Context, accountID string, kb *handlers_ochrevector.KBStore, vector handlers_ochrevector.VectorService, converse converseFn, body []byte, input *bedrockagentruntime.RetrieveAndGenerateInput) (*bedrockagentruntime.RetrieveAndGenerateOutput, error) {
+	if input == nil || input.Input == nil || aws.StringValue(input.Input.Text) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	ragConfig := input.RetrieveAndGenerateConfiguration
+	if ragConfig == nil || aws.StringValue(ragConfig.Type) != bedrockagentruntime.RetrieveAndGenerateTypeKnowledgeBase || ragConfig.KnowledgeBaseConfiguration == nil {
+		return nil, awserrors.Errorf(awserrors.ErrorValidationException, "bedrock-agent-runtime: only KNOWLEDGE_BASE retrieveAndGenerate is supported")
+	}
+	kbConfig := ragConfig.KnowledgeBaseConfiguration
+	kbID := aws.StringValue(kbConfig.KnowledgeBaseId)
+	modelArn := aws.StringValue(kbConfig.ModelArn)
+	if kbID == "" || modelArn == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+
+	kbRec, err := kb.Get(ctx, accountID, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if kbRec == nil {
+		return nil, errKBNotFound(kbID)
+	}
+
+	numResults := 0
+	if kbConfig.RetrievalConfiguration != nil && kbConfig.RetrievalConfiguration.VectorSearchConfiguration != nil {
+		numResults = int(aws.Int64Value(kbConfig.RetrievalConfiguration.VectorSearchConfiguration.NumberOfResults))
+	}
+
+	filter, err := decodeRetrieveAndGenerateFilter(body)
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+
+	queryText := aws.StringValue(input.Input.Text)
+	queryResp, err := vector.Query(ctx, &handlers_ochrevector.QueryRequest{
+		IndexID: kbRec.IndexID,
+		Text:    queryText,
+		K:       numResults,
+		Filter:  filter,
+	}, accountID)
+	if err != nil {
+		return nil, translateVectorErr(err)
+	}
+
+	results := make([]*bedrockagentruntime.KnowledgeBaseRetrievalResult, 0, len(queryResp.Results))
+	chunks := make([]string, 0, len(queryResp.Results))
+	for _, r := range queryResp.Results {
+		results = append(results, queryResultToRetrievalResult(r))
+		chunks = append(chunks, r.Chunk)
+	}
+
+	template := defaultRAGPromptTemplate
+	if kbConfig.GenerationConfiguration != nil && kbConfig.GenerationConfiguration.PromptTemplate != nil {
+		if tp := aws.StringValue(kbConfig.GenerationConfiguration.PromptTemplate.TextPromptTemplate); tp != "" {
+			template = tp
+		}
+	}
+	systemText := renderRAGPrompt(template, queryText, chunks)
+
+	// embeddingModelIDFromARN is generic ARN-suffix extraction (not actually
+	// embedding-specific despite its name), reused here for modelArn rather
+	// than duplicating the same "foundation-model/" parsing.
+	modelID := embeddingModelIDFromARN(modelArn)
+	converseInput := &bedrockruntime.ConverseInput{
+		System: []*bedrockruntime.SystemContentBlock{{Text: aws.String(systemText)}},
+		Messages: []*bedrockruntime.Message{{
+			Role:    aws.String(bedrockruntime.ConversationRoleUser),
+			Content: []*bedrockruntime.ContentBlock{{Text: aws.String(queryText)}},
+		}},
+	}
+	if kbConfig.GenerationConfiguration != nil && kbConfig.GenerationConfiguration.InferenceConfig != nil && kbConfig.GenerationConfiguration.InferenceConfig.TextInferenceConfig != nil {
+		tic := kbConfig.GenerationConfiguration.InferenceConfig.TextInferenceConfig
+		converseInput.InferenceConfig = &bedrockruntime.InferenceConfiguration{
+			MaxTokens:     tic.MaxTokens,
+			StopSequences: tic.StopSequences,
+			Temperature:   tic.Temperature,
+			TopP:          tic.TopP,
+		}
+	}
+
+	out, err := converse(ctx, accountID, modelID, converseInput)
+	if err != nil {
+		return nil, err
+	}
+	outputText := converseOutputText(out)
+
+	sessionID := aws.StringValue(input.SessionId)
+	if sessionID == "" {
+		sessionID = uuid.NewString()
+	}
+
+	// One aggregate citation covering the whole generated answer: the
+	// underlying Converse call is a plain chat completion with no span-level
+	// attribution signal, so there is no way to know which retrieved chunk
+	// backs which part of the model's answer.
+	var citations []*bedrockagentruntime.Citation
+	if len(results) > 0 {
+		refs := make([]*bedrockagentruntime.RetrievedReference, 0, len(results))
+		for _, r := range results {
+			refs = append(refs, &bedrockagentruntime.RetrievedReference{Content: r.Content, Location: r.Location})
+		}
+		citations = []*bedrockagentruntime.Citation{{
+			GeneratedResponsePart: &bedrockagentruntime.GeneratedResponsePart{
+				TextResponsePart: &bedrockagentruntime.TextResponsePart{Text: aws.String(outputText)},
+			},
+			RetrievedReferences: refs,
+		}}
+	}
+
+	return &bedrockagentruntime.RetrieveAndGenerateOutput{
+		Citations: citations,
+		Output:    &bedrockagentruntime.RetrieveAndGenerateOutput_{Text: aws.String(outputText)},
+		SessionId: aws.String(sessionID),
+	}, nil
+}

--- a/spinifex/gateway/bedrockagentruntime.go
+++ b/spinifex/gateway/bedrockagentruntime.go
@@ -390,6 +390,10 @@ func queryResultToRetrievalResult(r handlers_ochrevector.QueryResult) *bedrockag
 	}
 }
 
+// defaultRetrieveResults matches AWS Retrieve's documented default so an
+// omitted numberOfResults returns 5, not the vector store's own K default.
+const defaultRetrieveResults = 5
+
 // Retrieve resolves knowledgeBaseId's bound index and runs a similarity query
 // against it: retrievalQuery.text -> Text, numberOfResults -> K, filter ->
 // translate() onto .9's Filter AST. Phase 5 is single-page (D2's scope is
@@ -413,6 +417,9 @@ func Retrieve(ctx context.Context, accountID string, kb *handlers_ochrevector.KB
 	numResults := 0
 	if input.RetrievalConfiguration != nil && input.RetrievalConfiguration.VectorSearchConfiguration != nil {
 		numResults = int(aws.Int64Value(input.RetrievalConfiguration.VectorSearchConfiguration.NumberOfResults))
+	}
+	if numResults <= 0 {
+		numResults = defaultRetrieveResults
 	}
 
 	filter, err := decodeRetrieveFilter(body)
@@ -511,6 +518,9 @@ func RetrieveAndGenerate(ctx context.Context, accountID string, kb *handlers_och
 	numResults := 0
 	if kbConfig.RetrievalConfiguration != nil && kbConfig.RetrievalConfiguration.VectorSearchConfiguration != nil {
 		numResults = int(aws.Int64Value(kbConfig.RetrievalConfiguration.VectorSearchConfiguration.NumberOfResults))
+	}
+	if numResults <= 0 {
+		numResults = defaultRetrieveResults
 	}
 
 	filter, err := decodeRetrieveAndGenerateFilter(body)

--- a/spinifex/gateway/bedrockagentruntime_request_test.go
+++ b/spinifex/gateway/bedrockagentruntime_request_test.go
@@ -1,0 +1,227 @@
+// In-package: exercises BedrockAgentRuntime_Request's route table and
+// dispatcher end-to-end over real HTTP requests, mirroring
+// bedrock_request_test.go/bedrockagent_request_test.go's harnesses for the
+// sibling bedrock/bedrock-agent services.
+//
+//test:in-package
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/bedrockagentruntime"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newBedrockAgentRuntimeRequestGateway builds a GatewayConfig wired the same
+// way as newBedrockAgentRequestGateway (real JetStream-backed KB/DataSource
+// stores, allow-everything IAMService) plus newBedrockRequestGateway's vLLM
+// routing (BedrockEndpoints/BedrockAccess), since RetrieveAndGenerate's
+// generation step reaches gateway_bedrock.Converse in-process.
+func newBedrockAgentRuntimeRequestGateway(t *testing.T, vector handlers_ochrevector.VectorService, vllmURL string) *GatewayConfig {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	return &GatewayConfig{
+		IAMService:              allowAllIAMService(),
+		BedrockAgentKB:          handlers_ochrevector.NewKBStore(js),
+		BedrockAgentDataSources: handlers_ochrevector.NewDataSourceStore(js),
+		BedrockAgentVector:      vector,
+		BedrockEndpoints: map[string]string{
+			bedrockTestLlamaModelID: vllmURL,
+		},
+		BedrockAccess: grantAllModels{},
+	}
+}
+
+func bedrockAgentRuntimeRequestWithAccount(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), ctxAccountID, bedrockAgentTestAccount)
+	ctx = context.WithValue(ctx, ctxIdentity, "alice")
+	ctx = context.WithValue(ctx, ctxPrincipalType, principalTypeUser)
+	return req.WithContext(ctx)
+}
+
+func newTestKnowledgeBaseRecord(t *testing.T, gw *GatewayConfig, kbID, indexID string) {
+	t.Helper()
+	require.NoError(t, gw.BedrockAgentKB.Create(context.Background(), bedrockAgentTestAccount, handlers_ochrevector.KBRecord{
+		ID: kbID, Name: "docs", Status: handlers_ochrevector.StateReady,
+		EmbeddingModel: "amazon.titan-embed-text-v2:0", Dimension: 1024, IndexID: indexID,
+	}))
+}
+
+func TestBedrockAgentRuntimeRequest_Retrieve_HappyPath(t *testing.T) {
+	ts := newVLLMStub(t)
+	vector := &fakeBedrockAgentVectorService{queryResp: handlers_ochrevector.QueryResponse{
+		Results: []handlers_ochrevector.QueryResult{
+			{Chunk: "the dragon lives in a cave", SourceKey: "docs/a.txt", Score: 0.9},
+		},
+	}}
+	gw := newBedrockAgentRuntimeRequestGateway(t, vector, ts.URL)
+	newTestKnowledgeBaseRecord(t, gw, "kb-1", "idx-1")
+
+	body := `{"retrievalQuery": {"text": "dragons"}, "retrievalConfiguration": {"vectorSearchConfiguration": {"numberOfResults": 5}}}`
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/knowledgebases/kb-1/retrieve", body)
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgentRuntime_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagentruntime.RetrieveOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	require.Len(t, out.RetrievalResults, 1)
+	assert.Equal(t, "the dragon lives in a cave", *out.RetrievalResults[0].Content.Text)
+	assert.Equal(t, "docs/a.txt", *out.RetrievalResults[0].Location.S3Location.Uri)
+
+	require.NotNil(t, vector.queryReq)
+	assert.Equal(t, "idx-1", vector.queryReq.IndexID)
+	assert.Equal(t, 5, vector.queryReq.K)
+}
+
+func TestBedrockAgentRuntimeRequest_Retrieve_WithFilter(t *testing.T) {
+	ts := newVLLMStub(t)
+	vector := &fakeBedrockAgentVectorService{}
+	gw := newBedrockAgentRuntimeRequestGateway(t, vector, ts.URL)
+	newTestKnowledgeBaseRecord(t, gw, "kb-1", "idx-1")
+
+	body := `{
+		"retrievalQuery": {"text": "dragons"},
+		"retrievalConfiguration": {"vectorSearchConfiguration": {"filter": {"equals": {"key": "genre", "value": "fiction"}}}}
+	}`
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/knowledgebases/kb-1/retrieve", body)
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgentRuntime_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	require.NotNil(t, vector.queryReq)
+	require.NotNil(t, vector.queryReq.Filter)
+	assert.Equal(t, handlers_ochrevector.FilterEquals, vector.queryReq.Filter.Op)
+	assert.Equal(t, "genre", vector.queryReq.Filter.Key)
+}
+
+func TestBedrockAgentRuntimeRequest_Retrieve_UnknownKnowledgeBase(t *testing.T) {
+	ts := newVLLMStub(t)
+	gw := newBedrockAgentRuntimeRequestGateway(t, &fakeBedrockAgentVectorService{}, ts.URL)
+
+	body := `{"retrievalQuery": {"text": "dragons"}}`
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/knowledgebases/does-not-exist/retrieve", body)
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgentRuntime_Request(w, req)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestBedrockAgentRuntimeRequest_Retrieve_MalformedBodyReturnsValidationException(t *testing.T) {
+	ts := newVLLMStub(t)
+	gw := newBedrockAgentRuntimeRequestGateway(t, &fakeBedrockAgentVectorService{}, ts.URL)
+
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/knowledgebases/kb-1/retrieve", "{not-json")
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgentRuntime_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
+}
+
+func TestBedrockAgentRuntimeRequest_RetrieveAndGenerate_HappyPath(t *testing.T) {
+	ts := newVLLMStub(t)
+	vector := &fakeBedrockAgentVectorService{queryResp: handlers_ochrevector.QueryResponse{
+		Results: []handlers_ochrevector.QueryResult{
+			{Chunk: "the dragon lives in a cave", SourceKey: "docs/a.txt", Score: 0.9},
+		},
+	}}
+	gw := newBedrockAgentRuntimeRequestGateway(t, vector, ts.URL)
+	newTestKnowledgeBaseRecord(t, gw, "kb-1", "idx-1")
+
+	body := `{
+		"input": {"text": "where does the dragon live?"},
+		"retrieveAndGenerateConfiguration": {
+			"type": "KNOWLEDGE_BASE",
+			"knowledgeBaseConfiguration": {
+				"knowledgeBaseId": "kb-1",
+				"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/` + bedrockTestLlamaModelID + `"
+			}
+		}
+	}`
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/retrieveAndGenerate", body)
+	w := httptest.NewRecorder()
+	require.NoError(t, gw.BedrockAgentRuntime_Request(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out bedrockagentruntime.RetrieveAndGenerateOutput
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, "hi from vllm", *out.Output.Text)
+	require.NotEmpty(t, *out.SessionId)
+	require.Len(t, out.Citations, 1)
+	require.Len(t, out.Citations[0].RetrievedReferences, 1)
+	assert.Equal(t, "the dragon lives in a cave", *out.Citations[0].RetrievedReferences[0].Content.Text)
+}
+
+func TestBedrockAgentRuntimeRequest_RetrieveAndGenerate_UnknownKnowledgeBase(t *testing.T) {
+	ts := newVLLMStub(t)
+	gw := newBedrockAgentRuntimeRequestGateway(t, &fakeBedrockAgentVectorService{}, ts.URL)
+
+	body := `{
+		"input": {"text": "q"},
+		"retrieveAndGenerateConfiguration": {
+			"type": "KNOWLEDGE_BASE",
+			"knowledgeBaseConfiguration": {"knowledgeBaseId": "does-not-exist", "modelArn": "` + bedrockTestLlamaModelID + `"}
+		}
+	}`
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/retrieveAndGenerate", body)
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgentRuntime_Request(w, req)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestBedrockAgentRuntimeRequest_RetrieveAndGenerate_MalformedBodyReturnsValidationException(t *testing.T) {
+	ts := newVLLMStub(t)
+	gw := newBedrockAgentRuntimeRequestGateway(t, &fakeBedrockAgentVectorService{}, ts.URL)
+
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/retrieveAndGenerate", "{not-json")
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgentRuntime_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
+}
+
+func TestBedrockAgentRuntimeRequest_UnknownRouteReturnsInvalidAction(t *testing.T) {
+	ts := newVLLMStub(t)
+	gw := newBedrockAgentRuntimeRequestGateway(t, &fakeBedrockAgentVectorService{}, ts.URL)
+
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPatch, "/knowledgebases/kb-1/retrieve", "")
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgentRuntime_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidAction, err.Error())
+}
+
+func TestBedrockAgentRuntimeRequest_MissingAccountIDReturnsInternalError(t *testing.T) {
+	ts := newVLLMStub(t)
+	gw := newBedrockAgentRuntimeRequestGateway(t, &fakeBedrockAgentVectorService{}, ts.URL)
+
+	req := withTestIdentity(httptest.NewRequest(http.MethodPost, "/retrieveAndGenerate", nil))
+	w := httptest.NewRecorder()
+	// Account-less requests are rejected by the policy gate, which runs ahead
+	// of the handler's own account guard.
+	err := gw.BedrockAgentRuntime_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
+}
+
+func TestBedrockAgentRuntimeRequest_NilDependenciesReturnServerInternal(t *testing.T) {
+	gw := &GatewayConfig{IAMService: allowAllIAMService()}
+
+	req := bedrockAgentRuntimeRequestWithAccount(http.MethodPost, "/knowledgebases/kb-1/retrieve", `{"retrievalQuery":{"text":"q"}}`)
+	w := httptest.NewRecorder()
+	err := gw.BedrockAgentRuntime_Request(w, req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+}

--- a/spinifex/gateway/bedrockagentruntime_test.go
+++ b/spinifex/gateway/bedrockagentruntime_test.go
@@ -1,0 +1,447 @@
+// In-package: exercises bedrockagentruntime.go's unexported filter
+// translator (wireFilter) and the exported Retrieve/RetrieveAndGenerate
+// mapping functions directly, mirroring bedrockagent_test.go's split between
+// unexported-mapper and operation-level coverage.
+//
+//test:in-package
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrockagentruntime"
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWireFilter_ToFilter_Leaves(t *testing.T) {
+	cases := []struct {
+		name   string
+		filter wireFilter
+		wantOp handlers_ochrevector.FilterOp
+		wantK  string
+		wantV  any
+	}{
+		{"equals", wireFilter{Equals: &wireFilterAttr{Key: "genre", Value: "fiction"}}, handlers_ochrevector.FilterEquals, "genre", "fiction"},
+		{"notEquals", wireFilter{NotEquals: &wireFilterAttr{Key: "genre", Value: "fiction"}}, handlers_ochrevector.FilterNotEquals, "genre", "fiction"},
+		{"greaterThan", wireFilter{GreaterThan: &wireFilterAttr{Key: "year", Value: 2000.0}}, handlers_ochrevector.FilterGreaterThan, "year", 2000.0},
+		{"greaterThanOrEquals", wireFilter{GreaterThanOrEquals: &wireFilterAttr{Key: "year", Value: 2000.0}}, handlers_ochrevector.FilterGreaterThanOrEqual, "year", 2000.0},
+		{"lessThan", wireFilter{LessThan: &wireFilterAttr{Key: "year", Value: 2000.0}}, handlers_ochrevector.FilterLessThan, "year", 2000.0},
+		{"lessThanOrEquals", wireFilter{LessThanOrEquals: &wireFilterAttr{Key: "year", Value: 2000.0}}, handlers_ochrevector.FilterLessThanOrEqual, "year", 2000.0},
+		{"startsWith", wireFilter{StartsWith: &wireFilterAttr{Key: "title", Value: "The "}}, handlers_ochrevector.FilterStartsWith, "title", "The "},
+		{"stringContains", wireFilter{StringContains: &wireFilterAttr{Key: "title", Value: "dragon"}}, handlers_ochrevector.FilterStringContains, "title", "dragon"},
+		{"listContains", wireFilter{ListContains: &wireFilterAttr{Key: "tags", Value: "scifi"}}, handlers_ochrevector.FilterListContains, "tags", "scifi"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.filter.toFilter()
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantOp, got.Op)
+			assert.Equal(t, tc.wantK, got.Key)
+			assert.Equal(t, tc.wantV, got.Value)
+		})
+	}
+}
+
+func TestWireFilter_ToFilter_InNotIn(t *testing.T) {
+	f := wireFilter{In: &wireFilterAttr{Key: "genre", Value: []any{"fiction", "scifi"}}}
+	got, err := f.toFilter()
+	require.NoError(t, err)
+	assert.Equal(t, handlers_ochrevector.FilterIn, got.Op)
+	assert.Equal(t, []string{"fiction", "scifi"}, got.Value)
+
+	f = wireFilter{NotIn: &wireFilterAttr{Key: "genre", Value: []any{"horror"}}}
+	got, err = f.toFilter()
+	require.NoError(t, err)
+	assert.Equal(t, handlers_ochrevector.FilterNotIn, got.Op)
+	assert.Equal(t, []string{"horror"}, got.Value)
+}
+
+func TestWireFilter_ToFilter_InRequiresList(t *testing.T) {
+	f := wireFilter{In: &wireFilterAttr{Key: "genre", Value: "fiction"}}
+	_, err := f.toFilter()
+	assert.Error(t, err)
+}
+
+func TestWireFilter_ToFilter_AndOrAll(t *testing.T) {
+	f := wireFilter{AndAll: []wireFilter{
+		{Equals: &wireFilterAttr{Key: "genre", Value: "fiction"}},
+		{GreaterThan: &wireFilterAttr{Key: "year", Value: 2000.0}},
+	}}
+	got, err := f.toFilter()
+	require.NoError(t, err)
+	assert.Equal(t, handlers_ochrevector.FilterAndAll, got.Op)
+	require.Len(t, got.Children, 2)
+	assert.Equal(t, handlers_ochrevector.FilterEquals, got.Children[0].Op)
+	assert.Equal(t, handlers_ochrevector.FilterGreaterThan, got.Children[1].Op)
+
+	f = wireFilter{OrAll: []wireFilter{
+		{Equals: &wireFilterAttr{Key: "genre", Value: "fiction"}},
+		{Equals: &wireFilterAttr{Key: "genre", Value: "scifi"}},
+	}}
+	got, err = f.toFilter()
+	require.NoError(t, err)
+	assert.Equal(t, handlers_ochrevector.FilterOrAll, got.Op)
+	require.Len(t, got.Children, 2)
+}
+
+func TestWireFilter_ToFilter_NestedCombinator(t *testing.T) {
+	f := wireFilter{AndAll: []wireFilter{
+		{Equals: &wireFilterAttr{Key: "genre", Value: "fiction"}},
+		{OrAll: []wireFilter{
+			{Equals: &wireFilterAttr{Key: "lang", Value: "en"}},
+			{Equals: &wireFilterAttr{Key: "lang", Value: "fr"}},
+		}},
+	}}
+	got, err := f.toFilter()
+	require.NoError(t, err)
+	require.Len(t, got.Children, 2)
+	assert.Equal(t, handlers_ochrevector.FilterOrAll, got.Children[1].Op)
+	require.Len(t, got.Children[1].Children, 2)
+}
+
+func TestWireFilter_ToFilter_EmptyChildRejected(t *testing.T) {
+	f := wireFilter{AndAll: []wireFilter{{}, {Equals: &wireFilterAttr{Key: "x", Value: "y"}}}}
+	_, err := f.toFilter()
+	assert.Error(t, err)
+}
+
+func TestWireFilter_ToFilter_NilOrEmptyIsNoFilter(t *testing.T) {
+	var f *wireFilter
+	got, err := f.toFilter()
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	f = &wireFilter{}
+	got, err = f.toFilter()
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestDecodeRetrieveFilter(t *testing.T) {
+	body := []byte(`{
+		"knowledgeBaseId": "kb-1",
+		"retrievalQuery": {"text": "dragons"},
+		"retrievalConfiguration": {
+			"vectorSearchConfiguration": {
+				"numberOfResults": 5,
+				"filter": {"equals": {"key": "genre", "value": "fiction"}}
+			}
+		}
+	}`)
+	f, err := decodeRetrieveFilter(body)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	assert.Equal(t, handlers_ochrevector.FilterEquals, f.Op)
+	assert.Equal(t, "genre", f.Key)
+}
+
+func TestDecodeRetrieveFilter_Absent(t *testing.T) {
+	f, err := decodeRetrieveFilter([]byte(`{"knowledgeBaseId": "kb-1", "retrievalQuery": {"text": "dragons"}}`))
+	require.NoError(t, err)
+	assert.Nil(t, f)
+
+	f, err = decodeRetrieveFilter(nil)
+	require.NoError(t, err)
+	assert.Nil(t, f)
+}
+
+func TestDecodeRetrieveAndGenerateFilter(t *testing.T) {
+	body := []byte(`{
+		"input": {"text": "who is the dragon?"},
+		"retrieveAndGenerateConfiguration": {
+			"type": "KNOWLEDGE_BASE",
+			"knowledgeBaseConfiguration": {
+				"knowledgeBaseId": "kb-1",
+				"modelArn": "anthropic.claude-3-5-sonnet",
+				"retrievalConfiguration": {
+					"vectorSearchConfiguration": {
+						"filter": {"andAll": [
+							{"equals": {"key": "genre", "value": "fiction"}},
+							{"in": {"key": "lang", "value": ["en", "fr"]}}
+						]}
+					}
+				}
+			}
+		}
+	}`)
+	f, err := decodeRetrieveAndGenerateFilter(body)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	assert.Equal(t, handlers_ochrevector.FilterAndAll, f.Op)
+	require.Len(t, f.Children, 2)
+}
+
+func TestRenderRAGPrompt(t *testing.T) {
+	got := renderRAGPrompt("Context:\n$search_results$\n\nQ: $query$", "what?", []string{"chunk one", "chunk two"})
+	assert.Contains(t, got, "chunk one\n\nchunk two")
+	assert.Contains(t, got, "Q: what?")
+}
+
+func TestConverseOutputText(t *testing.T) {
+	assert.Empty(t, converseOutputText(nil))
+	assert.Empty(t, converseOutputText(&bedrockruntime.ConverseOutput{}))
+
+	out := &bedrockruntime.ConverseOutput{
+		Output: &bedrockruntime.ConverseOutput_{
+			Message: &bedrockruntime.Message{
+				Content: []*bedrockruntime.ContentBlock{
+					{Text: aws.String("hello ")},
+					{Text: aws.String("world")},
+				},
+			},
+		},
+	}
+	assert.Equal(t, "hello world", converseOutputText(out))
+}
+
+func TestQueryResultToRetrievalResult(t *testing.T) {
+	r := handlers_ochrevector.QueryResult{Chunk: "some text", SourceKey: "docs/a.txt", Score: 0.87}
+	got := queryResultToRetrievalResult(r)
+	assert.Equal(t, "some text", *got.Content.Text)
+	assert.Equal(t, bedrockagentruntime.RetrievalResultLocationTypeS3, *got.Location.Type)
+	assert.Equal(t, "docs/a.txt", *got.Location.S3Location.Uri)
+	assert.InDelta(t, 0.87, *got.Score, 0.0001)
+}
+
+func newTestKBRecord(t *testing.T, kb *handlers_ochrevector.KBStore, accountID, kbID, indexID string) {
+	t.Helper()
+	require.NoError(t, kb.Create(context.Background(), accountID, handlers_ochrevector.KBRecord{
+		ID: kbID, Name: "docs", Status: handlers_ochrevector.StateReady,
+		EmbeddingModel: "amazon.titan-embed-text-v2:0", Dimension: 1024, IndexID: indexID,
+	}))
+}
+
+func TestRetrieve_MapsRequestAndResponse(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	newTestKBRecord(t, kb, bedrockAgentTestAccount, "kb-1", "idx-1")
+
+	vector := &fakeBedrockAgentVectorService{queryResp: handlers_ochrevector.QueryResponse{
+		Results: []handlers_ochrevector.QueryResult{
+			{Chunk: "chunk a", SourceKey: "docs/a.txt", Score: 0.9},
+			{Chunk: "chunk b", SourceKey: "docs/b.txt", Score: 0.5},
+		},
+	}}
+
+	body := []byte(`{
+		"knowledgeBaseId": "kb-1",
+		"retrievalQuery": {"text": "dragons"},
+		"retrievalConfiguration": {"vectorSearchConfiguration": {"numberOfResults": 2, "filter": {"equals": {"key": "genre", "value": "fiction"}}}}
+	}`)
+	input := &bedrockagentruntime.RetrieveInput{
+		KnowledgeBaseId: aws.String("kb-1"),
+		RetrievalQuery:  &bedrockagentruntime.KnowledgeBaseQuery{Text: aws.String("dragons")},
+		RetrievalConfiguration: &bedrockagentruntime.KnowledgeBaseRetrievalConfiguration{
+			VectorSearchConfiguration: &bedrockagentruntime.KnowledgeBaseVectorSearchConfiguration{NumberOfResults: aws.Int64(2)},
+		},
+	}
+
+	out, err := Retrieve(context.Background(), bedrockAgentTestAccount, kb, vector, body, input)
+	require.NoError(t, err)
+	require.Len(t, out.RetrievalResults, 2)
+	assert.Equal(t, "chunk a", *out.RetrievalResults[0].Content.Text)
+	assert.Equal(t, "docs/b.txt", *out.RetrievalResults[1].Location.S3Location.Uri)
+
+	require.NotNil(t, vector.queryReq)
+	assert.Equal(t, "idx-1", vector.queryReq.IndexID)
+	assert.Equal(t, "dragons", vector.queryReq.Text)
+	assert.Equal(t, 2, vector.queryReq.K)
+	require.NotNil(t, vector.queryReq.Filter)
+	assert.Equal(t, handlers_ochrevector.FilterEquals, vector.queryReq.Filter.Op)
+}
+
+func TestRetrieve_UnknownKnowledgeBase(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	vector := &fakeBedrockAgentVectorService{}
+	input := &bedrockagentruntime.RetrieveInput{
+		KnowledgeBaseId: aws.String("does-not-exist"),
+		RetrievalQuery:  &bedrockagentruntime.KnowledgeBaseQuery{Text: aws.String("dragons")},
+	}
+	_, err := Retrieve(context.Background(), bedrockAgentTestAccount, kb, vector, nil, input)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestRetrieve_RejectsMissingQueryText(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	vector := &fakeBedrockAgentVectorService{}
+	_, err := Retrieve(context.Background(), bedrockAgentTestAccount, kb, vector, nil, &bedrockagentruntime.RetrieveInput{KnowledgeBaseId: aws.String("kb-1")})
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorValidationException))
+}
+
+// fakeConverse scripts a Converse response so RetrieveAndGenerate can be
+// tested without a live model backend, mirroring how fakeBedrockAgentVectorService
+// stands in for the daemon.
+type fakeConverse struct {
+	gotAccountID string
+	gotModelID   string
+	gotInput     *bedrockruntime.ConverseInput
+	resp         *bedrockruntime.ConverseOutput
+	err          error
+}
+
+func (f *fakeConverse) call(_ context.Context, accountID, modelID string, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {
+	f.gotAccountID = accountID
+	f.gotModelID = modelID
+	f.gotInput = input
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+func fakeConverseOutput(text string) *bedrockruntime.ConverseOutput {
+	return &bedrockruntime.ConverseOutput{
+		Output: &bedrockruntime.ConverseOutput_{
+			Message: &bedrockruntime.Message{Content: []*bedrockruntime.ContentBlock{{Text: aws.String(text)}}},
+		},
+	}
+}
+
+func TestRetrieveAndGenerate_HappyPath(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	newTestKBRecord(t, kb, bedrockAgentTestAccount, "kb-1", "idx-1")
+
+	vector := &fakeBedrockAgentVectorService{queryResp: handlers_ochrevector.QueryResponse{
+		Results: []handlers_ochrevector.QueryResult{{Chunk: "the dragon lives in a cave", SourceKey: "docs/a.txt", Score: 0.9}},
+	}}
+	fc := &fakeConverse{resp: fakeConverseOutput("The dragon lives in a cave.")}
+
+	input := &bedrockagentruntime.RetrieveAndGenerateInput{
+		Input: &bedrockagentruntime.RetrieveAndGenerateInput_{Text: aws.String("where does the dragon live?")},
+		RetrieveAndGenerateConfiguration: &bedrockagentruntime.RetrieveAndGenerateConfiguration{
+			Type: aws.String(bedrockagentruntime.RetrieveAndGenerateTypeKnowledgeBase),
+			KnowledgeBaseConfiguration: &bedrockagentruntime.KnowledgeBaseRetrieveAndGenerateConfiguration{
+				KnowledgeBaseId: aws.String("kb-1"),
+				ModelArn:        aws.String("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"),
+			},
+		},
+	}
+
+	out, err := RetrieveAndGenerate(context.Background(), bedrockAgentTestAccount, kb, vector, fc.call, nil, input)
+	require.NoError(t, err)
+	assert.Equal(t, "The dragon lives in a cave.", *out.Output.Text)
+	require.NotEmpty(t, *out.SessionId)
+	require.Len(t, out.Citations, 1)
+	require.Len(t, out.Citations[0].RetrievedReferences, 1)
+	assert.Equal(t, "the dragon lives in a cave", *out.Citations[0].RetrievedReferences[0].Content.Text)
+
+	assert.Equal(t, "anthropic.claude-3-5-sonnet-20241022-v2:0", fc.gotModelID)
+	require.Len(t, fc.gotInput.Messages, 1)
+	assert.Equal(t, "where does the dragon live?", *fc.gotInput.Messages[0].Content[0].Text)
+	require.Len(t, fc.gotInput.System, 1)
+	assert.Contains(t, *fc.gotInput.System[0].Text, "the dragon lives in a cave")
+}
+
+func TestRetrieveAndGenerate_EchoesCallerSessionID(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	newTestKBRecord(t, kb, bedrockAgentTestAccount, "kb-1", "idx-1")
+	vector := &fakeBedrockAgentVectorService{}
+	fc := &fakeConverse{resp: fakeConverseOutput("answer")}
+
+	input := &bedrockagentruntime.RetrieveAndGenerateInput{
+		Input:     &bedrockagentruntime.RetrieveAndGenerateInput_{Text: aws.String("q")},
+		SessionId: aws.String("caller-session-id"),
+		RetrieveAndGenerateConfiguration: &bedrockagentruntime.RetrieveAndGenerateConfiguration{
+			Type: aws.String(bedrockagentruntime.RetrieveAndGenerateTypeKnowledgeBase),
+			KnowledgeBaseConfiguration: &bedrockagentruntime.KnowledgeBaseRetrieveAndGenerateConfiguration{
+				KnowledgeBaseId: aws.String("kb-1"),
+				ModelArn:        aws.String("some-model"),
+			},
+		},
+	}
+	out, err := RetrieveAndGenerate(context.Background(), bedrockAgentTestAccount, kb, vector, fc.call, nil, input)
+	require.NoError(t, err)
+	assert.Equal(t, "caller-session-id", *out.SessionId)
+}
+
+func TestRetrieveAndGenerate_UsesCustomPromptTemplate(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	newTestKBRecord(t, kb, bedrockAgentTestAccount, "kb-1", "idx-1")
+	vector := &fakeBedrockAgentVectorService{queryResp: handlers_ochrevector.QueryResponse{
+		Results: []handlers_ochrevector.QueryResult{{Chunk: "ctx chunk", SourceKey: "k", Score: 0.5}},
+	}}
+	fc := &fakeConverse{resp: fakeConverseOutput("answer")}
+
+	input := &bedrockagentruntime.RetrieveAndGenerateInput{
+		Input: &bedrockagentruntime.RetrieveAndGenerateInput_{Text: aws.String("my question")},
+		RetrieveAndGenerateConfiguration: &bedrockagentruntime.RetrieveAndGenerateConfiguration{
+			Type: aws.String(bedrockagentruntime.RetrieveAndGenerateTypeKnowledgeBase),
+			KnowledgeBaseConfiguration: &bedrockagentruntime.KnowledgeBaseRetrieveAndGenerateConfiguration{
+				KnowledgeBaseId: aws.String("kb-1"),
+				ModelArn:        aws.String("some-model"),
+				GenerationConfiguration: &bedrockagentruntime.GenerationConfiguration{
+					PromptTemplate: &bedrockagentruntime.PromptTemplate{
+						TextPromptTemplate: aws.String("CUSTOM: $search_results$ / $query$"),
+					},
+				},
+			},
+		},
+	}
+	_, err := RetrieveAndGenerate(context.Background(), bedrockAgentTestAccount, kb, vector, fc.call, nil, input)
+	require.NoError(t, err)
+	require.Len(t, fc.gotInput.System, 1)
+	assert.Equal(t, "CUSTOM: ctx chunk / my question", *fc.gotInput.System[0].Text)
+}
+
+func TestRetrieveAndGenerate_UnknownKnowledgeBase(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	vector := &fakeBedrockAgentVectorService{}
+	fc := &fakeConverse{}
+	input := &bedrockagentruntime.RetrieveAndGenerateInput{
+		Input: &bedrockagentruntime.RetrieveAndGenerateInput_{Text: aws.String("q")},
+		RetrieveAndGenerateConfiguration: &bedrockagentruntime.RetrieveAndGenerateConfiguration{
+			Type: aws.String(bedrockagentruntime.RetrieveAndGenerateTypeKnowledgeBase),
+			KnowledgeBaseConfiguration: &bedrockagentruntime.KnowledgeBaseRetrieveAndGenerateConfiguration{
+				KnowledgeBaseId: aws.String("does-not-exist"),
+				ModelArn:        aws.String("some-model"),
+			},
+		},
+	}
+	_, err := RetrieveAndGenerate(context.Background(), bedrockAgentTestAccount, kb, vector, fc.call, nil, input)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
+}
+
+func TestRetrieveAndGenerate_RejectsNonKnowledgeBaseType(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	vector := &fakeBedrockAgentVectorService{}
+	fc := &fakeConverse{}
+	input := &bedrockagentruntime.RetrieveAndGenerateInput{
+		Input: &bedrockagentruntime.RetrieveAndGenerateInput_{Text: aws.String("q")},
+		RetrieveAndGenerateConfiguration: &bedrockagentruntime.RetrieveAndGenerateConfiguration{
+			Type: aws.String("EXTERNAL_SOURCES"),
+		},
+	}
+	_, err := RetrieveAndGenerate(context.Background(), bedrockAgentTestAccount, kb, vector, fc.call, nil, input)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorValidationException))
+}
+
+func TestRetrieveAndGenerate_PropagatesConverseError(t *testing.T) {
+	kb, _ := newBedrockAgentTestStores(t)
+	newTestKBRecord(t, kb, bedrockAgentTestAccount, "kb-1", "idx-1")
+	vector := &fakeBedrockAgentVectorService{}
+	fc := &fakeConverse{err: errors.New(awserrors.ErrorAccessDeniedException)}
+	input := &bedrockagentruntime.RetrieveAndGenerateInput{
+		Input: &bedrockagentruntime.RetrieveAndGenerateInput_{Text: aws.String("q")},
+		RetrieveAndGenerateConfiguration: &bedrockagentruntime.RetrieveAndGenerateConfiguration{
+			Type: aws.String(bedrockagentruntime.RetrieveAndGenerateTypeKnowledgeBase),
+			KnowledgeBaseConfiguration: &bedrockagentruntime.KnowledgeBaseRetrieveAndGenerateConfiguration{
+				KnowledgeBaseId: aws.String("kb-1"),
+				ModelArn:        aws.String("some-model"),
+			},
+		},
+	}
+	_, err := RetrieveAndGenerate(context.Background(), bedrockAgentTestAccount, kb, vector, fc.call, nil, input)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorAccessDeniedException))
+}

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -179,20 +179,21 @@ type GatewayConfig struct {
 }
 
 var supportedServices = map[string]bool{
-	"ec2":                  true,
-	"iam":                  true,
-	"sts":                  true,
-	"elasticloadbalancing": true,
-	"eks":                  true,
-	"ecs":                  true,
-	"ecr":                  true,
-	"acm":                  true,
-	"rds":                  true,
-	"tagging":              true,
-	"spinifex":             true,
-	"bedrock":              true,
-	"bedrock-runtime":      true,
-	"bedrock-agent":        true,
+	"ec2":                   true,
+	"iam":                   true,
+	"sts":                   true,
+	"elasticloadbalancing":  true,
+	"eks":                   true,
+	"ecs":                   true,
+	"ecr":                   true,
+	"acm":                   true,
+	"rds":                   true,
+	"tagging":               true,
+	"spinifex":              true,
+	"bedrock":               true,
+	"bedrock-runtime":       true,
+	"bedrock-agent":         true,
+	"bedrock-agent-runtime": true,
 }
 
 // EC2ErrorResponse is the EC2 query-API error envelope.
@@ -419,6 +420,8 @@ func (gw *GatewayConfig) Request(w http.ResponseWriter, r *http.Request) {
 		err = gw.BedrockRuntime_Request(w, r)
 	case "bedrock-agent":
 		err = gw.BedrockAgent_Request(w, r)
+	case "bedrock-agent-runtime":
+		err = gw.BedrockAgentRuntime_Request(w, r)
 	case "ecs":
 		err = gw.ECS_Request(w, r)
 	case "ecr":
@@ -448,14 +451,25 @@ func (gw *GatewayConfig) GetService(r *http.Request) (string, error) {
 	if !ok {
 		return "", errors.New(awserrors.ErrorAuthFailure)
 	}
-	// bedrock and bedrock-runtime share the SigV4 signing name "bedrock", so the
-	// credential scope alone cannot tell the control plane from the data plane —
+	// The whole Bedrock family (bedrock, bedrock-runtime, bedrock-agent,
+	// bedrock-agent-runtime) shares the SigV4 signing name "bedrock" -- real
 	// AWS separates them by endpoint hostname, but the gateway serves one
-	// endpoint. The request path is the discriminator: /model/... and singular
-	// /guardrail/... are exclusive to the data plane; control-plane guardrail
-	// CRUD uses the plural /guardrails, so the prefixes never collide.
-	if svc == "bedrock" && (strings.HasPrefix(r.URL.Path, "/model/") || strings.HasPrefix(r.URL.Path, "/guardrail/")) {
-		svc = "bedrock-runtime"
+	// endpoint, so the request path is the only discriminator available here.
+	// /model/... and singular /guardrail/... are exclusive to bedrock-runtime;
+	// control-plane guardrail CRUD uses the plural /guardrails, so the
+	// prefixes never collide. Retrieve's /knowledgebases/{id}/retrieve and
+	// RetrieveAndGenerate's /retrieveAndGenerate are checked ahead of the
+	// bedrock-agent /knowledgebases/... prefix, since Retrieve's own path is
+	// itself a /knowledgebases/... path.
+	if svc == "bedrock" {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/model/") || strings.HasPrefix(r.URL.Path, "/guardrail/"):
+			svc = "bedrock-runtime"
+		case r.URL.Path == "/retrieveAndGenerate" || (strings.HasPrefix(r.URL.Path, "/knowledgebases/") && strings.HasSuffix(r.URL.Path, "/retrieve")):
+			svc = "bedrock-agent-runtime"
+		case strings.HasPrefix(r.URL.Path, "/knowledgebases/"):
+			svc = "bedrock-agent"
+		}
 	}
 	if !supportedServices[svc] {
 		slog.Debug("Unsupported service", "service", svc)
@@ -633,9 +647,10 @@ func (gw *GatewayConfig) ErrorHandler(w http.ResponseWriter, r *http.Request, er
 		errorMsg.HTTPCode = 500
 	}
 
-	// EKS, ECR, ACM, ECS, tagging, and bedrock/bedrock-runtime/bedrock-agent use
-	// AWS JSON 1.1; query/XML services fall through.
-	if svc == "eks" || svc == "ecr" || svc == "acm" || svc == "ecs" || svc == "tagging" || svc == "bedrock" || svc == "bedrock-runtime" || svc == "bedrock-agent" {
+	// EKS, ECR, ACM, ECS, tagging, and the bedrock/bedrock-runtime/bedrock-agent/
+	// bedrock-agent-runtime family use AWS JSON 1.1; query/XML services fall
+	// through.
+	if svc == "eks" || svc == "ecr" || svc == "acm" || svc == "ecs" || svc == "tagging" || svc == "bedrock" || svc == "bedrock-runtime" || svc == "bedrock-agent" || svc == "bedrock-agent-runtime" {
 		body := GenerateEKSErrorResponse(code, errorMsg.Message, requestId)
 		slog.Debug("Generated JSON error response", "service", svc, "error", err, "code", code, "json", string(body), "requestId", requestId)
 		w.Header().Set("Content-Type", eksJSONContentType)

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -28,6 +28,7 @@ import (
 	gateway_ecrauth "github.com/mulgadc/spinifex/spinifex/gateway/ecrauth"
 	"github.com/mulgadc/spinifex/spinifex/gateway/policy"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
 	handlers_quota "github.com/mulgadc/spinifex/spinifex/handlers/quota"
 	handlers_sts "github.com/mulgadc/spinifex/spinifex/handlers/sts"
 	"github.com/mulgadc/spinifex/spinifex/otelsetup"
@@ -162,6 +163,19 @@ type GatewayConfig struct {
 	// and friends). Nil falls back to an unconfigured store, under which
 	// reads/writes error rather than panic.
 	BedrockGuardrails *gateway_bedrock.GuardrailStore
+	// BedrockAgentKB and BedrockAgentDataSources persist bedrock-agent
+	// knowledge-base and data-source resource metadata (D-arch: gateway-owned,
+	// not the daemon-owned vector engine). Nil for either fails
+	// BedrockAgent_Request with ServerInternal rather than panicking, the same
+	// as an unconfigured gw.NATSConn does for every other service.
+	BedrockAgentKB          *handlers_ochrevector.KBStore
+	BedrockAgentDataSources *handlers_ochrevector.DataSourceStore
+	// BedrockAgentVector forwards CreateIndex/DeleteIndex/Ingest/DescribeJob/
+	// ListJobs calls to .9's daemon-side VectorService over NATS
+	// (handlers_ochrevector.NewNATSVectorService). It is the interface, not
+	// the concrete client, so a test can inject a fake without a live NATS
+	// connection.
+	BedrockAgentVector handlers_ochrevector.VectorService
 }
 
 var supportedServices = map[string]bool{
@@ -178,6 +192,7 @@ var supportedServices = map[string]bool{
 	"spinifex":             true,
 	"bedrock":              true,
 	"bedrock-runtime":      true,
+	"bedrock-agent":        true,
 }
 
 // EC2ErrorResponse is the EC2 query-API error envelope.
@@ -402,6 +417,8 @@ func (gw *GatewayConfig) Request(w http.ResponseWriter, r *http.Request) {
 		err = gw.Bedrock_Request(w, r)
 	case "bedrock-runtime":
 		err = gw.BedrockRuntime_Request(w, r)
+	case "bedrock-agent":
+		err = gw.BedrockAgent_Request(w, r)
 	case "ecs":
 		err = gw.ECS_Request(w, r)
 	case "ecr":
@@ -616,9 +633,9 @@ func (gw *GatewayConfig) ErrorHandler(w http.ResponseWriter, r *http.Request, er
 		errorMsg.HTTPCode = 500
 	}
 
-	// EKS, ECR, ACM, ECS, tagging, and bedrock/bedrock-runtime use AWS JSON 1.1;
-	// query/XML services fall through.
-	if svc == "eks" || svc == "ecr" || svc == "acm" || svc == "ecs" || svc == "tagging" || svc == "bedrock" || svc == "bedrock-runtime" {
+	// EKS, ECR, ACM, ECS, tagging, and bedrock/bedrock-runtime/bedrock-agent use
+	// AWS JSON 1.1; query/XML services fall through.
+	if svc == "eks" || svc == "ecr" || svc == "acm" || svc == "ecs" || svc == "tagging" || svc == "bedrock" || svc == "bedrock-runtime" || svc == "bedrock-agent" {
 		body := GenerateEKSErrorResponse(code, errorMsg.Message, requestId)
 		slog.Debug("Generated JSON error response", "service", svc, "error", err, "code", code, "json", string(body), "requestId", requestId)
 		w.Header().Set("Content-Type", eksJSONContentType)

--- a/spinifex/gateway/gateway_test.go
+++ b/spinifex/gateway/gateway_test.go
@@ -783,6 +783,48 @@ func TestGetService(t *testing.T) {
 			path:    "/guardrails/gr-abc123",
 			wantSvc: "bedrock",
 		},
+		{
+			// bedrock-agent shares the same "bedrock" signing name as the rest
+			// of the family; CreateKnowledgeBase's /knowledgebases/ path must
+			// resolve to bedrock-agent, not stay "bedrock".
+			name:    "bedrock scope on CreateKnowledgeBase path resolves to bedrock-agent",
+			ctxVal:  "bedrock",
+			path:    "/knowledgebases/",
+			wantSvc: "bedrock-agent",
+		},
+		{
+			name:    "bedrock scope on GetKnowledgeBase path resolves to bedrock-agent",
+			ctxVal:  "bedrock",
+			path:    "/knowledgebases/kb-123",
+			wantSvc: "bedrock-agent",
+		},
+		{
+			name:    "bedrock scope on CreateDataSource path resolves to bedrock-agent",
+			ctxVal:  "bedrock",
+			path:    "/knowledgebases/kb-123/datasources/",
+			wantSvc: "bedrock-agent",
+		},
+		{
+			// Retrieve's own path is itself a /knowledgebases/... path, so it
+			// must be checked ahead of the bare bedrock-agent prefix check.
+			name:    "bedrock scope on Retrieve path resolves to bedrock-agent-runtime",
+			ctxVal:  "bedrock",
+			path:    "/knowledgebases/kb-123/retrieve",
+			wantSvc: "bedrock-agent-runtime",
+		},
+		{
+			name:    "bedrock scope on RetrieveAndGenerate path resolves to bedrock-agent-runtime",
+			ctxVal:  "bedrock",
+			path:    "/retrieveAndGenerate",
+			wantSvc: "bedrock-agent-runtime",
+		},
+		{
+			// A native bedrock-agent-runtime scope is left untouched.
+			name:    "bedrock-agent-runtime scope stays bedrock-agent-runtime",
+			ctxVal:  "bedrock-agent-runtime",
+			path:    "/retrieveAndGenerate",
+			wantSvc: "bedrock-agent-runtime",
+		},
 	}
 
 	for _, tc := range tests {

--- a/spinifex/handlers/ochrevector/api.go
+++ b/spinifex/handlers/ochrevector/api.go
@@ -56,9 +56,14 @@ type ListIndexesResponse struct {
 // EmbeddingModel/Dimension are ignored and overwritten server-side from the
 // index's own registered values (see vectorService.Ingest) -- an index's
 // embedding model is a property of the index (D6/D8), not of any one caller.
+// DataSourceID is optional: the bedrock-agent gateway stamps it from the
+// DataSource record driving this ingest, so the resulting job can later be
+// tied back to it exactly; a direct ochre.vector.ingest caller may leave it
+// empty.
 type IngestRequest struct {
-	IndexID string     `json:"indexId"`
-	Source  SourceSpec `json:"source"`
+	IndexID      string     `json:"indexId"`
+	Source       SourceSpec `json:"source"`
+	DataSourceID string     `json:"dataSourceId,omitempty"`
 }
 
 type IngestResponse struct {
@@ -126,7 +131,7 @@ var _ indexService = (*Service)(nil)
 // ingestStarter is the StartIngest surface vectorService delegates to;
 // *IngestService satisfies it structurally.
 type ingestStarter interface {
-	StartIngest(ctx context.Context, accountID, indexID string, source SourceSpec) (*JobRecord, error)
+	StartIngest(ctx context.Context, accountID, indexID string, source SourceSpec, dataSourceID string) (*JobRecord, error)
 }
 
 var _ ingestStarter = (*IngestService)(nil)
@@ -245,7 +250,7 @@ func (s *vectorService) Ingest(ctx context.Context, req *IngestRequest, accountI
 	source.EmbeddingModel = idx.EmbeddingModel
 	source.Dimension = idx.Dimension
 
-	job, err := s.ingest.StartIngest(ctx, accountID, req.IndexID, source)
+	job, err := s.ingest.StartIngest(ctx, accountID, req.IndexID, source, req.DataSourceID)
 	if err != nil {
 		return nil, fmt.Errorf("ochrevector: ingest: %w", err)
 	}

--- a/spinifex/handlers/ochrevector/api.go
+++ b/spinifex/handlers/ochrevector/api.go
@@ -19,6 +19,7 @@ const (
 	SubjectIngest      = "ochre.vector.ingest"
 	SubjectDescribeJob = "ochre.vector.describeJob"
 	SubjectQuery       = "ochre.vector.query"
+	SubjectListJobs    = "ochre.vector.listJobs"
 )
 
 // CreateIndexRequest names a new index and its fixed, per-index properties
@@ -89,9 +90,17 @@ type QueryResponse struct {
 	Results []QueryResult `json:"results"`
 }
 
+// ListJobsRequest has no fields: accountID comes from the caller context
+// (D10), never the payload, mirroring ListIndexesRequest.
+type ListJobsRequest struct{}
+
+type ListJobsResponse struct {
+	Jobs []JobRecord `json:"jobs"`
+}
+
 // VectorService is the tenant vector-store surface: index CRUD, ingestion,
-// job status, and similarity query. Every method's accountID argument is
-// supplied by the transport alone (a NATS message header for the daemon
+// job status/listing, and similarity query. Every method's accountID argument
+// is supplied by the transport alone (a NATS message header for the daemon
 // subscription, D10) -- no request type above carries an account field, so a
 // spoofed payload account can never widen a caller's own scope.
 type VectorService interface {
@@ -100,6 +109,7 @@ type VectorService interface {
 	ListIndexes(ctx context.Context, req *ListIndexesRequest, accountID string) (*ListIndexesResponse, error)
 	Ingest(ctx context.Context, req *IngestRequest, accountID string) (*IngestResponse, error)
 	DescribeJob(ctx context.Context, req *DescribeJobRequest, accountID string) (*DescribeJobResponse, error)
+	ListJobs(ctx context.Context, req *ListJobsRequest, accountID string) (*ListJobsResponse, error)
 	Query(ctx context.Context, req *QueryRequest, accountID string) (*QueryResponse, error)
 }
 
@@ -121,10 +131,11 @@ type ingestStarter interface {
 
 var _ ingestStarter = (*IngestService)(nil)
 
-// jobGetter is the job-lookup surface DescribeJob delegates to; *JobStore
-// satisfies it structurally.
+// jobGetter is the job-lookup/listing surface DescribeJob and ListJobs
+// delegate to; *JobStore satisfies it structurally.
 type jobGetter interface {
 	Get(ctx context.Context, accountID, jobID string) (*JobRecord, error)
+	List(ctx context.Context, accountID string) ([]JobRecord, error)
 }
 
 var _ jobGetter = (*JobStore)(nil)
@@ -255,6 +266,15 @@ func (s *vectorService) DescribeJob(ctx context.Context, req *DescribeJobRequest
 	return &DescribeJobResponse{Job: *job}, nil
 }
 
+// ListJobs returns every ingestion job record owned by accountID.
+func (s *vectorService) ListJobs(ctx context.Context, _ *ListJobsRequest, accountID string) (*ListJobsResponse, error) {
+	jobs, err := s.jobs.List(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("ochrevector: list jobs: %w", err)
+	}
+	return &ListJobsResponse{Jobs: jobs}, nil
+}
+
 // Query resolves IndexID's pinned embedding model from the registry (D8),
 // embeds Text against it, then runs the similarity search directly against
 // backend. A non-READY index (CREATING/DELETING/STALE) returns empty results
@@ -330,6 +350,10 @@ func (c *NATSVectorService) Ingest(ctx context.Context, req *IngestRequest, acco
 
 func (c *NATSVectorService) DescribeJob(ctx context.Context, req *DescribeJobRequest, accountID string) (*DescribeJobResponse, error) {
 	return utils.NATSRequest[DescribeJobResponse](ctx, c.nc, SubjectDescribeJob, req, c.timeout, accountID)
+}
+
+func (c *NATSVectorService) ListJobs(ctx context.Context, req *ListJobsRequest, accountID string) (*ListJobsResponse, error) {
+	return utils.NATSRequest[ListJobsResponse](ctx, c.nc, SubjectListJobs, req, c.timeout, accountID)
 }
 
 func (c *NATSVectorService) Query(ctx context.Context, req *QueryRequest, accountID string) (*QueryResponse, error) {

--- a/spinifex/handlers/ochrevector/api_test.go
+++ b/spinifex/handlers/ochrevector/api_test.go
@@ -121,6 +121,25 @@ func TestVectorService_ListIndexes_ScopedPerAccount(t *testing.T) {
 	assert.Equal(t, "idx-a", out.Indexes[0].ID)
 }
 
+func TestVectorService_ListJobs_ScopedPerAccount(t *testing.T) {
+	s := newAPITestSetup(t)
+	ctx := context.Background()
+	_, err := s.svc.CreateIndex(ctx, &CreateIndexRequest{IndexID: "idx-one", Name: "kb1", Dimension: 8}, apiAccountA)
+	require.NoError(t, err)
+	ingestOut, err := s.svc.Ingest(ctx, &IngestRequest{IndexID: "idx-one", Source: SourceSpec{Bucket: "docs"}}, apiAccountA)
+	require.NoError(t, err)
+
+	out, err := s.svc.ListJobs(ctx, &ListJobsRequest{}, apiAccountA)
+	require.NoError(t, err)
+	require.Len(t, out.Jobs, 1)
+	assert.Equal(t, ingestOut.Job.ID, out.Jobs[0].ID)
+
+	// A foreign account's listing never surfaces another tenant's jobs.
+	empty, err := s.svc.ListJobs(ctx, &ListJobsRequest{}, apiAccountB)
+	require.NoError(t, err)
+	assert.Empty(t, empty.Jobs)
+}
+
 // TestVectorService_Ingest_StampsIndexPinnedModel proves Ingest overwrites
 // whatever EmbeddingModel/Dimension a caller sends with the index's own
 // registered values (D6/D8): the stored source-spec must always match the
@@ -305,6 +324,7 @@ func subscribeVectorService(t *testing.T, nc *nats.Conn, svc VectorService) {
 		{SubjectIngest, stubVectorNATSHandler(svc.Ingest)},
 		{SubjectDescribeJob, stubVectorNATSHandler(svc.DescribeJob)},
 		{SubjectQuery, stubVectorNATSHandler(svc.Query)},
+		{SubjectListJobs, stubVectorNATSHandler(svc.ListJobs)},
 	}
 	for _, s := range subs {
 		sub, err := nc.QueueSubscribe(s.subject, "spinifex-workers", s.handler)
@@ -343,6 +363,11 @@ func TestNATSVectorService_RoundTrip(t *testing.T) {
 	descOut, err := client.DescribeJob(ctx, &DescribeJobRequest{JobID: ingestOut.Job.ID}, apiAccountA)
 	require.NoError(t, err)
 	assert.Equal(t, ingestOut.Job.ID, descOut.Job.ID)
+
+	listJobsOut, err := client.ListJobs(ctx, &ListJobsRequest{}, apiAccountA)
+	require.NoError(t, err)
+	require.Len(t, listJobsOut.Jobs, 1)
+	assert.Equal(t, ingestOut.Job.ID, listJobsOut.Jobs[0].ID)
 
 	backend.queryResults = []QueryResult{{Chunk: "hi", SourceKey: "docs/a.txt", Score: 0.9}}
 	queryOut, err := client.Query(ctx, &QueryRequest{IndexID: "idx-one", Text: "hello"}, apiAccountA)

--- a/spinifex/handlers/ochrevector/api_test.go
+++ b/spinifex/handlers/ochrevector/api_test.go
@@ -162,6 +162,27 @@ func TestVectorService_Ingest_StampsIndexPinnedModel(t *testing.T) {
 	assert.Equal(t, JobStatePending, out.Job.State)
 }
 
+// TestVectorService_Ingest_ThreadsDataSourceIDOntoJob proves Ingest's
+// optional DataSourceID reaches the reserved job record unchanged, end to
+// end through the real IngestService.StartIngest, not just JobRecord's own
+// field plumbing.
+func TestVectorService_Ingest_ThreadsDataSourceIDOntoJob(t *testing.T) {
+	s := newAPITestSetup(t)
+	ctx := context.Background()
+	_, err := s.svc.CreateIndex(ctx, &CreateIndexRequest{IndexID: "idx-one", Name: "kb1", Dimension: 8}, apiAccountA)
+	require.NoError(t, err)
+
+	out, err := s.svc.Ingest(ctx, &IngestRequest{
+		IndexID: "idx-one", Source: SourceSpec{Bucket: "docs"}, DataSourceID: "ds-1",
+	}, apiAccountA)
+	require.NoError(t, err)
+	assert.Equal(t, "ds-1", out.Job.DataSourceID)
+
+	got, err := s.svc.DescribeJob(ctx, &DescribeJobRequest{JobID: out.Job.ID}, apiAccountA)
+	require.NoError(t, err)
+	assert.Equal(t, "ds-1", got.Job.DataSourceID)
+}
+
 func TestVectorService_Ingest_MissingIndexErrors(t *testing.T) {
 	s := newAPITestSetup(t)
 	_, err := s.svc.Ingest(context.Background(), &IngestRequest{IndexID: "no-such-index", Source: SourceSpec{Bucket: "docs"}}, apiAccountA)

--- a/spinifex/handlers/ochrevector/appliance.go
+++ b/spinifex/handlers/ochrevector/appliance.go
@@ -143,6 +143,12 @@ type Appliance struct {
 	// directly) skips the metadata purge, unchanged from before it existed.
 	registry *Registry
 	jobs     *JobStore
+
+	// kb and ds are optional Teardown collaborators (WithKBStores) for the
+	// gateway-owned bedrock-agent knowledge-base/data-source records: a nil
+	// pair skips their purge, mirroring registry/jobs above.
+	kb *KBStore
+	ds *DataSourceStore
 }
 
 // NewAppliance constructs an Appliance over js, encrypting/decrypting the
@@ -183,6 +189,19 @@ func (a *Appliance) WithStores(registry *Registry, jobs *JobStore) *Appliance {
 	return a
 }
 
+// WithKBStores attaches the gateway-owned knowledge-base and data-source KV
+// stores Teardown purges alongside the index registry/job store above, so a
+// rebuilt appliance never leaves a KB/DataSource record pointing at an index
+// that no longer exists. Optional, mirroring WithStores: an Appliance that
+// never calls this skips the purge (back-compat default).
+func (a *Appliance) WithKBStores(kb *KBStore, ds *DataSourceStore) *Appliance {
+	a.mu.Lock()
+	a.kb = kb
+	a.ds = ds
+	a.mu.Unlock()
+	return a
+}
+
 // TeardownHostPort removes this daemon's own VPC host port, if Connect ever
 // installed one. Not per-endpoint -- the port belongs to this node, not to
 // any one Connect call -- so this is meant for daemon shutdown, not for
@@ -196,8 +215,9 @@ func (a *Appliance) TeardownHostPort() error {
 }
 
 // Teardown removes the singleton platform appliance -- RDS instance, host
-// port, then (if WithStores was called) index/job metadata, then the KV
-// record -- so a rebuilt appliance starts coherent. Every step runs
+// port, then (if WithStores/WithKBStores were called) index/job and
+// KB/DataSource metadata, then the KV record -- so a rebuilt appliance starts
+// coherent. Every step runs
 // regardless of an earlier one's failure, and every failure is joined into
 // the returned error. Idempotent overall: tearing down an already-absent
 // appliance is a no-op success. Does not re-provision -- the daemon's own
@@ -215,7 +235,7 @@ func (a *Appliance) Teardown(ctx context.Context) error {
 	}
 
 	a.mu.Lock()
-	registry, jobs := a.registry, a.jobs
+	registry, jobs, kb, ds := a.registry, a.jobs, a.kb, a.ds
 	a.mu.Unlock()
 	// Purged after the data-bearing RDS instance is gone but before the
 	// appliance record: a crash here still leaves a record an operator can
@@ -228,6 +248,19 @@ func (a *Appliance) Teardown(ctx context.Context) error {
 	if jobs != nil {
 		if err := jobs.PurgeAll(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("ochrevector: purge ingestion jobs: %w", err))
+		}
+	}
+	// kb/ds are gateway-owned metadata, not daemon-owned like registry/jobs
+	// above, but they still point at this appliance's index/backend, so a
+	// torn-down appliance must not leave them dangling either.
+	if kb != nil {
+		if err := kb.PurgeAll(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("ochrevector: purge knowledge bases: %w", err))
+		}
+	}
+	if ds != nil {
+		if err := ds.PurgeAll(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("ochrevector: purge data sources: %w", err))
 		}
 	}
 

--- a/spinifex/handlers/ochrevector/appliance_test.go
+++ b/spinifex/handlers/ochrevector/appliance_test.go
@@ -629,6 +629,37 @@ func TestTeardown_WithStoresPurgesRegistryAndJobs(t *testing.T) {
 	assert.Empty(t, remainingJobs, "Teardown must purge every job record")
 }
 
+// TestTeardown_WithKBStoresPurgesKnowledgeBasesAndDataSources proves an
+// Appliance wired via WithKBStores purges every gateway-owned knowledge-base
+// and data-source record on Teardown, so a reprovisioned appliance never
+// leaves KB/DataSource metadata pointing at an index that no longer exists.
+func TestTeardown_WithKBStoresPurgesKnowledgeBasesAndDataSources(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	masterKey := testMasterKey(t)
+	launcher := &fakeLauncher{endpoint: "10.0.0.35", port: 5432}
+	appliance, err := NewAppliance(js, masterKey, launcher)
+	require.NoError(t, err)
+	seedAvailableAppliance(t, appliance, masterKey, "10.0.0.35", 5432)
+
+	kb := NewKBStore(js)
+	ds := NewDataSourceStore(js)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	require.NoError(t, kb.Create(ctx, "111111111111", KBRecord{ID: "kb-one", IndexID: "idx-one", CreatedAt: now, UpdatedAt: now}))
+	require.NoError(t, ds.Create(ctx, "111111111111", DataSourceRecord{ID: "ds-one", KnowledgeBaseID: "kb-one", CreatedAt: now, UpdatedAt: now}))
+
+	appliance.WithKBStores(kb, ds)
+	require.NoError(t, appliance.Teardown(ctx))
+
+	remainingKBs, err := kb.List(ctx, "111111111111")
+	require.NoError(t, err)
+	assert.Empty(t, remainingKBs, "Teardown must purge every knowledge base record")
+
+	remainingDS, err := ds.List(ctx, "111111111111")
+	require.NoError(t, err)
+	assert.Empty(t, remainingDS, "Teardown must purge every data source record")
+}
+
 // TestTeardown_WithoutStoresStillWorks proves an Appliance that never calls
 // WithStores (every pre-existing caller and test) still tears down cleanly:
 // the registry/jobs purge is nil-safe, not a new required dependency.

--- a/spinifex/handlers/ochrevector/ingest.go
+++ b/spinifex/handlers/ochrevector/ingest.go
@@ -67,9 +67,11 @@ func NewIngestService(jobs *JobStore, registry *Registry, backend VectorBackend,
 }
 
 // StartIngest validates indexID exists for accountID, then reserves a new
-// PENDING job for source. It does not run the job -- a scheduler/daemon
-// calls RunJob later (Stage 4); tests call RunJob directly.
-func (s *IngestService) StartIngest(ctx context.Context, accountID, indexID string, source SourceSpec) (*JobRecord, error) {
+// PENDING job for source, tagged with dataSourceID (empty when the caller has
+// no bedrock-agent DataSource, e.g. a direct ochre.vector.ingest call). It
+// does not run the job -- a scheduler/daemon calls RunJob later (Stage 4);
+// tests call RunJob directly.
+func (s *IngestService) StartIngest(ctx context.Context, accountID, indexID string, source SourceSpec, dataSourceID string) (*JobRecord, error) {
 	idxRec, err := s.Registry.Get(ctx, accountID, indexID)
 	if err != nil {
 		return nil, err
@@ -80,12 +82,13 @@ func (s *IngestService) StartIngest(ctx context.Context, accountID, indexID stri
 
 	now := time.Now().UTC()
 	rec := JobRecord{
-		ID:        utils.GenerateResourceID("job"),
-		IndexID:   indexID,
-		Source:    source,
-		State:     JobStatePending,
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID:           utils.GenerateResourceID("job"),
+		IndexID:      indexID,
+		DataSourceID: dataSourceID,
+		Source:       source,
+		State:        JobStatePending,
+		CreatedAt:    now,
+		UpdatedAt:    now,
 	}
 	if err := s.Jobs.Reserve(ctx, accountID, rec); err != nil {
 		return nil, err

--- a/spinifex/handlers/ochrevector/ingest_test.go
+++ b/spinifex/handlers/ochrevector/ingest_test.go
@@ -108,7 +108,7 @@ func TestStartIngest_MissingIndexErrors(t *testing.T) {
 	svc, _, _, _, _ := newIngestTestSetup(t)
 	ctx := context.Background()
 
-	_, err := svc.StartIngest(ctx, ingestAccountA, "idx-does-not-exist", testSource())
+	_, err := svc.StartIngest(ctx, ingestAccountA, "idx-does-not-exist", testSource(), "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrIndexNotFound)
 }
@@ -118,7 +118,7 @@ func TestStartIngest_ReturnsPendingJobWithoutRunning(t *testing.T) {
 	ctx := context.Background()
 	putObject(t, store, ingestPrefix+"doc1.txt", "hello world")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NotNil(t, job)
 	assert.Equal(t, JobStatePending, job.State)
@@ -130,6 +130,28 @@ func TestStartIngest_ReturnsPendingJobWithoutRunning(t *testing.T) {
 	assert.Equal(t, 0, backend.replaceDocumentCallCount(ingestAccountA, "idx-one", ingestPrefix+"doc1.txt"))
 }
 
+// TestStartIngest_StampsDataSourceID proves a non-empty dataSourceID argument
+// lands on the reserved job record unchanged, and an empty one (a direct
+// ochre.vector.ingest caller with no bedrock-agent DataSource) leaves it
+// empty rather than defaulting to some placeholder value.
+func TestStartIngest_StampsDataSourceID(t *testing.T) {
+	svc, _, _, _, _ := newIngestTestSetup(t)
+	ctx := context.Background()
+
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "ds-1")
+	require.NoError(t, err)
+	assert.Equal(t, "ds-1", job.DataSourceID)
+
+	got, err := svc.Jobs.Get(ctx, ingestAccountA, job.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "ds-1", got.DataSourceID)
+
+	noDSJob, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
+	require.NoError(t, err)
+	assert.Empty(t, noDSJob.DataSourceID)
+}
+
 func TestRunJob_HappyPath(t *testing.T) {
 	svc, registry, backend, store, embedder := newIngestTestSetup(t)
 	ctx := context.Background()
@@ -139,7 +161,7 @@ func TestRunJob_HappyPath(t *testing.T) {
 	putObject(t, store, ingestPrefix+"doc3.txt", "and a third one, for good measure")
 
 	source := testSource()
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source)
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source, "")
 	require.NoError(t, err)
 
 	require.NoError(t, svc.RunJob(ctx, *job))
@@ -180,7 +202,7 @@ func TestRunJob_IdempotentRerun(t *testing.T) {
 	key := ingestPrefix + "doc1.txt"
 	putObject(t, store, key, "the quick brown fox jumps over the lazy dog")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 
 	require.NoError(t, svc.RunJob(ctx, *job))
@@ -218,7 +240,7 @@ func TestRunJob_PerDocumentFailureIsSkippedAndRecorded(t *testing.T) {
 	putObject(t, store, badKey, "this document contains POISON and will fail to embed")
 	embedder.failIfContains = "POISON"
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.RunJob(ctx, *job))
 
@@ -250,7 +272,7 @@ func TestRunJob_EmbedderFullyDownFailsJob(t *testing.T) {
 	putObject(t, store, ingestPrefix+"doc2.txt", "document two")
 	embedder.failAll = true
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 
 	err = svc.RunJob(ctx, *job)
@@ -273,7 +295,7 @@ func TestRunJob_EmptyDocumentClearsExistingRows(t *testing.T) {
 	key := ingestPrefix + "empty.txt"
 	putObject(t, store, key, "   \n\t  ")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.RunJob(ctx, *job))
 
@@ -311,7 +333,7 @@ func TestIngestService_Reconcile_RedrivesStaleRunningJob(t *testing.T) {
 	key := ingestPrefix + "doc1.txt"
 	putObject(t, store, key, "a document that a crashed worker never finished")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.Jobs.SetState(ctx, ingestAccountA, job.ID, JobStateRunning))
 
@@ -333,7 +355,7 @@ func TestIngestService_Reconcile_LeavesFreshRunningJobAlone(t *testing.T) {
 	key := ingestPrefix + "doc1.txt"
 	putObject(t, store, key, "still in flight")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.Jobs.SetState(ctx, ingestAccountA, job.ID, JobStateRunning))
 
@@ -384,7 +406,7 @@ func TestRunJob_AllDocumentsFailNonEmbedReason_FailsJob(t *testing.T) {
 	jobs := NewJobStore(js)
 	svc := NewIngestService(jobs, registry, backend, store, embedder)
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 
 	err = svc.RunJob(ctx, *job)
@@ -418,7 +440,7 @@ func TestRunJob_StampsSourceMetadataOntoRows(t *testing.T) {
 	source := testSource()
 	source.Metadata = map[string]string{"category": "handbook", "team": "platform"}
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source)
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source, "")
 	require.NoError(t, err)
 	require.NoError(t, svc.RunJob(ctx, *job))
 
@@ -435,7 +457,7 @@ func TestRunJob_StampsSourceMetadataOntoRows(t *testing.T) {
 	// selects the one document.
 	otherKey := ingestPrefix + "doc2.txt"
 	putObject(t, store, otherKey, "a second document, same source tags")
-	job2, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source)
+	job2, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source, "")
 	require.NoError(t, err)
 	require.NoError(t, svc.RunJob(ctx, *job2))
 
@@ -452,7 +474,7 @@ func TestIngestService_Reconcile_IgnoresPendingAndTerminalJobs(t *testing.T) {
 	ctx := context.Background()
 	putObject(t, store, ingestPrefix+"doc1.txt", "pending, never run")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	forceJobUpdatedAt(t, svc.Jobs, ingestAccountA, job.ID, time.Now().UTC().Add(-2*jobStaleAfter))
 
@@ -473,7 +495,7 @@ func TestIngestService_Sweep_RunsPendingJobToReady(t *testing.T) {
 	key := ingestPrefix + "doc1.txt"
 	putObject(t, store, key, "a pending job the scheduler must claim and run")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.Equal(t, JobStatePending, job.State)
 
@@ -496,7 +518,7 @@ func TestIngestService_Sweep_RedrivesStaleRunningJob(t *testing.T) {
 	key := ingestPrefix + "doc1.txt"
 	putObject(t, store, key, "a stale running job the scheduler must re-drive")
 
-	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.Jobs.SetState(ctx, ingestAccountA, job.ID, JobStateRunning))
 	forceJobUpdatedAt(t, svc.Jobs, ingestAccountA, job.ID, time.Now().UTC().Add(-2*jobStaleAfter))
@@ -519,15 +541,15 @@ func TestIngestService_Sweep_LeavesFreshRunningAndTerminalJobsAlone(t *testing.T
 
 	freshKey := ingestPrefix + "fresh.txt"
 	putObject(t, store, freshKey, "still in flight, must not be touched")
-	freshJob, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	freshJob, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.Jobs.SetState(ctx, ingestAccountA, freshJob.ID, JobStateRunning))
 
-	readyJob, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	readyJob, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.Jobs.SetState(ctx, ingestAccountA, readyJob.ID, JobStateReady))
 
-	failedJob, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource())
+	failedJob, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
 	require.NoError(t, err)
 	require.NoError(t, svc.Jobs.SetState(ctx, ingestAccountA, failedJob.ID, JobStateFailed))
 

--- a/spinifex/handlers/ochrevector/jobs.go
+++ b/spinifex/handlers/ochrevector/jobs.go
@@ -48,9 +48,13 @@ type FailedDoc struct {
 // RUNNING -> READY (completed, possibly with per-document failures) or
 // FAILED (the job itself could not complete, e.g. embedder fully down).
 type JobRecord struct {
-	ID              string      `json:"id"`
-	AccountID       string      `json:"accountId"`
-	IndexID         string      `json:"indexId"`
+	ID        string `json:"id"`
+	AccountID string `json:"accountId"`
+	IndexID   string `json:"indexId"`
+	// DataSourceID ties this job to the bedrock-agent DataSource it was
+	// started from, if any: empty for a job started directly against
+	// ochre.vector.ingest with no data source involved.
+	DataSourceID    string      `json:"dataSourceId,omitempty"`
 	Source          SourceSpec  `json:"source"`
 	State           string      `json:"state"`
 	DocumentsTotal  int         `json:"documentsTotal"`

--- a/spinifex/handlers/ochrevector/kbstore.go
+++ b/spinifex/handlers/ochrevector/kbstore.go
@@ -1,0 +1,415 @@
+package handlers_ochrevector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// kbBucket is the cluster-replicated KV bucket holding bedrock-agent
+// knowledge-base records, per-account, mirroring registryBucket's pattern.
+// Unencrypted: knowledge-base metadata (name, status, bound index) carries no
+// secrets, unlike the credentials gateway_bedrock.CredentialStore protects.
+const kbBucket = "ochre-kb"
+
+// dataSourceBucket is the cluster-replicated KV bucket holding bedrock-agent
+// data-source records, per-account, mirroring kbBucket.
+const dataSourceBucket = "ochre-kb-datasource"
+
+// kbBucketHistory and dataSourceBucketHistory keep one revision per key: a
+// record is one JSON document mutated in place, not a series.
+const (
+	kbBucketHistory         = 1
+	dataSourceBucketHistory = 1
+)
+
+// ErrKBExists reports that Create lost the single-writer claim on a knowledge
+// base id already reserved for that account.
+var ErrKBExists = errors.New("ochrevector: knowledge base already exists")
+
+// ErrKBNotFound reports that an operation targeted an account+knowledge-base
+// pair with no record.
+var ErrKBNotFound = errors.New("ochrevector: knowledge base not found")
+
+// ErrDataSourceExists reports that Create lost the single-writer claim on a
+// data-source id already reserved for that account.
+var ErrDataSourceExists = errors.New("ochrevector: data source already exists")
+
+// ErrDataSourceNotFound reports that an operation targeted an
+// account+data-source pair with no record.
+var ErrDataSourceNotFound = errors.New("ochrevector: data source not found")
+
+// KBRecord is one bedrock-agent knowledge base: the AWS-shaped resource
+// wrapping a single bound vector Index (D1: one KB binds exactly one index).
+// Status reuses the vector index lifecycle strings (StateReady et al, see
+// registry.go) rather than minting a parallel AWS-shaped enum here -- the
+// gateway layer translates to AWS's KnowledgeBaseStatus wire values.
+type KBRecord struct {
+	ID             string `json:"id"`
+	AccountID      string `json:"accountId"`
+	Name           string `json:"name"`
+	Description    string `json:"description,omitempty"`
+	Status         string `json:"status"`
+	EmbeddingModel string `json:"embeddingModel"`
+	// EmbeddingModelArn is the caller's original embeddingModelArn, stored
+	// verbatim for round-trip echo; EmbeddingModel is the bare model id
+	// derived from it (see embeddingModelIDFromARN) that CreateIndex and the
+	// embedder actually key on.
+	EmbeddingModelArn string `json:"embeddingModelArn,omitempty"`
+	Dimension         int    `json:"dimension"`
+	IndexID           string `json:"indexId"`
+	// RoleArn and StorageConfigJSON are accepted-and-stubbed (D5): stored
+	// verbatim so Get/List echo back what the caller sent, but never acted
+	// on -- pgvector abstracts away AWS's OpenSearch/RDS storage binding.
+	// StorageConfigJSON is an opaque JSON blob (the AWS StorageConfiguration
+	// shape) rather than a typed field, so this package stays free of an
+	// aws-sdk-go dependency; the gateway layer decodes/encodes it.
+	RoleArn           string          `json:"roleArn,omitempty"`
+	StorageConfigJSON json.RawMessage `json:"storageConfig,omitempty"`
+	CreatedAt         time.Time       `json:"createdAt"`
+	UpdatedAt         time.Time       `json:"updatedAt"`
+}
+
+// DataSourceRecord is one bedrock-agent data source: the S3 + chunking
+// ingestion config for one KnowledgeBaseID, stored as a SourceSpec so
+// StartIngestionJob can build an IngestRequest from it directly. Status
+// reuses the vector index lifecycle strings, mirroring KBRecord.
+type DataSourceRecord struct {
+	ID              string     `json:"id"`
+	AccountID       string     `json:"accountId"`
+	KnowledgeBaseID string     `json:"knowledgeBaseId"`
+	Name            string     `json:"name"`
+	Description     string     `json:"description,omitempty"`
+	Status          string     `json:"status"`
+	Source          SourceSpec `json:"source"`
+	CreatedAt       time.Time  `json:"createdAt"`
+	UpdatedAt       time.Time  `json:"updatedAt"`
+}
+
+// KBStore persists KBRecords in the ochre-kb JetStream KV bucket, mirroring
+// Registry's lazy get-or-create bucket, key "accountID/id", per-account
+// prefix-scan list.
+type KBStore struct {
+	js jetstream.JetStream
+
+	mu sync.Mutex
+	kv jetstream.KeyValue
+}
+
+// NewKBStore constructs a KBStore over js.
+func NewKBStore(js jetstream.JetStream) *KBStore {
+	return &KBStore{js: js}
+}
+
+// bucket lazily opens (or creates) the KB KV bucket, caching the handle.
+func (s *KBStore) bucket(ctx context.Context) (jetstream.KeyValue, error) {
+	if s.js == nil {
+		return nil, errors.New("ochrevector: knowledge base store has no JetStream client configured")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.kv != nil {
+		return s.kv, nil
+	}
+	kv, err := kvutil.GetOrCreateBucket(ctx, s.js, kbBucket, kbBucketHistory)
+	if err != nil {
+		return nil, err
+	}
+	s.kv = kv
+	return kv, nil
+}
+
+// kbKey scopes every record to its owning account, so a foreign account's raw
+// id guess can never collide with another tenant's key.
+func kbKey(accountID, id string) string {
+	return accountID + "/" + id
+}
+
+// Create atomically claims rec.ID for accountID: the create-only KV write is
+// the single-writer mutex (mirrors Registry.Reserve), so two concurrent
+// creates of the same id race safely and exactly one wins. rec.AccountID is
+// stamped from accountID, overriding whatever the caller set.
+func (s *KBStore) Create(ctx context.Context, accountID string, rec KBRecord) error {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return err
+	}
+	rec.AccountID = accountID
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("ochrevector: encode knowledge base %s: %w", rec.ID, err)
+	}
+	if _, err := kv.Create(ctx, kbKey(accountID, rec.ID), data); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return ErrKBExists
+		}
+		return fmt.Errorf("ochrevector: reserve knowledge base %s: %w", rec.ID, err)
+	}
+	return nil
+}
+
+// Get reads accountID's record for id, returning (nil, nil) when absent.
+func (s *KBStore) Get(ctx context.Context, accountID, id string) (*KBRecord, error) {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := kv.Get(ctx, kbKey(accountID, id))
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ochrevector: kv get %s: %w", kbKey(accountID, id), err)
+	}
+	var rec KBRecord
+	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+		return nil, fmt.Errorf("ochrevector: decode %s: %w", kbKey(accountID, id), err)
+	}
+	return &rec, nil
+}
+
+// List returns every knowledge base owned by accountID, so one tenant's
+// listing never surfaces another's.
+func (s *KBStore) List(ctx context.Context, accountID string) ([]KBRecord, error) {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := kv.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ochrevector: list keys: %w", err)
+	}
+	prefix := accountID + "/"
+	var out []KBRecord
+	for _, key := range keys {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		entry, err := kv.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("ochrevector: kv get %s: %w", key, err)
+		}
+		var rec KBRecord
+		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+			return nil, fmt.Errorf("ochrevector: decode %s: %w", key, err)
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+// Delete removes accountID's id record. Idempotent: deleting an
+// already-absent record is a no-op success.
+func (s *KBStore) Delete(ctx context.Context, accountID, id string) error {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return err
+	}
+	key := kbKey(accountID, id)
+	if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("ochrevector: delete knowledge base %s: %w", id, err)
+	}
+	return nil
+}
+
+// PurgeAll deletes every knowledge base record across every account.
+// Idempotent: an empty bucket is a no-op success.
+func (s *KBStore) PurgeAll(ctx context.Context) error {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return err
+	}
+	keys, err := kv.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil
+		}
+		return fmt.Errorf("ochrevector: list keys: %w", err)
+	}
+	for _, key := range keys {
+		if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			return fmt.Errorf("ochrevector: purge knowledge base %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// DataSourceStore persists DataSourceRecords in the ochre-kb-datasource
+// JetStream KV bucket, mirroring KBStore.
+type DataSourceStore struct {
+	js jetstream.JetStream
+
+	mu sync.Mutex
+	kv jetstream.KeyValue
+}
+
+// NewDataSourceStore constructs a DataSourceStore over js.
+func NewDataSourceStore(js jetstream.JetStream) *DataSourceStore {
+	return &DataSourceStore{js: js}
+}
+
+// bucket lazily opens (or creates) the data-source KV bucket, caching the
+// handle.
+func (s *DataSourceStore) bucket(ctx context.Context) (jetstream.KeyValue, error) {
+	if s.js == nil {
+		return nil, errors.New("ochrevector: data source store has no JetStream client configured")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.kv != nil {
+		return s.kv, nil
+	}
+	kv, err := kvutil.GetOrCreateBucket(ctx, s.js, dataSourceBucket, dataSourceBucketHistory)
+	if err != nil {
+		return nil, err
+	}
+	s.kv = kv
+	return kv, nil
+}
+
+// dataSourceKey scopes every record to its owning account, so a foreign
+// account's raw id guess can never collide with another tenant's key.
+func dataSourceKey(accountID, id string) string {
+	return accountID + "/" + id
+}
+
+// Create atomically claims rec.ID for accountID, mirroring KBStore.Create.
+func (s *DataSourceStore) Create(ctx context.Context, accountID string, rec DataSourceRecord) error {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return err
+	}
+	rec.AccountID = accountID
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("ochrevector: encode data source %s: %w", rec.ID, err)
+	}
+	if _, err := kv.Create(ctx, dataSourceKey(accountID, rec.ID), data); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return ErrDataSourceExists
+		}
+		return fmt.Errorf("ochrevector: reserve data source %s: %w", rec.ID, err)
+	}
+	return nil
+}
+
+// Get reads accountID's record for id, returning (nil, nil) when absent.
+func (s *DataSourceStore) Get(ctx context.Context, accountID, id string) (*DataSourceRecord, error) {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := kv.Get(ctx, dataSourceKey(accountID, id))
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ochrevector: kv get %s: %w", dataSourceKey(accountID, id), err)
+	}
+	var rec DataSourceRecord
+	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+		return nil, fmt.Errorf("ochrevector: decode %s: %w", dataSourceKey(accountID, id), err)
+	}
+	return &rec, nil
+}
+
+// List returns every data source owned by accountID, across every knowledge
+// base, so one tenant's listing never surfaces another's.
+func (s *DataSourceStore) List(ctx context.Context, accountID string) ([]DataSourceRecord, error) {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := kv.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ochrevector: list keys: %w", err)
+	}
+	prefix := accountID + "/"
+	var out []DataSourceRecord
+	for _, key := range keys {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		entry, err := kv.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("ochrevector: kv get %s: %w", key, err)
+		}
+		var rec DataSourceRecord
+		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+			return nil, fmt.Errorf("ochrevector: decode %s: %w", key, err)
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+// ListByKnowledgeBase returns accountID's data sources scoped to
+// knowledgeBaseID, the shape ListDataSources needs.
+func (s *DataSourceStore) ListByKnowledgeBase(ctx context.Context, accountID, knowledgeBaseID string) ([]DataSourceRecord, error) {
+	all, err := s.List(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]DataSourceRecord, 0, len(all))
+	for _, rec := range all {
+		if rec.KnowledgeBaseID == knowledgeBaseID {
+			out = append(out, rec)
+		}
+	}
+	return out, nil
+}
+
+// Delete removes accountID's id record. Idempotent: deleting an
+// already-absent record is a no-op success.
+func (s *DataSourceStore) Delete(ctx context.Context, accountID, id string) error {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return err
+	}
+	key := dataSourceKey(accountID, id)
+	if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("ochrevector: delete data source %s: %w", id, err)
+	}
+	return nil
+}
+
+// PurgeAll deletes every data source record across every account. Idempotent:
+// an empty bucket is a no-op success.
+func (s *DataSourceStore) PurgeAll(ctx context.Context) error {
+	kv, err := s.bucket(ctx)
+	if err != nil {
+		return err
+	}
+	keys, err := kv.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil
+		}
+		return fmt.Errorf("ochrevector: list keys: %w", err)
+	}
+	for _, key := range keys {
+		if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			return fmt.Errorf("ochrevector: purge data source %s: %w", key, err)
+		}
+	}
+	return nil
+}

--- a/spinifex/handlers/ochrevector/kbstore_test.go
+++ b/spinifex/handlers/ochrevector/kbstore_test.go
@@ -121,6 +121,71 @@ func TestDataSourceStore_CreateCollisionReturnsErrDataSourceExists(t *testing.T)
 	assert.ErrorIs(t, err, ErrDataSourceExists)
 }
 
+func TestKBStore_PurgeAll(t *testing.T) {
+	store := newKBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, kbAccountA, KBRecord{ID: "kb-a1"}))
+	require.NoError(t, store.Create(ctx, kbAccountB, KBRecord{ID: "kb-b1"}))
+
+	require.NoError(t, store.PurgeAll(ctx))
+
+	listA, err := store.List(ctx, kbAccountA)
+	require.NoError(t, err)
+	assert.Empty(t, listA)
+	listB, err := store.List(ctx, kbAccountB)
+	require.NoError(t, err)
+	assert.Empty(t, listB)
+
+	// Idempotent: purging an already-empty bucket still succeeds.
+	require.NoError(t, store.PurgeAll(ctx))
+}
+
+func TestKBStore_NoJetStreamClientReturnsError(t *testing.T) {
+	store := NewKBStore(nil)
+	ctx := context.Background()
+
+	err := store.Create(ctx, kbAccountA, KBRecord{ID: "kb-1"})
+	assert.Error(t, err)
+
+	_, err = store.Get(ctx, kbAccountA, "kb-1")
+	assert.Error(t, err)
+
+	_, err = store.List(ctx, kbAccountA)
+	assert.Error(t, err)
+}
+
+func TestDataSourceStore_PurgeAll(t *testing.T) {
+	store := newDataSourceTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, kbAccountA, DataSourceRecord{ID: "ds-a1", KnowledgeBaseID: "kb-1"}))
+	require.NoError(t, store.Create(ctx, kbAccountB, DataSourceRecord{ID: "ds-b1", KnowledgeBaseID: "kb-2"}))
+
+	require.NoError(t, store.PurgeAll(ctx))
+
+	listA, err := store.List(ctx, kbAccountA)
+	require.NoError(t, err)
+	assert.Empty(t, listA)
+
+	// Idempotent: purging an already-empty bucket still succeeds.
+	require.NoError(t, store.PurgeAll(ctx))
+}
+
+func TestDataSourceStore_NoJetStreamClientReturnsError(t *testing.T) {
+	store := NewDataSourceStore(nil)
+	ctx := context.Background()
+
+	err := store.Create(ctx, kbAccountA, DataSourceRecord{ID: "ds-1"})
+	assert.Error(t, err)
+
+	_, err = store.Get(ctx, kbAccountA, "ds-1")
+	assert.Error(t, err)
+
+	_, err = store.List(ctx, kbAccountA)
+	assert.Error(t, err)
+}
+
 func TestDataSourceStore_ListByKnowledgeBase(t *testing.T) {
 	store := newDataSourceTestStore(t)
 	ctx := context.Background()

--- a/spinifex/handlers/ochrevector/kbstore_test.go
+++ b/spinifex/handlers/ochrevector/kbstore_test.go
@@ -1,0 +1,143 @@
+// In-package to match the sibling registry/jobs test files (registry_test.go,
+// jobs_test.go) and exercise CAS/prefix-scan behavior directly.
+//
+//test:in-package
+package handlers_ochrevector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	kbAccountA = "111111111111"
+	kbAccountB = "222222222222"
+)
+
+func newKBTestStore(t *testing.T) *KBStore {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	return NewKBStore(js)
+}
+
+func newDataSourceTestStore(t *testing.T) *DataSourceStore {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	return NewDataSourceStore(js)
+}
+
+func TestKBStore_CreateGetListDelete(t *testing.T) {
+	store := newKBTestStore(t)
+	ctx := context.Background()
+
+	rec := KBRecord{ID: "kb-1", Name: "docs", Status: StateReady, Dimension: 1536}
+	require.NoError(t, store.Create(ctx, kbAccountA, rec))
+
+	got, err := store.Get(ctx, kbAccountA, "kb-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "docs", got.Name)
+	assert.Equal(t, kbAccountA, got.AccountID)
+
+	// A foreign account never sees another tenant's record.
+	foreign, err := store.Get(ctx, kbAccountB, "kb-1")
+	require.NoError(t, err)
+	assert.Nil(t, foreign)
+
+	list, err := store.List(ctx, kbAccountA)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	require.NoError(t, store.Delete(ctx, kbAccountA, "kb-1"))
+	got, err = store.Get(ctx, kbAccountA, "kb-1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Delete is idempotent: a second delete of an absent record still succeeds.
+	require.NoError(t, store.Delete(ctx, kbAccountA, "kb-1"))
+}
+
+func TestKBStore_CreateCollisionReturnsErrKBExists(t *testing.T) {
+	store := newKBTestStore(t)
+	ctx := context.Background()
+
+	rec := KBRecord{ID: "kb-1", Name: "docs", Status: StateReady}
+	require.NoError(t, store.Create(ctx, kbAccountA, rec))
+
+	err := store.Create(ctx, kbAccountA, rec)
+	assert.ErrorIs(t, err, ErrKBExists)
+}
+
+func TestKBStore_ListScopedPerAccount(t *testing.T) {
+	store := newKBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, kbAccountA, KBRecord{ID: "kb-a1"}))
+	require.NoError(t, store.Create(ctx, kbAccountA, KBRecord{ID: "kb-a2"}))
+	require.NoError(t, store.Create(ctx, kbAccountB, KBRecord{ID: "kb-b1"}))
+
+	listA, err := store.List(ctx, kbAccountA)
+	require.NoError(t, err)
+	assert.Len(t, listA, 2)
+
+	listB, err := store.List(ctx, kbAccountB)
+	require.NoError(t, err)
+	assert.Len(t, listB, 1)
+}
+
+func TestDataSourceStore_CreateGetListDelete(t *testing.T) {
+	store := newDataSourceTestStore(t)
+	ctx := context.Background()
+
+	rec := DataSourceRecord{ID: "ds-1", KnowledgeBaseID: "kb-1", Name: "s3-docs", Status: StateReady}
+	require.NoError(t, store.Create(ctx, kbAccountA, rec))
+
+	got, err := store.Get(ctx, kbAccountA, "ds-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "kb-1", got.KnowledgeBaseID)
+
+	require.NoError(t, store.Delete(ctx, kbAccountA, "ds-1"))
+	got, err = store.Get(ctx, kbAccountA, "ds-1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Delete is idempotent.
+	require.NoError(t, store.Delete(ctx, kbAccountA, "ds-1"))
+}
+
+func TestDataSourceStore_CreateCollisionReturnsErrDataSourceExists(t *testing.T) {
+	store := newDataSourceTestStore(t)
+	ctx := context.Background()
+
+	rec := DataSourceRecord{ID: "ds-1", KnowledgeBaseID: "kb-1"}
+	require.NoError(t, store.Create(ctx, kbAccountA, rec))
+
+	err := store.Create(ctx, kbAccountA, rec)
+	assert.ErrorIs(t, err, ErrDataSourceExists)
+}
+
+func TestDataSourceStore_ListByKnowledgeBase(t *testing.T) {
+	store := newDataSourceTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, kbAccountA, DataSourceRecord{ID: "ds-1", KnowledgeBaseID: "kb-1"}))
+	require.NoError(t, store.Create(ctx, kbAccountA, DataSourceRecord{ID: "ds-2", KnowledgeBaseID: "kb-1"}))
+	require.NoError(t, store.Create(ctx, kbAccountA, DataSourceRecord{ID: "ds-3", KnowledgeBaseID: "kb-2"}))
+
+	scoped, err := store.ListByKnowledgeBase(ctx, kbAccountA, "kb-1")
+	require.NoError(t, err)
+	assert.Len(t, scoped, 2)
+
+	scoped, err = store.ListByKnowledgeBase(ctx, kbAccountA, "kb-2")
+	require.NoError(t, err)
+	assert.Len(t, scoped, 1)
+
+	scoped, err = store.ListByKnowledgeBase(ctx, kbAccountA, "kb-does-not-exist")
+	require.NoError(t, err)
+	assert.Empty(t, scoped)
+}

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -25,6 +25,7 @@ import (
 	handlers_bedrock "github.com/mulgadc/spinifex/spinifex/handlers/bedrock"
 	"github.com/mulgadc/spinifex/spinifex/handlers/ecr"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
 	handlers_quota "github.com/mulgadc/spinifex/spinifex/handlers/quota"
 	handlers_sts "github.com/mulgadc/spinifex/spinifex/handlers/sts"
 	"github.com/mulgadc/spinifex/spinifex/network/reconcile"
@@ -366,6 +367,15 @@ func launchService(config *config.ClusterConfig) error {
 	// inference enforcement can read it back, but nothing enforces it yet.
 	bedrockGuardrails := gateway_bedrock.NewGuardrailStore(js, len(config.Nodes), nodeConfig.Region)
 
+	// bedrock-agent knowledge-base + data-source resource metadata: gateway-
+	// owned (D-arch), opened directly against JetStream the same way the
+	// bedrock stores above are, rather than a second NATS hop through the
+	// daemon. bedrockAgentVector forwards CreateIndex/Ingest/DescribeJob/
+	// ListJobs/etc to .9's daemon-side VectorService over NATS.
+	bedrockAgentKB := handlers_ochrevector.NewKBStore(js)
+	bedrockAgentDataSources := handlers_ochrevector.NewDataSourceStore(js)
+	bedrockAgentVector := handlers_ochrevector.NewNATSVectorService(natsConn)
+
 	// Bedrock invocation records: every Converse/InvokeModel call (streaming
 	// or not) is published to the invocation stream, then fanned out by
 	// deliveryConsumer to any account with a configured destination bucket
@@ -423,6 +433,9 @@ func launchService(config *config.ClusterConfig) error {
 		BedrockAccessAdmin:      bedrockAccess,
 		BedrockProvisioned:      bedrockProvisioned,
 		BedrockGuardrails:       bedrockGuardrails,
+		BedrockAgentKB:          bedrockAgentKB,
+		BedrockAgentDataSources: bedrockAgentDataSources,
+		BedrockAgentVector:      bedrockAgentVector,
 	}
 
 	// Rotate the ECR signing key on a 30-day cadence, retaining the previous keys


### PR DESCRIPTION
## Summary
Implements Ochre Phase 5 (`mulga-vmfng.10`): the emulated AWS `bedrock-agent` (knowledge-base + data-source + ingestion CRUD) and `bedrock-agent-runtime` (`Retrieve` / `RetrieveAndGenerate` RAG) API surface, as a thin REST-JSON translation layer over the `.9` tenant vector store. No new vector engine — maps AWS shapes onto the existing `ochre.vector.*` NATS service and reuses `gateway_bedrock.Converse` in-process for RAG generation.

Plan: `docs/development/feature/ochre-phase5-knowledge-bases.md`.

## What's in it
- **`bedrock-agent`** (`gateway/bedrockagent.go`): Create/Get/List/Delete KnowledgeBase + DataSource, StartIngestionJob, GetIngestionJob, ListIngestionJobs. KB : index is 1:1; data-source S3 + chunking maps onto `SourceSpec`.
- **`bedrock-agent-runtime`** (`gateway/bedrockagentruntime.go`): `Retrieve` → vector `Query`; `RetrieveAndGenerate` → retrieve + in-process Converse, with citations + server-generated `sessionId`.
- New `ochre.vector.listJobs` NATS subject + `VectorService.ListJobs`.
- KB/DataSource JetStream KV stores (`ochre-kb`, `ochre-kb-datasource`), mirroring `.9`'s registry/jobs CAS idiom.
- Gateway registration + a `GetService` discriminator fix so all four bedrock-family services (which all sign SigV4 as `bedrock`) route correctly.
- Filter translator: AWS `RetrievalFilter` → `.9` `Filter` AST, full operator set. Uses a shadow-decode because vendored aws-sdk-go v1.55.8's `RetrievalFilter` predates the leaf operators (would otherwise silently drop conditions).

## Decisions (see plan D1–D7)
1:1 KB↔index; in-process Converse for RAG; `storageConfiguration`/`roleArn` accept-and-stub; `sessionId` server-generated, no persisted memory (Phase 5); chunking `ChunkOverlap = round(maxTokens × overlap%/100)`; Retrieve defaults to 5 results (AWS parity).

## Known limitations / follow-ups
- `JobRecord` has no `DataSourceID`, so ingestion-job↔data-source ownership is a best-effort Bucket+Prefix match (exact threading noted as a follow-up).
- Retrieval-result `metadata` omitted from responses (vendored SDK vintage lacks the field).
- Citations are one aggregate block (Converse gives no per-span signal); no pagination; KB lifecycle is synchronous (no async CREATING/DELETING states).
- KB/DataSource stores are gateway-owned, so appliance `Teardown` does not purge them — a torn-down appliance leaves dangling KB records (Retrieve then returns empty). Tracked.

## Testing
`make preflight` GREEN (diff coverage 79.1%, lint 0, govulncheck 0). Unit + HTTP-dispatcher tests for both services, mappers, filter translator, store CAS. **Live RAG verification on wattle pending.**

Roadmap note: AWS retired Bedrock **Agents** → AgentCore (hits `.11`, re-scope noted). Knowledge Bases (this PR) is unaffected.