### PR TITLE
fix: stop embedded NATS test servers sleeping 25ms on startup

### DIFF
--- a/spinifex/testutil/nats.go
+++ b/spinifex/testutil/nats.go
@@ -25,13 +25,27 @@ func StartTestNATS(t testing.TB) (*server.Server, *nats.Conn) {
 	ns, err := server.NewServer(opts)
 	require.NoError(t, err)
 	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
+	waitReadyForConnections(t, ns)
 	t.Cleanup(func() { ns.Shutdown() })
 
 	nc, err := nats.Connect(ns.ClientURL())
 	require.NoError(t, err)
 	t.Cleanup(func() { nc.Close() })
 	return ns, nc
+}
+
+// waitReadyForConnections spins until the server accepts connections. Calling
+// ReadyForConnections with a longer timeout makes it sleep 25ms per attempt,
+// which every embedded server in the suite would otherwise pay.
+func waitReadyForConnections(t testing.TB, ns *server.Server) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !ns.ReadyForConnections(time.Millisecond) {
+		if time.Now().After(deadline) {
+			t.Fatal("embedded NATS server not ready for connections within 5s")
+		}
+		time.Sleep(200 * time.Microsecond)
+	}
 }
 
 // StartTestJetStream starts an embedded NATS server with JetStream enabled
@@ -50,7 +64,7 @@ func StartTestJetStream(t *testing.T) (*server.Server, *nats.Conn, jetstream.Jet
 	ns, err := server.NewServer(opts)
 	require.NoError(t, err)
 	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
+	waitReadyForConnections(t, ns)
 	t.Cleanup(func() { ns.Shutdown() })
 
 	nc, err := nats.Connect(ns.ClientURL())


### PR DESCRIPTION
## Summary

Every test that stands up an embedded NATS server paid a fixed ~25ms doing nothing. Removing that sleep cuts ~48s off five packages alone.

`testutil.StartTestNATS` and `StartTestJetStream` waited for readiness with `ns.ReadyForConnections(5*time.Second)`. In nats-server v2.14.5, `readyForConnections` sleeps a hardcoded 25ms between attempts whenever the caller passes a timeout longer than 25ms. The listener is never up on the first check, because `go ns.Start()` is still racing — so **every single call slept the full 25ms**, then connected.

Passing a timeout under 25ms skips the sleep and spins instead. This polls at 200µs and keeps the same 5s ceiling and the same fatal-on-timeout behaviour.

## Measured impact

Verified before/after, `go test -count=1`, on the same machine:

| Package | Before | After | Saved |
|---|---|---|---|
| `spinifex/daemon` | 33.31s | 27.50s | −5.8s |
| `handlers/rds` | 21.07s | 7.35s | −13.7s |
| `handlers/eks` | 17.36s | 10.69s | −6.7s |
| `handlers/ec2/vpc` | 17.01s | 6.72s | −10.3s |
| `handlers/elbv2` | 16.99s | 5.29s | −11.7s |
| **Total** | **105.7s** | **57.5s** | **−48.2s (46%)** |

The win scales with how many servers a package boots: `elbv2` boots ~398 and drops 69%, while `daemon` boots ~197 and drops 17% because its runtime is dominated by other fixed timeouts.

There are 316 `StartTestJetStream` and 108 `StartTestNATS` call sites across 163 files, so packages beyond these five benefit too.

## Scope

One helper function, one file. No test files changed, no production code changed, no coverage impact.

## Not included

Profiling turned up further fixed-timeout costs, left for separate changes:

- `daemon`: `shutdown_test.go:340,396` makes five NATS requests designed to time out at 2s each (~10s). A subscriber exists but never replies, so NATS cannot short-circuit with `no responders`.
- `eks`: `hostFanoutTimeout` (`k3s_ha_control_plane.go:459`) is a 1s scatter-gather window always drained in full (~4s).
- Blanket `t.Parallel()` is the largest remaining win but is not safe as a drop-in — `daemon` has `t.Setenv` calls and several packages mutate package-level test seams.

## Testing

`make preflight` passes.