### PR TITLE
feat: name the caller account on NATS producer and consumer spans

### DIFF
--- a/spinifex/utils/nats.go
+++ b/spinifex/utils/nats.go
@@ -262,7 +262,7 @@ func NATSRequest[Out any](ctx context.Context, conn *nats.Conn, subject string, 
 		return nil, ErrClusterUnavailable
 	}
 
-	ctx, span := startProducerSpan(ctx, subject)
+	ctx, span := startProducerSpan(ctx, subject, accountID)
 	defer func() { endSpanWithError(span, err) }()
 
 	jsonData, err := json.Marshal(input)
@@ -388,7 +388,7 @@ func Gather(ctx context.Context, conn *nats.Conn, subject string, payload []byte
 		return nil, sum, ErrClusterUnavailable
 	}
 
-	ctx, span := startProducerSpan(ctx, subject)
+	ctx, span := startProducerSpan(ctx, subject, opts.AccountID)
 	defer func() { endSpanWithError(span, err) }()
 
 	inbox := nats.NewInbox()

--- a/spinifex/utils/nats_account_span_test.go
+++ b/spinifex/utils/nats_account_span_test.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// spanAccounts returns the account attribute of each recorded span by kind,
+// with an empty string where the span carries none.
+func spanAccounts(spans []sdktrace.ReadOnlySpan) map[trace.SpanKind]string {
+	accounts := make(map[trace.SpanKind]string, len(spans))
+	for _, span := range spans {
+		accounts[span.SpanKind()] = ""
+		for _, attr := range span.Attributes() {
+			if string(attr.Key) == AttrAccountID {
+				accounts[span.SpanKind()] = attr.Value.AsString()
+			}
+		}
+	}
+	return accounts
+}
+
+// Both ends of a NATS hop must name the account. Without it a tenant's request
+// is attributable at the gateway and anonymous everywhere it does its work,
+// which is the whole difficulty with one cluster serving many accounts.
+func TestNATSSpansCarryTheCallerAccount(t *testing.T) {
+	recorder := testutil.RecordSpans(t)
+
+	ns := startTestNATSServer(t)
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	defer nc.Close()
+
+	_, err = nc.Subscribe("test.account.echo", func(msg *nats.Msg) {
+		ServeNATSRequestCtx(msg, func(context.Context, *traceEchoRequest) (*traceEchoResponse, error) {
+			return &traceEchoResponse{Name: "ok"}, nil
+		})
+	})
+	require.NoError(t, err)
+
+	_, err = NATSRequest[traceEchoResponse](context.Background(), nc, "test.account.echo",
+		traceEchoRequest{Name: "x"}, 5*time.Second, "000000000042")
+	require.NoError(t, err)
+
+	accounts := spanAccounts(recorder.Ended())
+	assert.Equal(t, "000000000042", accounts[trace.SpanKindClient], "producer span must name the account it sent for")
+	assert.Equal(t, "000000000042", accounts[trace.SpanKindConsumer], "consumer span must name the account it served")
+}
+
+// Work with no caller is left unattributed. Defaulting it to the admin account
+// would make every sweep and probe look like tenant activity.
+func TestNATSConsumerSpanOmitsAnAbsentAccount(t *testing.T) {
+	recorder := testutil.RecordSpans(t)
+
+	msg := nats.NewMsg("test.account.none")
+	_, span := StartConsumerSpan(msg)
+	span.End()
+
+	require.Len(t, recorder.Ended(), 1)
+	assert.Empty(t, spanAccounts(recorder.Ended())[trace.SpanKindConsumer])
+}
+
+// The header is the source of truth on the consumer side: a handler reached
+// directly, without going through NATSRequest, is still attributed.
+func TestNATSConsumerSpanReadsTheAccountHeader(t *testing.T) {
+	recorder := testutil.RecordSpans(t)
+
+	msg := nats.NewMsg("test.account.header")
+	msg.Header.Set(AccountIDHeader, "000000000007")
+	_, span := StartConsumerSpan(msg)
+	span.End()
+
+	require.Len(t, recorder.Ended(), 1)
+	assert.Equal(t, "000000000007", spanAccounts(recorder.Ended())[trace.SpanKindConsumer])
+}

--- a/spinifex/utils/nats_trace.go
+++ b/spinifex/utils/nats_trace.go
@@ -43,27 +43,46 @@ func ExtractTraceContext(ctx context.Context, msg *nats.Msg) context.Context {
 	return otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(msg.Header))
 }
 
+// AttrAccountID names the account a span was served for. It matches the key
+// the gateway sets on its own spans, so one field attributes a request from the
+// front door to whichever service ends up doing the work.
+const AttrAccountID = "aws.account_id"
+
+// accountAttrs returns the account attribute for accountID, or nothing. Work
+// with no caller — a sweep, a reconciler, a node-to-node probe — is left
+// unattributed rather than being credited to whoever happens to be admin.
+func accountAttrs(accountID string) []attribute.KeyValue {
+	if accountID == "" {
+		return nil
+	}
+	return []attribute.KeyValue{attribute.String(AttrAccountID, accountID)}
+}
+
 // StartConsumerSpan extracts the producer's trace context from msg and opens
 // a consumer span for the subject. Callers must End() the returned span and
 // should pass the context into handler logic so logs correlate.
 func StartConsumerSpan(msg *nats.Msg) (context.Context, trace.Span) {
 	ctx := ExtractTraceContext(context.Background(), msg)
+	attrs := append([]attribute.KeyValue{
+		attribute.String("messaging.system", "nats"),
+		attribute.String("messaging.destination.name", msg.Subject),
+	}, accountAttrs(AccountIDFromMsg(msg))...)
+
 	return otel.Tracer(natsTracerName).Start(ctx, "NATS "+msg.Subject,
 		trace.WithSpanKind(trace.SpanKindConsumer),
-		trace.WithAttributes(
-			attribute.String("messaging.system", "nats"),
-			attribute.String("messaging.destination.name", msg.Subject),
-		))
+		trace.WithAttributes(attrs...))
 }
 
 // startProducerSpan opens a client span for an outbound request on subject.
-func startProducerSpan(ctx context.Context, subject string) (context.Context, trace.Span) {
+func startProducerSpan(ctx context.Context, subject, accountID string) (context.Context, trace.Span) {
+	attrs := append([]attribute.KeyValue{
+		attribute.String("messaging.system", "nats"),
+		attribute.String("messaging.destination.name", subject),
+	}, accountAttrs(accountID)...)
+
 	return otel.Tracer(natsTracerName).Start(ctx, "NATS "+subject,
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			attribute.String("messaging.system", "nats"),
-			attribute.String("messaging.destination.name", subject),
-		))
+		trace.WithAttributes(attrs...))
 }
 
 // endSpanWithError records err (if any) and ends the span.


### PR DESCRIPTION
## Why

The public sandbox is one Spinifex cluster on four nodes with tenancy at the account level. Every support question — which tenant caused this, what were they trying to do, who is consuming the cluster — starts with the account.

Right now the account reaches the telemetry at the gateway and stops there. Fleet-wide over 24h:

| service | transactions | carrying an account |
| --- | --- | --- |
| predastore | 595,864 | 0 |
| spinifex-daemon | 187,317 | 0 |
| awsgw | 150,567 | 68,301 |
| vpcd | 46,515 | 0 |
| northstar | 25,308 | 0 |
| viperblockd | 10,209 | 0 |

The daemon does log an account on 67,838 records, but as ad-hoc slog fields on individual handlers — never on a span, so it cannot be joined to the request that caused it.

## Change

The account already crosses NATS on every request as `X-Account-ID`, so no new propagation is needed — the spans simply have to name what is already on the wire.

- `StartConsumerSpan` reads the header onto the consumer span. That covers every handler built on `ServeNATSRequest`/`ServeNATSRequestCtx`, which is the chokepoint nearly all of them go through, plus viperblockd's subscriptions.
- `startProducerSpan` takes the account the caller is sending for, so `NATSRequest` and `Gather` fan-outs name it on the client side too.

`AttrAccountID` is `aws.account_id`, matching the key the gateway already sets, so one field follows a request from the front door to whichever service ends up doing the work.

An empty account is left off the span rather than recorded blank. Work with no caller — a janitor sweep, a reconciler, a node-to-node probe — belongs to nobody, and defaulting it to the admin account would make routine housekeeping look like tenant activity.

## Testing

- both ends of a real NATS round trip carry the account the request was sent for
- a consumer span with no account header carries no account attribute
- a handler reached directly, without going through `NATSRequest`, is still attributed from the header

`make preflight` passes.

## Follow-up

Predastore is the largest span producer in the fleet and authenticates its own callers, so it names the account itself — separate PR in that repo. Tenant dashboards build on this once both are deployed.