### PR TITLE
fix: Ochre self-host invoke family dispatch + faithful not-ready errors

### DIFF
--- a/spinifex/gateway/bedrock/catalog.go
+++ b/spinifex/gateway/bedrock/catalog.go
@@ -20,6 +20,10 @@ const (
 	providerPrefix  = "provider:"
 	vendorAnthropic = "anthropic"
 	modelARNFormat  = "arn:aws:bedrock:*::foundation-model/%s"
+	// familyMeta is the self-host model family served by the Llama invoke
+	// adapter. Any other self-host family is unhandled and refused explicitly
+	// rather than mis-served through Llama's native request schema.
+	familyMeta = "meta"
 )
 
 // catalogEntry is one static catalog record. Model IDs mirror AWS exactly so
@@ -42,6 +46,7 @@ type catalogEntry struct {
 	ModelName                     string
 	ProviderName                  string
 	Provider                      string // "self-host" or "provider:<vendor>"
+	Family                        string // self-host only; selects the invoke adapter (see familyMeta)
 	InputModalities               []string
 	OutputModalities              []string
 	ResponseStreamingSupported    bool
@@ -57,16 +62,13 @@ type catalogEntry struct {
 
 // catalog is the static model set: two self-hosted open models and one
 // Anthropic-direct model. Later phases extend this list.
-//
-// Both self-host entries are Meta models on purpose: self-host InvokeModel
-// dispatch picks llamaInvokeAdapter for every self-host entry, so a model of
-// another family would be served with Llama's native request schema.
 var catalog = []catalogEntry{
 	{
 		ModelID:                    "meta.llama3-2-1b-instruct-v1:0",
 		ModelName:                  "Llama 3.2 1B Instruct",
 		ProviderName:               "Meta",
 		Provider:                   tierSelfHost,
+		Family:                     familyMeta,
 		InputModalities:            []string{"TEXT"},
 		OutputModalities:           []string{"TEXT"},
 		ResponseStreamingSupported: false,
@@ -83,6 +85,7 @@ var catalog = []catalogEntry{
 		ModelName:                  "Llama 3.2 3B Instruct",
 		ProviderName:               "Meta",
 		Provider:                   tierSelfHost,
+		Family:                     familyMeta,
 		InputModalities:            []string{"TEXT"},
 		OutputModalities:           []string{"TEXT"},
 		ResponseStreamingSupported: false,

--- a/spinifex/gateway/bedrock/invoke.go
+++ b/spinifex/gateway/bedrock/invoke.go
@@ -12,6 +12,29 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
+// resolveEndpointError maps a failed endpoint resolution onto the AWS code the
+// daemon put on the wire, falling back to ServiceUnavailable for an un-coded
+// transport failure.
+func resolveEndpointError(err error) error {
+	if code, ok := awserrors.ResolveErrorCode(err); ok {
+		return errors.New(code)
+	}
+	return errors.New(awserrors.ErrorServiceUnavailableException)
+}
+
+// selfHostInvokeAdapter selects the InvokeAdapter for a self-host catalog
+// entry by family: familyMeta serves through the Llama adapter (honouring a
+// PT-account scope); any other family is refused rather than mis-served.
+func selfHostInvokeAdapter(family string, endpointResolver EndpointResolver, ptAccountID string) (InvokeAdapter, error) {
+	if family != familyMeta {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	if ptAccountID != "" {
+		return newLlamaInvokeAdapterForAccount(endpointResolver, ptAccountID), nil
+	}
+	return newLlamaInvokeAdapter(endpointResolver), nil
+}
+
 // InvokeAdapter translates a Bedrock InvokeModel raw request body into a
 // backend's native wire format and back, returning the response bytes
 // verbatim with their content-type. Unlike Provider (Converse), the wire
@@ -110,10 +133,9 @@ func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID stri
 	var a InvokeAdapter
 	switch {
 	case entry.Provider == tierSelfHost:
-		if ptAccountID != "" {
-			a = newLlamaInvokeAdapterForAccount(rt.endpointResolver, ptAccountID)
-		} else {
-			a = newLlamaInvokeAdapter(rt.endpointResolver)
+		a, err = selfHostInvokeAdapter(entry.Family, rt.endpointResolver, ptAccountID)
+		if err != nil {
+			return nil, "", err
 		}
 	case strings.HasPrefix(entry.Provider, providerPrefix):
 		switch strings.TrimPrefix(entry.Provider, providerPrefix) {
@@ -271,10 +293,9 @@ func (rt *InvokeStreamRouter) InvokeModelWithResponseStream(ctx context.Context,
 	var a InvokeAdapter
 	switch {
 	case entry.Provider == tierSelfHost:
-		if ptAccountID != "" {
-			a = newLlamaInvokeAdapterForAccount(rt.endpointResolver, ptAccountID)
-		} else {
-			a = newLlamaInvokeAdapter(rt.endpointResolver)
+		a, err = selfHostInvokeAdapter(entry.Family, rt.endpointResolver, ptAccountID)
+		if err != nil {
+			return nil, err
 		}
 	case strings.HasPrefix(entry.Provider, providerPrefix):
 		switch strings.TrimPrefix(entry.Provider, providerPrefix) {

--- a/spinifex/gateway/bedrock/invoke_llama.go
+++ b/spinifex/gateway/bedrock/invoke_llama.go
@@ -159,7 +159,7 @@ func (a *llamaInvokeAdapter) InvokeModel(ctx context.Context, modelID string, bo
 	baseURL, ok, err := a.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("llama invoke: endpoint resolution failed", "model", modelID, "err", err)
-		return nil, "", errors.New(awserrors.ErrorServiceUnavailableException)
+		return nil, "", resolveEndpointError(err)
 	}
 	if !ok {
 		return nil, "", errors.New(awserrors.ErrorModelNotReadyException)
@@ -243,7 +243,7 @@ func (a *llamaInvokeAdapter) InvokeModelWithResponseStream(ctx context.Context, 
 	baseURL, ok, err := a.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("llama invoke-stream: endpoint resolution failed", "model", modelID, "err", err)
-		return nil, errors.New(awserrors.ErrorServiceUnavailableException)
+		return nil, resolveEndpointError(err)
 	}
 	if !ok {
 		return nil, errors.New(awserrors.ErrorModelNotReadyException)

--- a/spinifex/gateway/bedrock/invoke_llama_test.go
+++ b/spinifex/gateway/bedrock/invoke_llama_test.go
@@ -3,6 +3,8 @@ package gateway_bedrock
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -103,6 +105,30 @@ func TestLlamaInvokeAdapter_InvokeModel_UnresolvedEndpointReturnsModelNotReady(t
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
 }
 
+// TestLlamaInvokeAdapter_InvokeModel_EndpointErrorPropagatesCode proves a
+// resolver err carrying an admission-refusal code (wrapped the way
+// decodedNATSError's Unwrap tree does) surfaces faithfully rather than being
+// flattened to ServiceUnavailableException.
+func TestLlamaInvokeAdapter_InvokeModel_EndpointErrorPropagatesCode(t *testing.T) {
+	wrapped := fmt.Errorf("endpoint resolve: %w", errors.New(awserrors.ErrorModelNotReadyException))
+	a := newLlamaInvokeAdapter(errEndpointResolver{err: wrapped})
+
+	_, _, err := a.InvokeModel(context.Background(), "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestLlamaInvokeAdapter_InvokeModel_EndpointErrorFallsBackToServiceUnavailable
+// proves an un-coded transport failure still falls back to
+// ServiceUnavailableException rather than surfacing raw transport text.
+func TestLlamaInvokeAdapter_InvokeModel_EndpointErrorFallsBackToServiceUnavailable(t *testing.T) {
+	a := newLlamaInvokeAdapter(errEndpointResolver{err: errors.New("nats: timeout")})
+
+	_, _, err := a.InvokeModel(context.Background(), "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServiceUnavailableException, err.Error())
+}
+
 // llamaCompletionsStreamFixture is a canned OpenAI /v1/completions streaming
 // SSE body: two text deltas, a finish_reason chunk, a trailing usage-only
 // chunk, then [DONE].
@@ -181,6 +207,27 @@ func TestLlamaInvokeAdapter_InvokeModelWithResponseStream_UnresolvedEndpointRetu
 	_, err := a.InvokeModelWithResponseStream(context.Background(), "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestLlamaInvokeAdapter_InvokeModelWithResponseStream_EndpointErrorPropagatesCode
+// mirrors the InvokeModel case for the streaming entry point.
+func TestLlamaInvokeAdapter_InvokeModelWithResponseStream_EndpointErrorPropagatesCode(t *testing.T) {
+	wrapped := fmt.Errorf("endpoint resolve: %w", errors.New(awserrors.ErrorModelNotReadyException))
+	a := newLlamaInvokeAdapter(errEndpointResolver{err: wrapped})
+
+	_, err := a.InvokeModelWithResponseStream(context.Background(), "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestLlamaInvokeAdapter_InvokeModelWithResponseStream_EndpointErrorFallsBackToServiceUnavailable
+// mirrors the InvokeModel case for the streaming entry point.
+func TestLlamaInvokeAdapter_InvokeModelWithResponseStream_EndpointErrorFallsBackToServiceUnavailable(t *testing.T) {
+	a := newLlamaInvokeAdapter(errEndpointResolver{err: errors.New("nats: timeout")})
+
+	_, err := a.InvokeModelWithResponseStream(context.Background(), "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServiceUnavailableException, err.Error())
 }
 
 func TestLlamaInvokeStreamSource_MidStreamDecodeErrorSurfacesAsStreamFault(t *testing.T) {

--- a/spinifex/gateway/bedrock/invoke_test.go
+++ b/spinifex/gateway/bedrock/invoke_test.go
@@ -12,6 +12,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// errEndpointResolver returns a caller-supplied non-nil err from every
+// resolve call, driving the endpoint-resolution failure branch a real daemon
+// outage or admission refusal would trigger.
+type errEndpointResolver struct {
+	err error
+}
+
+var _ EndpointResolver = errEndpointResolver{}
+
+func (r errEndpointResolver) Endpoint(_ context.Context, _ string) (string, bool, error) {
+	return "", false, r.err
+}
+
+func (r errEndpointResolver) EndpointForAccount(_ context.Context, _, _ string) (string, bool, error) {
+	return "", false, r.err
+}
+
+// withCatalogEntry appends entry to the package-level catalog for the
+// duration of the test, restoring the original slice on cleanup — the
+// dispatch tests need a self-host entry outside the shipped family set.
+func withCatalogEntry(t *testing.T, entry catalogEntry) {
+	t.Helper()
+	original := catalog
+	catalog = append(append([]catalogEntry{}, catalog...), entry)
+	t.Cleanup(func() { catalog = original })
+}
+
 func TestInvokeRouter_SelfHostSuccess(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -121,4 +148,47 @@ func TestInvokeStreamRouter_SelfHostNoEndpointReturnsModelNotReady(t *testing.T)
 	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestInvokeRouter_SelfHostUnhandledFamilyReturnsValidationException proves a
+// self-host entry outside the shipped family set is refused outright rather
+// than mis-served through Llama's native request schema — the fake endpoint
+// server records whether it was ever called at all.
+func TestInvokeRouter_SelfHostUnhandledFamilyReturnsValidationException(t *testing.T) {
+	modelID := "self-host.unhandled-family-v1:0"
+	withCatalogEntry(t, catalogEntry{ModelID: modelID, Provider: tierSelfHost, Family: "mistral"})
+
+	var called bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
+	_, _, err := rt.InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), "", "")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
+	assert.False(t, called, "an unhandled self-host family must never reach the Llama-serving endpoint")
+}
+
+// TestInvokeStreamRouter_SelfHostUnhandledFamilyReturnsValidationException
+// mirrors TestInvokeRouter_SelfHostUnhandledFamilyReturnsValidationException
+// for the streaming router.
+func TestInvokeStreamRouter_SelfHostUnhandledFamilyReturnsValidationException(t *testing.T) {
+	modelID := "self-host.unhandled-family-v1:0"
+	withCatalogEntry(t, catalogEntry{ModelID: modelID, Provider: tierSelfHost, Family: "mistral"})
+
+	var called bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil, nil)
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), "", "")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
+	assert.False(t, called, "an unhandled self-host family must never reach the Llama-serving endpoint")
 }

--- a/spinifex/gateway/bedrock/vllm.go
+++ b/spinifex/gateway/bedrock/vllm.go
@@ -163,7 +163,7 @@ func (p *vllmProvider) Converse(ctx context.Context, modelID string, input *bedr
 	baseURL, ok, err := p.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("vllm: endpoint resolution failed", "model", modelID, "err", err)
-		return nil, errors.New(awserrors.ErrorServiceUnavailableException)
+		return nil, resolveEndpointError(err)
 	}
 	if !ok {
 		return nil, errors.New(awserrors.ErrorModelNotReadyException)
@@ -288,7 +288,7 @@ func (p *vllmProvider) ConverseStream(ctx context.Context, modelID string, input
 	baseURL, ok, err := p.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("vllm stream: endpoint resolution failed", "model", modelID, "err", err)
-		return nil, errors.New(awserrors.ErrorServiceUnavailableException)
+		return nil, resolveEndpointError(err)
 	}
 	if !ok {
 		return nil, errors.New(awserrors.ErrorModelNotReadyException)

--- a/spinifex/gateway/bedrock/vllm_test.go
+++ b/spinifex/gateway/bedrock/vllm_test.go
@@ -3,6 +3,8 @@ package gateway_bedrock
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,6 +76,42 @@ func TestVLLMProvider_Converse_UnresolvedEndpointReturnsModelNotReady(t *testing
 	_, err := p.Converse(context.Background(), "meta.llama3-2-1b-instruct-v1:0", input)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestVLLMProvider_Converse_EndpointErrorPropagatesCode proves a resolver err
+// carrying an admission-refusal code (wrapped the way decodedNATSError's
+// Unwrap tree does) surfaces faithfully rather than being flattened to
+// ServiceUnavailableException.
+func TestVLLMProvider_Converse_EndpointErrorPropagatesCode(t *testing.T) {
+	wrapped := fmt.Errorf("endpoint resolve: %w", errors.New(awserrors.ErrorModelNotReadyException))
+	p := newVLLMProvider(errEndpointResolver{err: wrapped})
+
+	input := &bedrockruntime.ConverseInput{
+		Messages: []*bedrockruntime.Message{
+			{Role: aws.String(bedrockruntime.ConversationRoleUser), Content: []*bedrockruntime.ContentBlock{{Text: aws.String("hello")}}},
+		},
+	}
+
+	_, err := p.Converse(context.Background(), "meta.llama3-2-1b-instruct-v1:0", input)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestVLLMProvider_Converse_EndpointErrorFallsBackToServiceUnavailable proves
+// an un-coded transport failure still falls back to
+// ServiceUnavailableException rather than surfacing raw transport text.
+func TestVLLMProvider_Converse_EndpointErrorFallsBackToServiceUnavailable(t *testing.T) {
+	p := newVLLMProvider(errEndpointResolver{err: errors.New("nats: timeout")})
+
+	input := &bedrockruntime.ConverseInput{
+		Messages: []*bedrockruntime.Message{
+			{Role: aws.String(bedrockruntime.ConversationRoleUser), Content: []*bedrockruntime.ContentBlock{{Text: aws.String("hello")}}},
+		},
+	}
+
+	_, err := p.Converse(context.Background(), "meta.llama3-2-1b-instruct-v1:0", input)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServiceUnavailableException, err.Error())
 }
 
 // vllmStreamFixture is a canned OpenAI chat-completions streaming SSE body:
@@ -179,6 +217,39 @@ func TestVLLMProvider_ConverseStream_UnresolvedEndpointReturnsModelNotReady(t *t
 	_, err := p.ConverseStream(context.Background(), "meta.llama3-2-1b-instruct-v1:0", input)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestVLLMProvider_ConverseStream_EndpointErrorPropagatesCode mirrors the
+// Converse case for the streaming entry point.
+func TestVLLMProvider_ConverseStream_EndpointErrorPropagatesCode(t *testing.T) {
+	wrapped := fmt.Errorf("endpoint resolve: %w", errors.New(awserrors.ErrorModelNotReadyException))
+	p := newVLLMProvider(errEndpointResolver{err: wrapped})
+
+	input := &bedrockruntime.ConverseStreamInput{
+		Messages: []*bedrockruntime.Message{
+			{Role: aws.String(bedrockruntime.ConversationRoleUser), Content: []*bedrockruntime.ContentBlock{{Text: aws.String("hello")}}},
+		},
+	}
+
+	_, err := p.ConverseStream(context.Background(), "meta.llama3-2-1b-instruct-v1:0", input)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
+}
+
+// TestVLLMProvider_ConverseStream_EndpointErrorFallsBackToServiceUnavailable
+// mirrors the Converse case for the streaming entry point.
+func TestVLLMProvider_ConverseStream_EndpointErrorFallsBackToServiceUnavailable(t *testing.T) {
+	p := newVLLMProvider(errEndpointResolver{err: errors.New("nats: timeout")})
+
+	input := &bedrockruntime.ConverseStreamInput{
+		Messages: []*bedrockruntime.Message{
+			{Role: aws.String(bedrockruntime.ConversationRoleUser), Content: []*bedrockruntime.ContentBlock{{Text: aws.String("hello")}}},
+		},
+	}
+
+	_, err := p.ConverseStream(context.Background(), "meta.llama3-2-1b-instruct-v1:0", input)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServiceUnavailableException, err.Error())
 }
 
 func TestVLLMProvider_ConverseStream_UpstreamNon2xxMapsStatus(t *testing.T) {


### PR DESCRIPTION
Two bounded fixes on the self-host invoke seam (`gateway/bedrock`).

## kvxp5 — dispatch by model family, not tier
`InvokeRouter` / `InvokeStreamRouter` selected the adapter by `entry.Provider == tierSelfHost` and always built the Llama adapter, so a non-Meta self-host entry (Mistral, Qwen) was silently served through Llama's native request schema. Adds a `Family` field to `catalogEntry` and a `selfHostInvokeAdapter` helper: `familyMeta` → Llama adapter (PT-account branch kept); any other family → explicit `ValidationException`, never mis-served.

## qfk6d — preserve the not-ready code
Four resolve sites (`invoke_llama.go` ×2, `vllm.go` ×2) hardcoded `ServiceUnavailableException` on the `err` branch, discarding the AWS code the daemon put on the wire — an admission refusal ("no free GPU device has N MiB") reached the client as a 503 instead of `ModelNotReadyException` (429). New shared `resolveEndpointError` resolves the carried code via `awserrors.ResolveErrorCode`, falling back to `ServiceUnavailable` only for an un-coded transport failure. The `!ok` (launch-in-flight) branch is unchanged.

## Tests
New `errEndpointResolver` fake (returns a coded non-nil err); unhandled-family dispatch tests (assert `ValidationException` + endpoint never called); per-site code-propagation tests across all four sites (coded → propagated, un-coded → `ServiceUnavailable`).

`make preflight` green.