### PR TITLE
docs: record why awsgw sets no WriteTimeout

### DIFF
--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -519,6 +519,9 @@ func launchService(config *config.ClusterConfig) error {
 		return fmt.Errorf("load TLS cert: %w", err)
 	}
 
+	// WriteTimeout is deliberately absent: it is a total deadline rather than an
+	// idle one, so any value below the RDS command channel's 20s long poll kills
+	// every poll mid-flight and strands agents on a channel no command reaches.
 	server := &http.Server{
 		Addr:              nodeConfig.AWSGW.Host,
 		Handler:           handler,


### PR DESCRIPTION
`rds.PollDBCommands` is a 20-second long poll — the gateway blocks on a NATS subscription until a command arrives or the window closes, matching what SQS `ReceiveMessage` does with the same 20-second ceiling.

That makes the absence of `WriteTimeout` on the gateway's `http.Server` load-bearing. `WriteTimeout` is a total deadline rather than an idle one, so any value below 20 seconds kills every poll mid-flight and strands agents on a channel no command can reach. The symptom would be `ErrCommandUnreachable` on password rotations against perfectly healthy agents, which points nowhere near the config that caused it.

Nothing recorded that, and `docs/development/deferred/cmmc-level2-compliance.md` already proposes setting `WriteTimeout` on every HTTP listener. At the 60s it names the polls survive; the next pass that picks a smaller number does not.

Comment only, no behaviour change.

## Testing

`make preflight` — the `diff-coverage` gate skips at 3 changed lines.

Related observability work landed in mulga `main` (`c24cb491`, `c21df621`): the long poll is now excluded from awsgw latency aggregates, has its own dashboard section, and three alert rules read it as a rate. Deployed to the sink and verified.