### PR TITLE
fix(bedrock): authorize runtime/agent actions under the bedrock: IAM namespace

### DIFF
--- a/spinifex/gateway/policy/actions.go
+++ b/spinifex/gateway/policy/actions.go
@@ -1,6 +1,27 @@
 package policy
 
-// IAMAction formats a service and action as the IAM policy string "service:ActionName".
+// bedrockIAMFamily lists the Bedrock wire/signing service names that all
+// authorize under the single "bedrock:" IAM namespace in AWS (runtime, agent,
+// and agent-runtime actions are namespaced as bedrock: on AWS).
+var bedrockIAMFamily = map[string]bool{
+	"bedrock-runtime":       true,
+	"bedrock-agent":         true,
+	"bedrock-agent-runtime": true,
+}
+
+// iamNamespace maps a wire service name to its IAM policy namespace, collapsing
+// the Bedrock family to the shared "bedrock:" namespace. Every other service
+// keeps its own name.
+func iamNamespace(service string) string {
+	if bedrockIAMFamily[service] {
+		return "bedrock"
+	}
+	return service
+}
+
+// IAMAction formats a service and action as the IAM policy string
+// "namespace:ActionName", collapsing the Bedrock family to the shared bedrock:
+// namespace so AWS-shaped policies authorize as they do on AWS.
 func IAMAction(service, action string) string {
-	return service + ":" + action
+	return iamNamespace(service) + ":" + action
 }

--- a/spinifex/gateway/policy/actions_test.go
+++ b/spinifex/gateway/policy/actions_test.go
@@ -1,0 +1,27 @@
+package policy
+
+import "testing"
+
+// TestIAMAction_BedrockNamespace asserts the Bedrock wire-service family
+// collapses to the shared "bedrock:" IAM namespace, while other services keep
+// their own prefix, so AWS-shaped policies authorize as they do on AWS.
+func TestIAMAction_BedrockNamespace(t *testing.T) {
+	cases := []struct {
+		service, action, want string
+	}{
+		{"bedrock", "Converse", "bedrock:Converse"},
+		{"bedrock-runtime", "ConverseStream", "bedrock:ConverseStream"},
+		{"bedrock-runtime", "InvokeModel", "bedrock:InvokeModel"},
+		{"bedrock-agent", "CreateKnowledgeBase", "bedrock:CreateKnowledgeBase"},
+		{"bedrock-agent-runtime", "Retrieve", "bedrock:Retrieve"},
+		{"bedrock-agent-runtime", "RetrieveAndGenerate", "bedrock:RetrieveAndGenerate"},
+		{"ecr", "GetAuthorizationToken", "ecr:GetAuthorizationToken"},
+		{"ecs", "RunTask", "ecs:RunTask"},
+		{"s3", "GetObject", "s3:GetObject"},
+	}
+	for _, c := range cases {
+		if got := IAMAction(c.service, c.action); got != c.want {
+			t.Errorf("IAMAction(%q, %q) = %q, want %q", c.service, c.action, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Bedrock runtime and agent-runtime actions (ConverseStream, Retrieve, RetrieveAndGenerate) were authorized against IAM prefixes derived from their **wire-service** names (`bedrock-runtime`, `bedrock-agent-runtime`) instead of the canonical `bedrock:` IAM namespace. A correctly-scoped `bedrock:*` policy therefore denied them with a 403 AccessDeniedException.

`IAMAction(service, action)` now maps the bedrock wire-service family to the `bedrock:` namespace via `iamNamespace(service)`, so `bedrock-runtime:ConverseStream` authorizes as `bedrock:ConverseStream` (AWS parity).

## Changes
- `gateway/policy/actions.go`: add `bedrockIAMFamily` map + `iamNamespace(service)`; `IAMAction` formats `iamNamespace(service):action`.
- `gateway/policy/actions_test.go`: `TestIAMAction_BedrockNamespace`.

## Testing
- `go test ./spinifex/gateway/policy/` — ok.
- Live-verified on wattle: the Bunyip RAG chat's ConverseStream/Retrieve 403 is resolved with a `bedrock:`-scoped principal policy.
- preflight otherwise green; the sole failure (`TestDefaultLoggerNotHijackedByLibrary` in `cmd/spinifex/cmd`) is pre-existing on `dev` and untouched by this diff (policy-only, 2 files).