### PR TITLE
fix: authenticate ECS ECR pulls from the co-located gateway registry

### DIFF
--- a/cmd/ecs-agent/ecrresolver.go
+++ b/cmd/ecs-agent/ecrresolver.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -60,12 +61,25 @@ func (e *ecrResolver) client() (*http.Client, error) {
 	return c, nil
 }
 
-// isECRRef reports whether ref targets an ECR registry, i.e. its registry host
-// is "<acct>.dkr.ecr.<region>.<domain>". Only ECR pulls need a minted token;
-// public registries (docker.io and friends) pull anonymously, so refs without
-// an ECR host must not drag in IMDS host credentials.
-func isECRRef(ref string) bool {
+// gatewayRegistryHost returns the host[:port] of the co-located ECR registry
+// from the gateway URL; empty/unparseable yields "" (matches no ref). The
+// registry shares the gateway listener, so its port is the gateway port.
+func gatewayRegistryHost(gatewayURL string) string {
+	u, err := url.Parse(gatewayURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// isECRRef reports whether ref targets an ECR registry: an "<acct>.dkr.ecr."
+// host, or one equal to gatewayHost (the agent's own co-located registry
+// advertised as a bare host/IP). Other refs pull anonymously, no token.
+func isECRRef(ref, gatewayHost string) bool {
 	host, _, _ := strings.Cut(ref, "/")
+	if gatewayHost != "" && host == gatewayHost {
+		return true
+	}
 	if !strings.Contains(host, ".") && !strings.Contains(host, ":") {
 		return false // no registry host -> docker.io default
 	}
@@ -75,7 +89,7 @@ func isECRRef(ref string) bool {
 // Authorize returns the ECR token's user/password and proxy endpoint for ref.
 // Non-ECR refs resolve to anonymous pull (empty credentials).
 func (e *ecrResolver) Authorize(ctx context.Context, ref string) (user, pass, endpoint string, err error) {
-	if !isECRRef(ref) {
+	if !isECRRef(ref, gatewayRegistryHost(e.gatewayURL)) {
 		return "", "", "", nil
 	}
 	c, err := e.creds.Retrieve(ctx)

--- a/cmd/ecs-agent/ecrresolver_test.go
+++ b/cmd/ecs-agent/ecrresolver_test.go
@@ -115,17 +115,44 @@ func TestECRResolver_NonECRAnonymous(t *testing.T) {
 }
 
 func TestIsECRRef(t *testing.T) {
-	cases := map[string]bool{
-		"nginx:alpine":            false,
-		"docker.io/library/nginx": false,
-		"ghcr.io/org/app:1":       false,
-		"registry:5000/app:1":     false,
-		"123456789012.dkr.ecr.us-east-1.spinifex.internal/app:1": true,
-		"123456789012.dkr.ecr.ap-southeast-2.amazonaws.com/x":    true,
+	cases := []struct {
+		ref, gatewayHost string
+		want             bool
+	}{
+		{"nginx:alpine", "192.168.1.13:9999", false},
+		{"docker.io/library/nginx", "192.168.1.13:9999", false},
+		{"ghcr.io/org/app:1", "192.168.1.13:9999", false},
+		{"registry:5000/app:1", "192.168.1.13:9999", false},
+		{"123456789012.dkr.ecr.us-east-1.spinifex.internal/app:1", "192.168.1.13:9999", true},
+		{"123456789012.dkr.ecr.ap-southeast-2.amazonaws.com/x", "192.168.1.13:9999", true},
+		// Co-located gateway registry advertised as a bare host/IP.
+		{"192.168.1.13:9999/bunyip:latest", "192.168.1.13:9999", true},
+		{"192.168.1.13:9999/bunyip:latest", "", false},
 	}
-	for ref, want := range cases {
-		if got := isECRRef(ref); got != want {
-			t.Errorf("isECRRef(%q) = %v, want %v", ref, got, want)
+	for _, c := range cases {
+		if got := isECRRef(c.ref, c.gatewayHost); got != c.want {
+			t.Errorf("isECRRef(%q, %q) = %v, want %v", c.ref, c.gatewayHost, got, c.want)
 		}
+	}
+}
+
+// TestECRResolver_Authorize_BareHostGateway asserts that a ref whose host
+// equals the agent's own gateway host authenticates via the co-located ECR
+// registry, even though it lacks a ".dkr.ecr." name.
+func TestECRResolver_Authorize_BareHostGateway(t *testing.T) {
+	srv := gatewayStub(t, "AWS:jwt", "https://192.168.1.13:9999", http.StatusOK)
+	creds := stubCreds{c: credentials.Credentials{
+		AccessKeyID: "AKIA", SecretAccessKey: "secret", SessionToken: "sess",
+		Expiration: time.Now().Add(time.Hour),
+	}}
+	r := newECRResolver(creds, "us-east-1", srv.URL, trusting(srv))
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+	user, pass, _, err := r.Authorize(context.Background(), host+"/bunyip:latest")
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if user != "AWS" || pass != "jwt" {
+		t.Errorf("got %q:%q, want AWS:jwt", user, pass)
 	}
 }

--- a/spinifex/handlers/ecs/instancerole.go
+++ b/spinifex/handlers/ecs/instancerole.go
@@ -21,9 +21,10 @@ const (
 	// whitelists; it must match exactly for IMDS role-cred vending to admit it.
 	ecsAssumeRolePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
 
-	// ecsInstanceRolePolicyDoc grants the container-instance agent the ECS
-	// control-plane actions the gateway enforces for assumed-role principals.
-	ecsInstanceRolePolicyDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ecs:*","Resource":"*"}]}`
+	// ecsInstanceRolePolicyDoc grants the agent the ECS control-plane actions the
+	// gateway enforces for assumed-role principals, plus ECR read so it can pull
+	// task images via the instance role when a task carries no execution role.
+	ecsInstanceRolePolicyDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ecs:*","Resource":"*"},{"Effect":"Allow","Action":["ecr:GetAuthorizationToken","ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Resource":"*"}]}`
 )
 
 // ensureECSInstanceProfile find-or-creates the ecsInstanceRole, its ecs:* policy


### PR DESCRIPTION
Closes `mulga-u0c7z` (P1). Plan:
`docs/development/bugs/ecs-agent-ecr-gateway-host-auth.md` in mulga.

## Problem

The ecs-agent pulled images from Ochre ECR **anonymously** whenever the gateway
advertised its registry as a bare host/IP rather than a
`<acct>.dkr.ecr.<region>.<suffix>` parity name. `isECRRef` classified a ref as
ECR only when its host contained `.dkr.ecr.`, so a bare-host ref short-circuited
to anonymous before any role or `pullResolver` logic ran. The registry requires
a SigV4 token, so the pull got `401 Unauthorized` and the task never left
PENDING.

That bare-host form is the DNS-free edge default, so on a DNS-less single node
no ECS task could pull from Ochre ECR at all.

## Change

Recognise the agent's own configured gateway registry host as ECR, in addition
to the existing heuristic. The resolver already carries `gatewayURL` and the
co-located registry is served on that same host:port, so the match is against
whatever host the gateway advertises — not a per-cluster special case.

Public registries never equal the gateway host, so docker.io, ghcr.io and
public.ecr.aws stay anonymous; `.dkr.ecr.` refs are untouched.

Second half, found during live verification: with the ref classified correctly
the pull then failed authenticated with `GetAuthorizationToken:
AccessDeniedException`. The system `ecsInstanceRole` granted `ecs:*` and no ECR
actions, but the pull path falls back to the instance role when a task has no
execution role. `ecsInstanceRolePolicyDoc` now carries the four ECR read
actions, mirroring AWS's `AmazonEC2ContainerServiceforEC2Role`.

**Existing clusters are not reconciled** — `ensureECSRolePolicy` never versions
an existing policy, so only new clusters pick this up. Tracked as `mulga-8f7dv`.

## Assumption

The co-located registry is served on the gateway listener, so registry port
equals gateway port and the match is exact host:port. A future config that
splits the registry onto its own port would need the agent to key off that port
instead; noted in the code.

## Testing

`go test ./cmd/ecs-agent/... ./spinifex/handlers/ecs/...` green.

Live on wattle (tenant `000000000002`, cluster `bunyip`): rebuilt the ecs-node
AMI with the agent fix, re-provisioned and registered. The pull error moved from
anonymous-401 to authenticated-403, confirming the `isECRRef` fix; attaching the
four ECR read actions then took the task to RUNNING with the ELB target HEALTHY.
The ALB front door is still not serving, which is the unrelated lb-agent
data-plane stall `mulga-2u6uo`.