### PR TITLE
test: stop test suites waiting out timeouts they never needed

### DIFF
--- a/spinifex/daemon/shutdown_test.go
+++ b/spinifex/daemon/shutdown_test.go
@@ -18,6 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// noReplyWait bounds a request that is expected to go unanswered. The handler
+// drops a misaddressed message synchronously, so over loopback this only has to
+// outlast a round trip, not the production reply budget.
+const noReplyWait = 100 * time.Millisecond
+
 // TestClusterShutdownStateKVRoundTrip verifies cluster shutdown state can be stored and retrieved from KV.
 func TestClusterShutdownStateKVRoundTrip(t *testing.T) {
 	nc, err := nats.Connect(sharedJSNATSURL)
@@ -337,7 +342,7 @@ func TestShutdownRequestTarget(t *testing.T) {
 		payload, err := json.Marshal(ShutdownRequest{Phase: "gate", Target: "some-other-node"})
 		require.NoError(t, err)
 
-		_, err = daemon.natsConn.Request(subject, payload, 2*time.Second)
+		_, err = daemon.natsConn.Request(subject, payload, noReplyWait)
 		require.Error(t, err, "a request for another node must not be answered")
 
 		assert.False(t, daemon.shuttingDown.Load(), "another node's drain must not gate this daemon")
@@ -393,7 +398,7 @@ func TestShutdownRequestTarget(t *testing.T) {
 				payload, err := json.Marshal(ShutdownRequest{Phase: phase, Target: "some-other-node"})
 				require.NoError(t, err)
 
-				_, err = daemon.natsConn.Request(subject, payload, 2*time.Second)
+				_, err = daemon.natsConn.Request(subject, payload, noReplyWait)
 				require.Error(t, err, "%s answered a request addressed to another node", phase)
 			})
 		}

--- a/spinifex/handlers/dns/writer_test.go
+++ b/spinifex/handlers/dns/writer_test.go
@@ -144,6 +144,7 @@ secret_key = "READONLY"
 }
 
 func TestZoneS3ConfigRejectsTOMLInsecure(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/spinifex/handlers/dns/zone_lookup_test.go
+++ b/spinifex/handlers/dns/zone_lookup_test.go
@@ -132,6 +132,7 @@ func TestHostsZone_NeverQueriesBareTLD(t *testing.T) {
 // treated as "not hosted" for that candidate only, so a real parent zone one
 // level up is still found.
 func TestHostsZone_S3ErrorAtOneLevelContinuesToParent(t *testing.T) {
+	t.Parallel()
 	objects := map[string]string{
 		"example.com.toml": minimalZoneTOML("example.com"),
 	}
@@ -146,6 +147,7 @@ func TestHostsZone_S3ErrorAtOneLevelContinuesToParent(t *testing.T) {
 // error — a certificate request must not hard-fail because a zone lookup was
 // unavailable.
 func TestHostsZone_S3ErrorEverywhereReturnsFalse(t *testing.T) {
+	t.Parallel()
 	errorKeys := map[string]bool{"lab.example.com.toml": true, "example.com.toml": true}
 	cfg, _ := hostsZoneTestConfig(t, map[string]string{}, errorKeys)
 

--- a/spinifex/handlers/eks/cluster_reconciler_test.go
+++ b/spinifex/handlers/eks/cluster_reconciler_test.go
@@ -219,7 +219,7 @@ func TestClusterReconciler_CreatingStaysWhenBootstrapMissing(t *testing.T) {
 	_, err = acctKV.Put(t.Context(), AdminKubeconfigKey("alpha"), []byte("enc-kc"))
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	_ = r.Run(ctx)
 
@@ -256,7 +256,7 @@ func TestClusterReconciler_CreatingStaysWhenJWKSUnverified(t *testing.T) {
 	_, err = acctKV.Put(t.Context(), OIDCJWKSKey("alpha"), []byte(`{"keys":[]}`))
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	_ = r.Run(ctx)
 
@@ -281,7 +281,7 @@ func TestClusterReconciler_CreatingStaysWhenHealthzFails(t *testing.T) {
 	freshenClusterCreatedAt(t, acctKV)
 	seedBootstrapState(t, acctKV)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	_ = r.Run(ctx)
 
@@ -337,7 +337,7 @@ func TestClusterReconciler_CreatingWithinDeadlineStaysCreating(t *testing.T) {
 
 	freshenClusterCreatedAt(t, acctKV)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	_ = r.Run(ctx)
 
@@ -416,7 +416,7 @@ func TestClusterReconciler_ActiveProbesAndWarnsOnHealthzFail(t *testing.T) {
 	require.NoError(t, SetClusterStatus(t.Context(), acctKV, "alpha", ClusterStatusActive))
 	stub.setResponse(http.StatusServiceUnavailable, nil)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	_ = r.Run(ctx)
 

--- a/spinifex/handlers/eks/delete_cluster_test.go
+++ b/spinifex/handlers/eks/delete_cluster_test.go
@@ -105,11 +105,11 @@ func newEKSServiceFixture(t *testing.T) *eksServiceFixture {
 	require.NoError(t, err)
 	// Tight Ready-gating knobs so nodegroup launches resolve in tests without the
 	// production 10m timeout; tests drive meta.NodeCount to simulate the reconciler.
-	svc.nodegroupReadyTimeout = 1 * time.Second
+	svc.nodegroupReadyTimeout = 50 * time.Millisecond
 	svc.nodegroupReadyPoll = 2 * time.Millisecond
 	// Tight worker-launch-retry knobs so a launch-failure retry test resolves
 	// quickly instead of against the production 5m/10s budget.
-	svc.workerLaunchRetryTimeout = 100 * time.Millisecond
+	svc.workerLaunchRetryTimeout = 30 * time.Millisecond
 	svc.workerLaunchRetryBackoff = 20 * time.Millisecond
 	// Tight boot-scan re-scan backoff so the eventually-consistent JetStream
 	// enumeration settles fast in tests instead of the production 100ms.
@@ -163,7 +163,7 @@ func newDeleteClusterFixture(t *testing.T, clusterName string) *deleteClusterFix
 // SG failure as the sole cause.
 func TestDeleteCluster_LeakedSGKeepsClusterDeleting(t *testing.T) {
 	origBudget, origInterval := sgDeleteWaitBudget, sgDeleteWaitInterval
-	sgDeleteWaitBudget, sgDeleteWaitInterval = 50*time.Millisecond, time.Millisecond
+	sgDeleteWaitBudget, sgDeleteWaitInterval = 10*time.Millisecond, time.Millisecond
 	defer func() { sgDeleteWaitBudget, sgDeleteWaitInterval = origBudget, origInterval }()
 
 	f := newDeleteClusterFixture(t, "alpha")

--- a/spinifex/handlers/eks/security_groups_test.go
+++ b/spinifex/handlers/eks/security_groups_test.go
@@ -328,7 +328,7 @@ func TestDeleteClusterSGs_FirstErrorSurfacedSweepContinues(t *testing.T) {
 // cluster SG pins the customer VPC.
 func TestDeleteClusterSGs_RetriesDependencyViolation(t *testing.T) {
 	origBudget, origInterval := sgDeleteWaitBudget, sgDeleteWaitInterval
-	sgDeleteWaitBudget, sgDeleteWaitInterval = 200*time.Millisecond, time.Millisecond
+	sgDeleteWaitBudget, sgDeleteWaitInterval = 20*time.Millisecond, time.Millisecond
 	defer func() { sgDeleteWaitBudget, sgDeleteWaitInterval = origBudget, origInterval }()
 
 	t.Run("transient then succeeds", func(t *testing.T) {

--- a/spinifex/handlers/rds/lifecycle_test.go
+++ b/spinifex/handlers/rds/lifecycle_test.go
@@ -23,7 +23,7 @@ import (
 
 // The wait for a stopping VM, shrunk so a stop that never lands is bounded in
 // milliseconds rather than in the minute a real one is given.
-const testVMStopTimeout = 400 * time.Millisecond
+const testVMStopTimeout = 40 * time.Millisecond
 
 // fakeInstanceCommander records the power commands the lifecycle ops issue, and
 // can refuse them the way a node that no longer holds the VM does.

--- a/spinifex/services/predastore/predastore_integration_test.go
+++ b/spinifex/services/predastore/predastore_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -233,8 +232,6 @@ func TestIntegration_FileUpload_PublicBucket2(t *testing.T) {
 
 	client := createS3Client(fixture, validAccessKey, validSecretKey)
 
-	time.Sleep(1 * time.Second)
-
 	// Upload test file
 	key := "test1.txt"
 	expectedContent := "hello-world-test-1-" + publicBucket
@@ -258,8 +255,6 @@ func TestIntegration_FileUpload_PublicBucket2(t *testing.T) {
 	if !assert.NotNil(t, result, "Result should not be nil") {
 		return
 	}
-
-	time.Sleep(1 * time.Second)
 
 	defer result.Body.Close()
 	downloadedContent, err := io.ReadAll(result.Body)

--- a/spinifex/services/viperblockd/viperblockd_integration_test.go
+++ b/spinifex/services/viperblockd/viperblockd_integration_test.go
@@ -65,7 +65,7 @@ func setupTestConfig(t *testing.T, natsURL string) *Config {
 
 	cfg := &Config{
 		NatsHost:       natsURL,
-		S3Host:         "https://s3.mock.local",
+		S3Host:         "http://127.0.0.1:1",
 		Bucket:         "test-bucket",
 		Region:         "us-east-1",
 		AccessKey:      "test-access-key",

--- a/spinifex/services/viperblockd/viperblockd_test.go
+++ b/spinifex/services/viperblockd/viperblockd_test.go
@@ -384,8 +384,10 @@ func TestServiceStartWithoutNATS(t *testing.T) {
 		t.Skip("Skipping integration test")
 	}
 
+	// Port 1 is never listening, so the dial is refused immediately rather than
+	// racing a NATS server that may be running on the default port.
 	cfg := &Config{
-		NatsHost: "nats://localhost:4222",
+		NatsHost: "nats://127.0.0.1:1",
 		BaseDir:  "/tmp/viperblock-test",
 	}
 
@@ -404,7 +406,7 @@ func TestServiceStartWithoutNATS(t *testing.T) {
 	case err := <-errChan:
 		// Expected to fail without NATS server
 		assert.Error(t, err)
-	case <-time.After(2 * time.Second):
+	case <-time.After(200 * time.Millisecond):
 		// Timeout is also acceptable
 		t.Log("Start() timed out as expected without NATS server")
 	}


### PR DESCRIPTION
Six test suites spent most of their wall clock parked on timers rather than doing work. CPU profiling put daemon at 7.2s of samples across 29s, eks at 2.4s CPU in 10.6s real, and dns at ~96% sleeping.

These are **test-only** changes. No production timeout, retry budget or interval is touched.

## Measured results

`go test -count=1`, same machine:

| Package | Before | After |
|---|---|---|
| daemon | 28.1s | **18.4s** |
| dns | 13.3s | **4.7s** |
| eks | 11.4s | **7.5s** |
| rds | 11.9s | **6.3s** |
| predastore | 15.0s | **13.6s** |
| viperblockd | 23.8s | no change above noise |

Roughly **104s to 74s** across the six.

viperblockd swings 18.9–25.4s run to run, so its two fixes are not separable from variance at package level. The targeted mount test does improve 2.8s to 2.0s.

## What changed

- **daemon** — `TestShutdownRequestTarget` issued five NATS requests with a 2s timeout that are *expected* to expire, costing 10.1s to prove a negative. The handler drops a misaddressed message synchronously, so 100ms is ample over loopback.
- **eks** — the shared fixture left `nodegroupReadyTimeout` at 1s against a 2ms poll; two tests exist precisely to watch it expire. Now 50ms. Same for the SG delete-wait budgets against their 1ms intervals. Five reconciler tests used 200–300ms context windows as the loop bound where the state settles in 2–3 ticks; 50ms still gives five ticks at the 10ms reconcile interval.
- **rds** — `testVMStopTimeout` 400ms to 40ms. The derived interval stays at `timeout/4`, so the assertions that poll count > 1 still hold.
- **predastore** — two `time.Sleep(1s)` calls at no synchronisation point (one before a `PutObject`, one between a `GetObject` and reading its body). The near-duplicate `PublicBucket` test covers the same bucket and key without them in 0.01s.
- **dns** — `t.Parallel()` on the three S3-failure tests. Each owns its `httptest` server and `t.TempDir()` and touches no package state. Deliberately *not* applied to the zonelock tests, which mutate package-level vars.
- **viperblockd** — the no-NATS test pointed at `localhost:4222`, so it raced any real NATS on the default port; now a closed port, which makes the error branch deterministic. The integration S3 host moves from an unresolvable name to a closed port.

## Not addressed here

The larger costs are all in production code and want their own beads:

1. **predastore shutdown hangs ~10s per meta replica.** `meta.Server.Run` calls `srv.Run(ctx)` before `s.shutdown()`, but `shutdown()` closes the raft transport that would let `srv.Run` return. Replicas re-campaign until raft's 10s transport timeout expires. This is a real `s3d` defect — 9.9s of the suite is teardown after the last test passes.
2. **dns burns up to 6s per DNS label during an S3 outage.** `newS3Client` never sets a `Retryer`, and `HostsZone` — on ACM's cert-request path — walks parent labels with `context.TODO()` and no deadline.
3. **eks pays ≥1s of dead wait per control-plane placement.** `hostFanoutTimeout` is a const and `fanout` drains to its deadline with no early exit.
4. **viperblock retries non-retryable errors.** The retryable flag is `!errors.Is(err, os.ErrNotExist)`, so HTTP 400 retries 5× per layer across three nested layers.

Separately, `jetstream_test.go` has an order dependency — a test asserting a shared bucket is empty passes only because an earlier test recreates it first (reproduced 3/3). That needs fixing before daemon can be parallelised, which is where the remaining large win is.

`make preflight` passes.