### PR TITLE
docs: repoint the network invariants doc comment at the proposal path

### DIFF
--- a/spinifex/network/invariants/doc.go
+++ b/spinifex/network/invariants/doc.go
@@ -1,6 +1,6 @@
 // Package invariants holds executable tests that pin the spinifex network
 // layer tree to the safety and liveness invariants declared in ADR-0006
-// (docs/development/proposals/az-local-architecture/0006-spinifex-network-layer-contract.md).
+// (docs/adr/0006-spinifex-network-layer-contract.md).
 //
 // Each test name encodes its governing ADR clause ID (TestS1_…, TestS4_…,
 // TestL1_…). On failure the test quotes the ADR clause verbatim so the fix

--- a/spinifex/network/invariants/doc.go
+++ b/spinifex/network/invariants/doc.go
@@ -1,6 +1,6 @@
 // Package invariants holds executable tests that pin the spinifex network
 // layer tree to the safety and liveness invariants declared in ADR-0006
-// (docs/adr/0006-spinifex-network-layer-contract.md).
+// (docs/development/proposals/region-local-architecture/0006-spinifex-network-layer-contract.md).
 //
 // Each test name encodes its governing ADR clause ID (TestS1_…, TestS4_…,
 // TestL1_…). On failure the test quotes the ADR clause verbatim so the fix


### PR DESCRIPTION
One line. `spinifex/network/invariants/doc.go` cited ADR-0006 at
`docs/development/proposals/az-local-architecture/`, which no longer exists —
the set lives at `docs/development/proposals/region-local-architecture/`.

No clause IDs are renumbered and no test changes: the invariants suite still
pins S1–S9 exactly as it did, this only fixes where a reader is sent to find
the wording.