### PR TITLE
fix: stop re-driving a public IP release that can never converge

### DIFF
--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -12,7 +12,9 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/gpu"
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/mulgadc/spinifex/spinifex/otelsetup"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -754,6 +756,18 @@ func (a *instanceCleanerAdapter) ReleasePublicIP(instance *vm.VM) error {
 	utils.PublishNATEvent(a.d.natsConn, "vpc.delete-nat", vpcId, instance.PublicIP, logicalIP, portName, "")
 
 	if err := a.d.externalIPAM.ReleaseIP(context.Background(), instance.PublicIPPool, instance.PublicIP, instance.ENIId); err != nil {
+		// An untracked lease is terminal: the local pool slot is already free and
+		// no retry can make a deleted lease reappear. Returning the error leaves
+		// this dependent permanently not-done, so the teardown reaper re-drives it
+		// every sweep and its KV write keeps refreshing the record's TTL. Record
+		// the strand and report success so teardown completes.
+		if errors.Is(err, dhcp.ErrLeaseNotTracked) {
+			otelsetup.RecordResourceLeak(context.Background(), "public_ip")
+			slog.Error("Public IP lease stranded; address will not be reclaimed automatically",
+				"ip", instance.PublicIP, "pool", instance.PublicIPPool,
+				"instanceId", instance.ID, "err", err)
+			return nil
+		}
 		slog.Warn("Failed to release public IP on termination",
 			"ip", instance.PublicIP, "pool", instance.PublicIPPool, "err", err)
 		return err

--- a/spinifex/network/external/dhcp/errors.go
+++ b/spinifex/network/external/dhcp/errors.go
@@ -1,0 +1,16 @@
+package dhcp
+
+import "errors"
+
+// ReleaseCodeLeaseNotTracked is the releaseWireReply.Code for a release whose
+// IP has no lease in the store. It travels on the wire so callers can branch on
+// the condition without matching the human-readable error text.
+const ReleaseCodeLeaseNotTracked = "lease_not_tracked"
+
+// ErrLeaseNotTracked reports that a release named an IP the lease store does not
+// hold, so nothing was sent upstream and the upstream lease may be stranded.
+//
+// Terminal, not transient: no retry can make a deleted lease reappear. Callers
+// driving a teardown must stop rather than re-drive, and should record the
+// address as leaked.
+var ErrLeaseNotTracked = errors.New("dhcp: no tracked lease for ip; upstream lease may be stranded")

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -560,10 +560,12 @@ func (m *Manager) handleReleaseMsg(msg *nats.Msg) {
 		case errors.Is(err, jetstream.ErrKeyNotFound):
 			// Answering SUCCESS here told the caller the address was freed when
 			// nothing went on the wire, so the upstream lease sat stranded and
-			// silent. Callers log-and-continue on a release error, so failing
-			// loudly surfaces the strand without wedging teardown.
+			// silent. The code marks it terminal so a teardown caller stops and
+			// records the strand instead of re-driving a release that can never
+			// converge.
 			slog.Warn("dhcp manager: release for untracked IP; nothing sent upstream", "pool", req.PoolName, "ip", req.IP)
-			respondReleaseErr(msg, fmt.Sprintf("no tracked lease for ip %s in pool %q; upstream lease may be stranded", req.IP, req.PoolName))
+			respondReleaseErrCode(msg, ReleaseCodeLeaseNotTracked,
+				fmt.Sprintf("no tracked lease for ip %s in pool %q; upstream lease may be stranded", req.IP, req.PoolName))
 			return
 		default:
 			respondReleaseErr(msg, fmt.Sprintf("lookup release ip: %v", err))
@@ -800,7 +802,13 @@ func respondAcquireErr(msg *nats.Msg, errMsg string) {
 }
 
 func respondReleaseErr(msg *nats.Msg, errMsg string) {
-	body, err := json.Marshal(releaseWireReply{Error: errMsg})
+	respondReleaseErrCode(msg, "", errMsg)
+}
+
+// respondReleaseErrCode answers with a machine-readable code alongside the
+// message. code may be empty for failures the caller cannot act on specifically.
+func respondReleaseErrCode(msg *nats.Msg, code, errMsg string) {
+	body, err := json.Marshal(releaseWireReply{Error: errMsg, Code: code})
 	if err != nil {
 		slog.Warn("dhcp manager: encode release error reply failed", "err", err)
 		return

--- a/spinifex/network/external/dhcp/nats_client.go
+++ b/spinifex/network/external/dhcp/nats_client.go
@@ -128,6 +128,11 @@ func (c *NATSClient) requestRelease(ctx context.Context, req releaseWireRequest)
 	if err := json.Unmarshal(msg.Data, &reply); err != nil {
 		return fmt.Errorf("decode release reply: %w", err)
 	}
+	// Wrapped rather than replaced so callers can branch with errors.Is while
+	// the message keeps the pool and address the responder named.
+	if reply.Code == ReleaseCodeLeaseNotTracked {
+		return fmt.Errorf("%w: %s", ErrLeaseNotTracked, reply.Error)
+	}
 	if reply.Error != "" {
 		return errors.New(reply.Error)
 	}

--- a/spinifex/network/external/dhcp/pool_allocator_test.go
+++ b/spinifex/network/external/dhcp/pool_allocator_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/network/external"
 	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,8 +110,10 @@ func TestDHCPPoolAllocatorRejectsPoolMismatch(t *testing.T) {
 }
 
 // An untracked IP must not report success. Answering SUCCESS with nothing sent
-// upstream is what let stranded leases accumulate unnoticed; every caller of
-// Release logs and continues, so surfacing the error costs no teardown progress.
+// upstream is what let stranded leases accumulate unnoticed. It surfaces as
+// ErrLeaseNotTracked so a teardown caller can tell this terminal condition from
+// a transient failure and stop, rather than re-driving a release that can never
+// converge.
 func TestDHCPPoolAllocatorReleaseUnknownIPErrors(t *testing.T) {
 	fake := dhcp.NewFake()
 	pool := external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
@@ -118,6 +122,27 @@ func TestDHCPPoolAllocatorReleaseUnknownIPErrors(t *testing.T) {
 	addr := netip.MustParseAddr("198.51.100.99")
 	err := allocator.Release(context.Background(), "wan", addr, "")
 	require.Error(t, err)
+	assert.ErrorIs(t, err, dhcp.ErrLeaseNotTracked)
 	assert.Contains(t, err.Error(), "no tracked lease for ip 198.51.100.99")
 	assert.Equal(t, 0, fake.ReleaseCount())
+}
+
+// The counterpart that keeps the fix honest: a release failing for any other
+// reason must NOT carry ErrLeaseNotTracked, or callers would treat a transient
+// failure as terminal and abandon a lease that was still reclaimable. Driven
+// through a stub responder because the manager tolerates an upstream release
+// failure and still answers success.
+func TestDHCPPoolAllocatorReleaseUncodedErrorIsNotTerminal(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	sub, err := nc.Subscribe(dhcp.TopicRelease, func(msg *nats.Msg) {
+		_ = msg.Respond([]byte(`{"error":"upstream unreachable"}`))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	client := dhcp.NewNATSClient(nc, 3*time.Second)
+	err = client.RequestReleaseByIP(context.Background(), "wan", "198.51.100.99")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, dhcp.ErrLeaseNotTracked)
+	assert.Contains(t, err.Error(), "upstream unreachable")
 }

--- a/spinifex/network/external/dhcp/wire.go
+++ b/spinifex/network/external/dhcp/wire.go
@@ -113,8 +113,12 @@ type releaseWireRequest struct {
 	IP       string `json:"ip,omitempty"`
 }
 
+// Code is machine-readable and lets callers branch on a condition without
+// matching the human-readable Error text. A responder that predates Code omits
+// it, which degrades to a plain error rather than misreporting one.
 type releaseWireReply struct {
 	Error string `json:"error,omitempty"`
+	Code  string `json:"code,omitempty"`
 }
 
 // drainWireReply reports how many leases the responding vpcd released. The

--- a/spinifex/otelsetup/metrics.go
+++ b/spinifex/otelsetup/metrics.go
@@ -14,10 +14,18 @@ import (
 // stay low-cardinality: resolved action names only, never resource IDs.
 const actionAttrKey = "rpc.method"
 
+// leakKindAttrKey names the class of resource that could not be reclaimed.
+// Values must stay low-cardinality: resource classes only, never addresses or
+// IDs — those belong in the accompanying log line.
+const leakKindAttrKey = "resource.kind"
+
 var (
 	instrumentsOnce sync.Once
 	requestCounter  metric.Int64Counter
 	requestDuration metric.Float64Histogram
+
+	leakOnce    sync.Once
+	leakCounter metric.Int64Counter
 )
 
 // requestInstruments lazily creates the shared request instruments. The
@@ -57,6 +65,25 @@ func RecordRequest(ctx context.Context, action, outcome string, elapsed time.Dur
 	}
 	if duration != nil {
 		duration.Record(ctx, elapsed.Seconds(), opt)
+	}
+}
+
+// RecordResourceLeak counts one resource that teardown could not reclaim and
+// will not retry. kind is a resource class such as "public_ip"; the identity of
+// the specific resource goes in the caller's log line, not here.
+func RecordResourceLeak(ctx context.Context, kind string) {
+	leakOnce.Do(func() {
+		var err error
+		leakCounter, err = otel.Meter(httpTracerName).Int64Counter("mulga.resource.leaked",
+			metric.WithDescription("Count of resources teardown abandoned without reclaiming."),
+			metric.WithUnit("{resource}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+	})
+	if leakCounter != nil {
+		leakCounter.Add(ctx, 1, metric.WithAttributeSet(
+			attribute.NewSet(attribute.String(leakKindAttrKey, kind))))
 	}
 }
 


### PR DESCRIPTION
Closes `mulga-vp1cb`.

## Problem

When the DHCP manager holds no tracked lease for an address, the release
responder answered with a generic error. The teardown reaper treats any release
error as retryable, so it re-drove the same release every two minutes, forever,
with no backoff — for an address that can never be reclaimed by that path. The
strand itself was invisible: nothing recorded that an address had leaked.

## Change

The untracked case is now a distinct, machine-readable outcome rather than a
generic failure:

- `dhcp.ErrLeaseNotTracked` plus a `Code` field on the release reply, so the
  condition survives the NATS request/reply boundary and callers can branch on
  it with `errors.Is` while the message keeps the pool and address the
  responder named.
- `ReleasePublicIP` treats that specific error as terminal: it logs the strand
  at error level with the address, pool and instance, records a
  `mulga.resource.leaked` counter point, and returns nil so the reaper stops
  retrying.
- Every other release error stays retryable, unchanged.

The new counter means a stranded address is now countable in the sink rather
than only inferable from a log line.

## Testing

`make preflight` green. The existing untracked-lease test now also asserts
`errors.Is(err, dhcp.ErrLeaseNotTracked)`, and a new test drives a stub NATS
responder returning an uncoded error to pin that ordinary transient failures
remain retryable.

Note: roughly 16 already-stranded addresses predate this change and are not
reclaimed by it.