### PR TITLE
feat: name vpcd and spinifex-ui request actions, split client errors from server errors

### DIFF
--- a/spinifex/handlers/imds/action.go
+++ b/spinifex/handlers/imds/action.go
@@ -1,0 +1,112 @@
+package handlers_imds
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/otelsetup"
+)
+
+// actionOther is the catch-all action name. A guest controls the request path,
+// so every unrecognised path must collapse to one value or a crawl of invented
+// paths would inflate the metric dimension without bound.
+const actionOther = "imds.other"
+
+// actionRejectedForwarded names an SSRF probe turned away by rejectForwarded,
+// which answers before nameAction runs.
+const actionRejectedForwarded = "imds.rejected.forwarded"
+
+// metaDataActions names the metadata keys dispatch serves, keyed by the path
+// suffix after prefixMetaData. Trailing slashes are trimmed before lookup, so
+// only the bare form appears here.
+var metaDataActions = map[string]string{
+	"":                            "imds.meta-data.root",
+	"instance-id":                 "imds.meta-data.instance-id",
+	"instance-life-cycle":         "imds.meta-data.instance-life-cycle",
+	"instance-type":               "imds.meta-data.instance-type",
+	"ami-id":                      "imds.meta-data.ami-id",
+	"ami-launch-index":            "imds.meta-data.ami-launch-index",
+	"reservation-id":              "imds.meta-data.reservation-id",
+	"local-ipv4":                  "imds.meta-data.local-ipv4",
+	"public-ipv4":                 "imds.meta-data.public-ipv4",
+	"public-hostname":             "imds.meta-data.public-hostname",
+	"hostname":                    "imds.meta-data.hostname",
+	"local-hostname":              "imds.meta-data.local-hostname",
+	"mac":                         "imds.meta-data.mac",
+	"security-groups":             "imds.meta-data.security-groups",
+	"network":                     "imds.meta-data.network",
+	"network/interfaces":          "imds.meta-data.network.interfaces",
+	"network/interfaces/macs":     "imds.meta-data.network.interfaces.macs",
+	"placement":                   "imds.meta-data.placement",
+	"placement/availability-zone": "imds.meta-data.placement.availability-zone",
+	"placement/region":            "imds.meta-data.placement.region",
+	"services":                    "imds.meta-data.services",
+	"services/domain":             "imds.meta-data.services.domain",
+	"services/partition":          "imds.meta-data.services.partition",
+	"iam":                         "imds.meta-data.iam",
+	"iam/info":                    "imds.meta-data.iam.info",
+}
+
+// imdsAction maps a request to a bounded action name for request metrics. The
+// role name, the MAC and the public-key index are stripped: they identify a
+// resource and would turn one action into one series per guest.
+func imdsAction(method, path string) string {
+	if method == http.MethodPut && path == pathToken {
+		return "imds.api.token"
+	}
+	switch path {
+	case pathToken:
+		return "imds.api.token"
+	case pathSpinifexCACert:
+		return "imds.spinifex.ca-cert"
+	case pathUserData:
+		return "imds.user-data"
+	case pathIdentityDocument:
+		return "imds.dynamic.instance-identity.document"
+	case "/":
+		return "imds.versions"
+	}
+
+	trimmed := strings.TrimSuffix(path, "/")
+	switch trimmed {
+	case "/latest":
+		return "imds.latest"
+	case prefixDynamic:
+		return "imds.dynamic"
+	case pathIdentityDir:
+		return "imds.dynamic.instance-identity"
+	case pathSecurityCredsDir:
+		return "imds.iam.security-credentials.list"
+	case pathPublicKeysDir:
+		return "imds.public-keys"
+	}
+
+	if strings.HasPrefix(path, prefixSecurityCreds) {
+		if len(path) > len(prefixSecurityCreds) {
+			return "imds.iam.security-credentials.role"
+		}
+		return "imds.iam.security-credentials.list"
+	}
+	if strings.HasPrefix(path, prefixNetworkMacs) {
+		return "imds.meta-data.network.interfaces.macs"
+	}
+	if strings.HasPrefix(path, prefixPublicKeys) {
+		return "imds.public-keys"
+	}
+	if sub, ok := strings.CutPrefix(trimmed, pathMetaDataRoot); ok {
+		if action, known := metaDataActions[strings.TrimPrefix(sub, "/")]; known {
+			return action
+		}
+	}
+	return actionOther
+}
+
+// nameAction records the bounded action for the in-flight request so request
+// metrics carry the IMDS endpoint rather than the bare HTTP verb. It runs
+// inside normalizeVersion, so the path it reads is already canonical /latest.
+func nameAction(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otelsetup.SetRequestAction(r.Context(), imdsAction(r.Method, r.URL.Path))
+		next.ServeHTTP(w, r)
+	})
+}

--- a/spinifex/handlers/imds/action_test.go
+++ b/spinifex/handlers/imds/action_test.go
@@ -1,0 +1,71 @@
+package handlers_imds
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIMDSActionNamesKnownEndpoints(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		{name: "token issue", method: http.MethodPut, path: "/latest/api/token", want: "imds.api.token"},
+		{name: "token wrong method", method: http.MethodGet, path: "/latest/api/token", want: "imds.api.token"},
+		{name: "ca cert", method: http.MethodGet, path: "/spinifex/ca.pem", want: "imds.spinifex.ca-cert"},
+		{name: "user data", method: http.MethodGet, path: "/latest/user-data", want: "imds.user-data"},
+		{name: "version listing", method: http.MethodGet, path: "/", want: "imds.versions"},
+		{name: "latest listing", method: http.MethodGet, path: "/latest", want: "imds.latest"},
+		{name: "latest listing trailing slash", method: http.MethodGet, path: "/latest/", want: "imds.latest"},
+		{name: "identity document", method: http.MethodGet, path: "/latest/dynamic/instance-identity/document", want: "imds.dynamic.instance-identity.document"},
+		{name: "identity dir", method: http.MethodGet, path: "/latest/dynamic/instance-identity", want: "imds.dynamic.instance-identity"},
+		{name: "meta-data root", method: http.MethodGet, path: "/latest/meta-data", want: "imds.meta-data.root"},
+		{name: "meta-data root trailing slash", method: http.MethodGet, path: "/latest/meta-data/", want: "imds.meta-data.root"},
+		{name: "instance id", method: http.MethodGet, path: "/latest/meta-data/instance-id", want: "imds.meta-data.instance-id"},
+		{name: "availability zone", method: http.MethodGet, path: "/latest/meta-data/placement/availability-zone", want: "imds.meta-data.placement.availability-zone"},
+		{name: "iam info", method: http.MethodGet, path: "/latest/meta-data/iam/info", want: "imds.meta-data.iam.info"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := imdsAction(tc.method, tc.path); got != tc.want {
+				t.Errorf("imdsAction(%q, %q) = %q, want %q", tc.method, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIMDSActionStripsResourceIdentifiers is the cardinality guard: a guest
+// controls these path segments, so any of them reaching the metric dimension
+// would produce one series per role, per MAC or per invented path.
+func TestIMDSActionStripsResourceIdentifiers(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "role name stripped", path: "/latest/meta-data/iam/security-credentials/my-app-role", want: "imds.iam.security-credentials.role"},
+		{name: "other role same action", path: "/latest/meta-data/iam/security-credentials/another-role", want: "imds.iam.security-credentials.role"},
+		{name: "credentials listing", path: "/latest/meta-data/iam/security-credentials", want: "imds.iam.security-credentials.list"},
+		{name: "credentials listing trailing slash", path: "/latest/meta-data/iam/security-credentials/", want: "imds.iam.security-credentials.list"},
+		{name: "mac stripped", path: "/latest/meta-data/network/interfaces/macs/0a:1b:2c:3d:4e:5f/vpc-id", want: "imds.meta-data.network.interfaces.macs"},
+		{name: "other mac same action", path: "/latest/meta-data/network/interfaces/macs/aa:bb:cc:dd:ee:ff/subnet-id", want: "imds.meta-data.network.interfaces.macs"},
+		{name: "macs listing", path: "/latest/meta-data/network/interfaces/macs", want: "imds.meta-data.network.interfaces.macs"},
+		{name: "public key index stripped", path: "/latest/meta-data/public-keys/0/openssh-key", want: "imds.public-keys"},
+		{name: "public keys listing", path: "/latest/meta-data/public-keys", want: "imds.public-keys"},
+		{name: "unknown meta-data key", path: "/latest/meta-data/not-a-real-key", want: actionOther},
+		{name: "invented deep path", path: "/latest/meta-data/a/b/c/d/e", want: actionOther},
+		{name: "path outside the tree", path: "/etc/passwd", want: actionOther},
+		{name: "empty path", path: "", want: actionOther},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := imdsAction(http.MethodGet, tc.path); got != tc.want {
+				t.Errorf("imdsAction(GET, %q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/spinifex/handlers/imds/metadata.go
+++ b/spinifex/handlers/imds/metadata.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
+	"github.com/mulgadc/spinifex/spinifex/otelsetup"
 )
 
 const (
@@ -44,9 +45,12 @@ const (
 )
 
 // rejectForwarded enforces the IMDS SSRF defence: requests with X-Forwarded-For are 403'd.
+// It names its own rejections for request metrics because it answers before
+// nameAction runs, so an SSRF probe is countable rather than an unnamed 403.
 func rejectForwarded(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get(hdrForwardedFor) != "" {
+			otelsetup.SetRequestAction(r.Context(), actionRejectedForwarded)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}

--- a/spinifex/handlers/imds/service.go
+++ b/spinifex/handlers/imds/service.go
@@ -176,7 +176,7 @@ func (s *IMDSServiceImpl) httpHandler() http.Handler {
 	mux.HandleFunc(pathToken, s.handleToken)
 	mux.HandleFunc(pathSpinifexCACert, s.handleCACert)
 	mux.HandleFunc("/", s.handleMetadata)
-	return otelsetup.HTTPMiddleware("vpcd")(rejectForwarded(normalizeVersion(mux)))
+	return otelsetup.HTTPMiddleware("vpcd")(rejectForwarded(normalizeVersion(nameAction(mux))))
 }
 
 // Run starts the per-tap reconcile loop and the token-sweep ticker, then blocks

--- a/spinifex/otelsetup/http.go
+++ b/spinifex/otelsetup/http.go
@@ -46,6 +46,21 @@ func (w *statusRecorder) Flush() {
 	_ = http.NewResponseController(w.ResponseWriter).Flush()
 }
 
+// outcomeForStatus classifies a response for the outcome dimension. 4xx is
+// client_error rather than error so a service's error rate stays server-fault
+// only, while client rejections (an IMDS 401, an unresolvable ENI's 404) stop
+// being counted as successes.
+func outcomeForStatus(status int) string {
+	switch {
+	case status >= http.StatusInternalServerError:
+		return "error"
+	case status >= http.StatusBadRequest:
+		return "client_error"
+	default:
+		return "success"
+	}
+}
+
 // HTTPMiddleware opens a server span per request, honoring an inbound W3C
 // traceparent header, and records request count/duration metrics. Handlers
 // rename the span (and SetRequestAction) once they resolve a logical
@@ -59,11 +74,7 @@ func HTTPMiddleware(serverName string) func(http.Handler) http.Handler {
 				start := time.Now()
 				rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 				next.ServeHTTP(rec, r)
-				outcome := "success"
-				if rec.status >= http.StatusInternalServerError {
-					outcome = "error"
-				}
-				RecordRequest(r.Context(), r.Method+" /health", outcome, time.Since(start))
+				RecordRequest(r.Context(), r.Method+" /health", outcomeForStatus(rec.status), time.Since(start))
 				return
 			}
 			ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
@@ -83,12 +94,10 @@ func HTTPMiddleware(serverName string) func(http.Handler) http.Handler {
 			next.ServeHTTP(rec, r.WithContext(ctx))
 
 			span.SetAttributes(semconv.HTTPResponseStatusCode(rec.status))
-			outcome := "success"
 			if rec.status >= http.StatusInternalServerError {
 				span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", rec.status))
-				outcome = "error"
 			}
-			RecordRequest(ctx, action.name, outcome, time.Since(start))
+			RecordRequest(ctx, action.name, outcomeForStatus(rec.status), time.Since(start))
 		})
 	}
 }

--- a/spinifex/otelsetup/http_test.go
+++ b/spinifex/otelsetup/http_test.go
@@ -127,3 +127,49 @@ func TestHTTPMiddlewareExtractsTraceparent(t *testing.T) {
 		t.Errorf("parent span id = %s, want inbound span id", got)
 	}
 }
+
+// TestOutcomeForStatusSeparatesClientErrors guards the classification the
+// dashboards split on: 4xx must not be counted as success (which hid every
+// IMDS 401 and 404) and must not be folded into error, which is server fault.
+func TestOutcomeForStatusSeparatesClientErrors(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{status: http.StatusOK, want: "success"},
+		{status: http.StatusNoContent, want: "success"},
+		{status: http.StatusNotModified, want: "success"},
+		{status: http.StatusBadRequest, want: "client_error"},
+		{status: http.StatusUnauthorized, want: "client_error"},
+		{status: http.StatusForbidden, want: "client_error"},
+		{status: http.StatusNotFound, want: "client_error"},
+		{status: http.StatusInternalServerError, want: "error"},
+		{status: http.StatusBadGateway, want: "error"},
+	}
+
+	for _, tc := range tests {
+		if got := outcomeForStatus(tc.status); got != tc.want {
+			t.Errorf("outcomeForStatus(%d) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
+// TestHTTPMiddleware4xxIsNotSpanError pins the split between the two signals:
+// a client error is a distinct metric outcome but must not mark the span
+// failed, or every 404 would show as a broken request in the trace view.
+func TestHTTPMiddleware4xxIsNotSpanError(t *testing.T) {
+	sr := withRecorder(t)
+
+	h := HTTPMiddleware("test")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/latest/api/token", nil))
+
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if got := spans[0].Status().Code; got == codes.Error {
+		t.Errorf("span status = %v, want not Error for a 4xx", got)
+	}
+}

--- a/spinifex/services/spinifexui/spinifexui.go
+++ b/spinifex/services/spinifexui/spinifexui.go
@@ -49,6 +49,15 @@ type clusterConfig struct {
 	Region string `json:"region"`
 }
 
+// namedRoute labels a route's request metrics with a fixed action, so
+// rpc_method carries the endpoint rather than the bare HTTP verb.
+func namedRoute(action string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otelsetup.SetRequestAction(r.Context(), action)
+		next.ServeHTTP(w, r)
+	})
+}
+
 // clusterConfigHandler serves the facts the SPA needs before it can sign
 // anything. no-store keeps a caching proxy in front of several clusters from
 // serving one the other's region.
@@ -200,6 +209,9 @@ func (svc *Service) launchService() error {
 		file, err := contentFS.Open(path)
 		if err == nil {
 			_ = file.Close()
+			// Asset filenames are content-hashed, so the action names the branch
+			// rather than the path — one series per build otherwise.
+			otelsetup.SetRequestAction(r.Context(), "ui.static")
 			// Use no-cache to force revalidation; http.FileServer sets ETags
 			// so browsers will get 304 Not Modified when files haven't changed
 			w.Header().Set("Cache-Control", "no-cache")
@@ -208,6 +220,7 @@ func (svc *Service) launchService() error {
 		}
 
 		// File doesn't exist, serve index.html for SPA routing
+		otelsetup.SetRequestAction(r.Context(), "ui.spa")
 		w.Header().Set("Cache-Control", "no-cache")
 		indexContent, err := fs.ReadFile(contentFS, "index.html")
 		if err != nil {
@@ -223,11 +236,12 @@ func (svc *Service) launchService() error {
 	mux := http.NewServeMux()
 
 	// Reverse proxy routes — must be registered before the SPA catch-all.
-	mux.Handle("/proxy/awsgw/", newReverseProxy("localhost:9999", "/proxy/awsgw", proxyTransport))
-	mux.Handle("/proxy/s3/", newReverseProxy("localhost:8443", "/proxy/s3", proxyTransport))
+	mux.Handle("/proxy/awsgw/", namedRoute("ui.proxy.awsgw", newReverseProxy("localhost:9999", "/proxy/awsgw", proxyTransport)))
+	mux.Handle("/proxy/s3/", namedRoute("ui.proxy.s3", newReverseProxy("localhost:8443", "/proxy/s3", proxyTransport)))
 
 	// CA certificate download.
 	mux.HandleFunc("/api/ca.pem", func(w http.ResponseWriter, r *http.Request) {
+		otelsetup.SetRequestAction(r.Context(), "ui.api.ca-cert")
 		if _, err := os.Stat(caCertPath); err != nil {
 			if os.IsNotExist(err) {
 				slog.Warn("CA certificate requested but not found", "path", caCertPath)
@@ -243,7 +257,7 @@ func (svc *Service) launchService() error {
 		http.ServeFile(w, r, caCertPath)
 	})
 
-	mux.HandleFunc("/api/config", clusterConfigHandler(svc.Config.Region))
+	mux.Handle("/api/config", namedRoute("ui.api.config", clusterConfigHandler(svc.Config.Region)))
 
 	// SPA catch-all.
 	mux.Handle("/", spaHandler)


### PR DESCRIPTION
Parts B and C of `mulga-koc1w`. Plan:
`docs/development/improvements/request-metric-actions-and-outcomes.md`.
Part A (daemon NATS outcome) is split out to `mulga-ihx08`.

## Scope note

The bead was filed from a query scoped to one environment. Read fleet-wide over
24h, every service does emit `mulga.requests` — so "no request metrics for vpcd,
awsgw or spinifex-ui" was not the gap. Two narrower ones are:

## B — actions were bare HTTP verbs

vpcd and spinifex-ui never called `otelsetup.SetRequestAction`, so
`labels.rpc_method` stayed at the verb the middleware sets. Over 24h vpcd had
exactly two action values, `GET` (5,023) and `PUT` (5,023). IMDS was countable
in aggregate but `/latest/api/token` was indistinguishable from a credential
fetch at `/latest/meta-data/iam/security-credentials/<role>`. Guests depend on
IMDS for credentials, so a failure there is user-visible and was not
attributable.

Both namers map to a closed set with a single catch-all, because a guest
controls the request path and an unbounded name would put one metric series
behind every invented path. The role name, the interface MAC and the public-key
index are stripped for the same reason; spinifex-ui names the static and SPA
branches rather than the content-hashed asset filename.

`rejectForwarded` names its own 403s. It answers before the namer runs, and
leaving it first in the chain keeps the SSRF defence where it was rather than
reordering around it — so an SSRF probe is now countable instead of an unnamed
403.

## C — every 4xx counted as a success

The middleware set `outcome = "error"` only for 5xx. That is why vpcd and
spinifex-ui reported *zero* errors over 24h despite IMDS answering 401 for a
missing IMDSv2 token and 404 for an unresolvable ENI.

4xx now records `client_error`. `error` keeps meaning 5xx, so existing
error-rate panels are unchanged rather than silently redefined, and a 4xx still
does not mark the span failed — otherwise every 404 would read as a broken
request in the trace view.

## Testing

`make preflight` green. New tests cover the namer against every known path plus
hostile and invented ones (the cardinality guard), the status classification,
and that a 4xx leaves the span status unset.

Note: the new outcome and action values start new time series, so a 24h
comparison across the deploy will show a step.