### PR TITLE
feat: put the caller and the auth verdict on gateway request telemetry

### DIFF
--- a/spinifex/gateway/auth.go
+++ b/spinifex/gateway/auth.go
@@ -74,6 +74,11 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 				return
 			}
 
+			// The key a request presented, recorded before it is known to be valid:
+			// a rejected caller has to be identifiable, and this is the last point
+			// every rejection below still shares.
+			auditFrom(r.Context()).setAccessKeyID(sig.Credential.AccessKeyID)
+
 			// Reject unknown services before crypto; otherwise Verify re-signs with
 			// the client-claimed service name and rubber-stamps the scope.
 			if !supportedServices[sig.Credential.Service] {
@@ -154,6 +159,8 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 			ctx = context.WithValue(ctx, ctxRegion, sig.Credential.Region)
 			ctx = context.WithValue(ctx, ctxAccessKey, sig.Credential.AccessKeyID)
 			ctx = context.WithValue(ctx, ctxPrincipalType, principal.principalType)
+			auditFrom(ctx).setIdentity(sig.Credential.AccessKeyID, principal.accountID,
+				sig.Credential.Region, sig.Credential.Service, principal.principalType)
 			if principal.assumedRoleARN != "" {
 				ctx = context.WithValue(ctx, ctxAssumedRoleARN, principal.assumedRoleARN)
 			}
@@ -354,8 +361,11 @@ func (gw *GatewayConfig) resolveSessionAKID(r *http.Request, accessKeyID, client
 }
 
 // writeSigV4Error writes an EC2-compatible XML error response for auth failures.
+// Every auth rejection funnels through here, a rate-limit lockout included, so
+// this is the one place that has to record the verdict onto the request.
 func (gw *GatewayConfig) writeSigV4Error(w http.ResponseWriter, r *http.Request, errorCode string) {
 	requestID := uuid.NewString()
+	auditFrom(r.Context()).setAuthError(errorCode)
 
 	errorMsg, exists := awserrors.ErrorLookup[errorCode]
 	if !exists {

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -242,6 +242,7 @@ func (gw *GatewayConfig) SetupRoutes() http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(otelsetup.HTTPMiddleware("awsgw"))
+	r.Use(requestAuditMiddleware)
 
 	if !gw.DisableLogging {
 		r.Use(slogRequestLogger)
@@ -837,6 +838,7 @@ func recordResolvedAction(ctx context.Context, service, action string) {
 	span.SetName(name)
 	span.SetAttributes(attribute.String("aws.action", action))
 	otelsetup.SetRequestAction(ctx, name)
+	auditFrom(ctx).setAction(service, action)
 }
 
 // traceActionEnricher renames the server span to the resolved SigV4
@@ -862,12 +864,14 @@ func traceActionEnricher(next http.Handler) http.Handler {
 	})
 }
 
-// slogRequestLogger is a middleware that logs each request via slog.
+// slogRequestLogger is a middleware that logs each request via slog. The audit
+// record carries the caller and the auth verdict onto the same line, so a
+// failing request is answerable without joining it to a separate auth log.
 func slogRequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		slog.InfoContext(r.Context(), "request", "method", r.Method, "path", r.URL.Path, "status", ww.Status(), "duration", time.Since(start))
+		logRequest(r, ww.Status(), time.Since(start))
 	})
 }

--- a/spinifex/gateway/requestaudit.go
+++ b/spinifex/gateway/requestaudit.go
@@ -1,0 +1,175 @@
+package gateway
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
+)
+
+// ctxAudit carries the per-request audit record. It is a pointer, unlike every
+// other value in this file's sibling context keys, because the request logger
+// is the OUTERMOST middleware and a context derived downstream never propagates
+// back up to it. The record is the only way the logger sees who called.
+const ctxAudit contextKey = "gateway.audit"
+
+// requestAudit is what the gateway knows about a request by the time it answers
+// it: who called, what they asked for, and how it was decided. It holds an
+// access key id and an error code, never a secret key, a session token or an
+// Authorization header — nothing here may carry a credential.
+type requestAudit struct {
+	mu            sync.Mutex
+	clientIP      string
+	accessKeyID   string
+	accountID     string
+	region        string
+	service       string
+	action        string
+	principalType string
+	authError     string
+}
+
+// requestAuditMiddleware attaches an audit record to every request. It is
+// registered unconditionally: span enrichment must not depend on whether access
+// logging happens to be enabled.
+func requestAuditMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		audit := &requestAudit{clientIP: utils.ClientIP(r.RemoteAddr)}
+		ctx := context.WithValue(r.Context(), ctxAudit, audit)
+		next.ServeHTTP(w, r.WithContext(ctx))
+		audit.annotate(ctx)
+	})
+}
+
+// auditFrom returns the request's audit record, or nil when there is none. Every
+// method below is nil-safe, so a handler called directly by a test behaves
+// exactly as it did before this record existed.
+func auditFrom(ctx context.Context) *requestAudit {
+	audit, _ := ctx.Value(ctxAudit).(*requestAudit)
+	return audit
+}
+
+// setIdentity records the authenticated caller. Called once, where the auth
+// middleware already puts the same values into the context.
+func (a *requestAudit) setIdentity(accessKeyID, accountID, region, service, principalType string) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.accessKeyID = accessKeyID
+	a.accountID = accountID
+	a.region = region
+	a.service = service
+	a.principalType = principalType
+}
+
+// setAction records the resolved AWS action. Query-protocol services resolve it
+// before dispatch, REST-JSON services once their dispatcher has run.
+func (a *requestAudit) setAction(service, action string) {
+	if a == nil || action == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.action = action
+	if service != "" {
+		a.service = service
+	}
+}
+
+// setAuthError records the AWS error code a request was rejected with. Every
+// auth rejection funnels through writeSigV4Error, including a rate-limit
+// lockout, so recording it there covers all of them.
+func (a *requestAudit) setAuthError(errorCode string) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.authError = errorCode
+}
+
+// setAccessKeyID records the key a request presented even when authentication
+// failed, so a rejected caller is still identifiable.
+func (a *requestAudit) setAccessKeyID(accessKeyID string) {
+	if a == nil || accessKeyID == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.accessKeyID = accessKeyID
+}
+
+// fields returns the non-empty audit values as alternating key/value pairs for
+// slog. Empty values are omitted rather than logged blank, so an unauthenticated
+// request does not carry a row of empty identity fields.
+func (a *requestAudit) fields() []any {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var out []any
+	for _, kv := range a.pairs() {
+		if kv.value != "" {
+			out = append(out, kv.key, kv.value)
+		}
+	}
+	return out
+}
+
+// annotate copies the audit values onto the server span, so a trace search for
+// failing requests answers from where, doing what and rejected why without
+// having to join against the log stream.
+func (a *requestAudit) annotate(ctx context.Context) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	for _, kv := range a.pairs() {
+		if kv.value != "" {
+			span.SetAttributes(attribute.String(kv.spanKey, kv.value))
+		}
+	}
+}
+
+type auditField struct {
+	key     string
+	spanKey string
+	value   string
+}
+
+// pairs names each field once for both sinks. Callers hold a.mu.
+func (a *requestAudit) pairs() []auditField {
+	return []auditField{
+		{"sourceIP", "client.address", a.clientIP},
+		{"accessKeyID", "aws.access_key_id", a.accessKeyID},
+		{"accountID", "aws.account_id", a.accountID},
+		{"region", "aws.region", a.region},
+		{"service", "aws.service", a.service},
+		{"action", "aws.action", a.action},
+		{"principalType", "aws.principal_type", a.principalType},
+		{"authError", "aws.auth_error", a.authError},
+	}
+}
+
+// logRequest emits the access log line for a finished request, carrying the
+// audit fields alongside the HTTP result.
+func logRequest(r *http.Request, status int, duration time.Duration) {
+	attrs := []any{"method", r.Method, "path", r.URL.Path, "status", status, "duration", duration}
+	slog.InfoContext(r.Context(), "request", append(attrs, auditFrom(r.Context()).fields()...)...)
+}

--- a/spinifex/gateway/requestaudit_test.go
+++ b/spinifex/gateway/requestaudit_test.go
@@ -1,0 +1,164 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+)
+
+// A handler reached outside the middleware chain — a direct call from a test —
+// has no audit record, so every accessor has to tolerate a nil receiver.
+func TestRequestAuditNilSafe(t *testing.T) {
+	audit := auditFrom(context.Background())
+	require.Nil(t, audit)
+
+	assert.NotPanics(t, func() {
+		audit.setIdentity("AKIA", "123456789012", "ap-southeast-2", "ec2", "user")
+		audit.setAction("ec2", "DescribeInstances")
+		audit.setAuthError(awserrors.ErrorInvalidClientTokenId)
+		audit.setAccessKeyID("AKIA")
+		audit.annotate(context.Background())
+	})
+	assert.Nil(t, audit.fields())
+}
+
+// Empty values are omitted rather than logged blank, so an unauthenticated
+// request does not carry a row of empty identity fields.
+func TestRequestAuditOmitsEmptyFields(t *testing.T) {
+	audit := &requestAudit{clientIP: "10.15.8.11"}
+	assert.Equal(t, []any{"sourceIP", "10.15.8.11"}, audit.fields())
+
+	audit.setIdentity("AKIAEXAMPLE", "123456789012", "ap-southeast-2", "ec2", "user")
+	audit.setAction("ec2", "DescribeInstances")
+	assert.Equal(t, []any{
+		"sourceIP", "10.15.8.11",
+		"accessKeyID", "AKIAEXAMPLE",
+		"accountID", "123456789012",
+		"region", "ap-southeast-2",
+		"service", "ec2",
+		"action", "DescribeInstances",
+		"principalType", "user",
+	}, audit.fields())
+}
+
+// The record may carry an access key id and an error code and nothing else that
+// could hold a credential. This asserts the field set so a later addition of a
+// session token or an Authorization header fails here first.
+func TestRequestAuditCarriesNoSecret(t *testing.T) {
+	audit := &requestAudit{}
+	var keys []string
+	for _, kv := range audit.pairs() {
+		keys = append(keys, kv.key)
+	}
+	assert.Equal(t, []string{
+		"sourceIP", "accessKeyID", "accountID", "region", "service", "action",
+		"principalType", "authError",
+	}, keys)
+}
+
+// auditRouter wires the audit middleware ahead of SigV4 auth the way
+// SetupRoutes does, and hands back the record for the request just served.
+func auditRouter(t *testing.T, keys map[string]*handlers_iam.AccessKey) (http.Handler, func() *requestAudit) {
+	t.Helper()
+
+	rl := NewAuthRateLimiter()
+	t.Cleanup(rl.Stop)
+
+	gw := &GatewayConfig{
+		DisableLogging: true,
+		Region:         testRegion,
+		IAMService:     &mockIAMService{masterKey: testMasterKey, accessKeys: keys},
+		RateLimiter:    rl,
+	}
+
+	var got *requestAudit
+	r := chi.NewRouter()
+	r.Use(requestAuditMiddleware)
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = auditFrom(r.Context())
+			next.ServeHTTP(w, r)
+		})
+	})
+	r.Use(gw.SigV4AuthMiddleware())
+	r.HandleFunc("/*", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	return r, func() *requestAudit { return got }
+}
+
+// A request that never presented credentials is still attributable to where it
+// came from, and carries the verdict it was answered with.
+func TestRequestAuditRecordsUnauthenticatedRejection(t *testing.T) {
+	handler, audit := auditRouter(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.15.8.11:54321"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.NotNil(t, audit())
+	assert.Equal(t, "10.15.8.11", audit().clientIP)
+	assert.Equal(t, awserrors.ErrorMissingAuthenticationToken, audit().authError)
+	assert.Empty(t, audit().accessKeyID)
+}
+
+// signedRequest builds a request whose signature is wrong but whose envelope
+// parses: the credential scope date must match X-Amz-Date or the request is
+// rejected as malformed before the access key is ever looked at.
+func signedRequest(remoteAddr string) *http.Request {
+	now := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAINVALIDKEY000000/"+
+		now.Format("20060102")+"/"+testRegion+"/ec2/aws4_request, "+
+		"SignedHeaders=host;x-amz-date, Signature="+
+		"0000000000000000000000000000000000000000000000000000000000000000")
+	req.Header.Set("X-Amz-Date", now.Format("20060102T150405Z"))
+	return req
+}
+
+// A rejected caller is identifiable: the key it presented is recorded even
+// though authentication failed on it.
+func TestRequestAuditRecordsRejectedAccessKey(t *testing.T) {
+	handler, audit := auditRouter(t, map[string]*handlers_iam.AccessKey{})
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, signedRequest("10.15.8.12:54321"))
+
+	require.NotNil(t, audit())
+	assert.Equal(t, "10.15.8.12", audit().clientIP)
+	assert.Equal(t, "AKIAINVALIDKEY000000", audit().accessKeyID)
+	assert.Equal(t, awserrors.ErrorInvalidClientTokenId, audit().authError)
+}
+
+// The lockout that answers 503 is the case that motivated this: without the
+// record, the response carries no client address and no reason at all.
+func TestRequestAuditRecordsRateLimitLockout(t *testing.T) {
+	handler, audit := auditRouter(t, map[string]*handlers_iam.AccessKey{})
+
+	send := func() int {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, signedRequest("10.15.8.13:54321"))
+		return w.Code
+	}
+
+	for range maxFailures {
+		send()
+	}
+	assert.Equal(t, http.StatusServiceUnavailable, send())
+
+	require.NotNil(t, audit())
+	assert.Equal(t, "10.15.8.13", audit().clientIP)
+	assert.Equal(t, awserrors.ErrorRequestLimitExceeded, audit().authError)
+}


### PR DESCRIPTION
## Problem

awsgw is the front door and the least observable service in the fleet. Its request telemetry says `POST /` and nothing else: no AWS action, no caller, no auth verdict.

A live case on wattle shows the cost. Over 24 hours the gateway answered 69,820 requests with status 503 and not one of them is attributable from the request docs. The cause was only findable by leaving them entirely and reading separate auth-failure log lines, which do carry `sourceIP` and `accessKeyID`: four guests present session credentials the gateway rejects, each rejection feeds `RateLimiter.RecordFailure`, the source IP locks out, and everything after that is answered 503. Joining two log lines back to a request is not root-cause analysis.

## Change

`slogRequestLogger` is the outermost middleware, so it cannot see context values that downstream middleware sets — a derived context does not propagate back up. A small mutable record now rides the request instead:

- `requestAuditMiddleware` attaches it, unconditionally, so span enrichment does not depend on whether access logging is enabled.
- The SigV4 success path records identity where it already sets the same context values.
- `writeSigV4Error` records the verdict. Every auth rejection funnels through it, a rate-limit lockout included, so one call covers all of them.
- `recordResolvedAction` records the action, which covers query-protocol and REST-JSON services both.
- The access log line and the server span both read it.

Every accessor is nil-safe, so a handler called directly by a test behaves exactly as before.

## Secrets

The record holds an access key id and an AWS error code. Never a secret key, a session token or an Authorization header. `TestRequestAuditCarriesNoSecret` asserts the field set, so adding one of those fails there first.

## Not in this PR

The bead also asks for a Kibana gateway dashboard, which is next, and sketches a dedicated `logs-awsgw.request-*` data stream. The stream is not needed to meet any of the acceptance criteria and costs a second pipeline; the retention question behind it is better answered once, alongside the same question for audit records.

## Testing

`make preflight` passes. Five new tests cover nil-safety, empty-field omission, the secret-free field set, an unauthenticated rejection, a rejected access key, and the 503 lockout that motivated this.

Bead: mulga-hhrn5. Live case: mulga-1h63r. Plan: `docs/development/feature/gateway-request-audit.md`.