### PR TITLE
docs: bring doc titles and descriptions into SEO length limits

### DIFF
--- a/docs/admin/setting-up-your-cluster/README.md
+++ b/docs/admin/setting-up-your-cluster/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Setting Up Your Cluster"
-description: "Import an AMI, create a VPC with a public subnet, and launch your first EC2 instance on Spinifex."
+title: "Set Up Your First Spinifex Cluster"
+description: "Import an AMI, create an SSH key pair and a VPC with a public subnet, then launch your first EC2 instance and connect to it on a fresh Spinifex cluster."
 category: "Admin"
 tags:
   - setup

--- a/docs/admin/setting-up-your-cluster/README.md
+++ b/docs/admin/setting-up-your-cluster/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Set Up Your First Spinifex Cluster"
+title: "Setting Up Your Cluster"
+seoTitle: "Set Up Your First Spinifex Cluster — Spinifex Docs"
 description: "Import an AMI, create an SSH key pair and a VPC with a public subnet, then launch your first EC2 instance and connect to it on a fresh Spinifex cluster."
 category: "Admin"
 tags:

--- a/docs/admin/spinifex-admin-cli/README.md
+++ b/docs/admin/spinifex-admin-cli/README.md
@@ -1,5 +1,6 @@
 ---
-title: "spx: The Spinifex Administration CLI"
+title: "Spinifex Admin CLI"
+seoTitle: "spx: The Spinifex Administration CLI — Spinifex Docs"
 description: "Complete reference for spx, the Spinifex admin CLI: initialise a cluster, manage accounts and nodes, drive the VM lifecycle, and start or stop services."
 category: "Admin"
 tags:

--- a/docs/admin/spinifex-admin-cli/README.md
+++ b/docs/admin/spinifex-admin-cli/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Spinifex Admin CLI"
-description: "Complete reference for the Spinifex administration CLI. Manage accounts, nodes, VMs, and services."
+title: "spx: The Spinifex Administration CLI"
+description: "Complete reference for spx, the Spinifex admin CLI: initialise a cluster, manage accounts and nodes, drive the VM lifecycle, and start or stop services."
 category: "Admin"
 tags:
   - cli

--- a/docs/admin/update/README.md
+++ b/docs/admin/update/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Updating Spinifex"
-description: "Upgrade an existing Spinifex installation to the latest release."
+title: "Update Spinifex to the Latest Release"
+description: "Upgrade an existing Spinifex install with the same installer used to deploy it, or take the manual path to review configuration migrations before applying them."
 category: "Admin"
 tags:
   - update

--- a/docs/admin/update/README.md
+++ b/docs/admin/update/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Update Spinifex to the Latest Release"
+title: "Updating Spinifex"
+seoTitle: "Update Spinifex to the Latest Release — Spinifex Docs"
 description: "Upgrade an existing Spinifex install with the same installer used to deploy it, or take the manual path to review configuration migrations before applying them."
 category: "Admin"
 tags:

--- a/docs/compute/gpu-passthrough/README.md
+++ b/docs/compute/gpu-passthrough/README.md
@@ -1,5 +1,6 @@
 ---
-title: "VFIO GPU Passthrough for EC2 Instances"
+title: "GPU Passthrough"
+seoTitle: "VFIO GPU Passthrough for EC2 Instances — Spinifex Docs"
 description: "Configure VFIO GPU passthrough on a Spinifex node to bind NVIDIA or AMD GPUs to guest VMs and expose GPU-enabled EC2 instance types to your workloads."
 category: "Compute"
 tags:

--- a/docs/compute/gpu-passthrough/README.md
+++ b/docs/compute/gpu-passthrough/README.md
@@ -1,6 +1,6 @@
 ---
-title: "GPU Passthrough"
-description: "Configure VFIO GPU passthrough on a Spinifex node to expose NVIDIA or AMD GPUs to EC2 instances."
+title: "VFIO GPU Passthrough for EC2 Instances"
+description: "Configure VFIO GPU passthrough on a Spinifex node to bind NVIDIA or AMD GPUs to guest VMs and expose GPU-enabled EC2 instance types to your workloads."
 category: "Compute"
 tags:
   - gpu

--- a/docs/compute/launching-instances/README.md
+++ b/docs/compute/launching-instances/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Launching AWS EC2 Instances on Spinifex"
+title: "Launching Instances"
+seoTitle: "Launching AWS EC2 Instances on Spinifex — Spinifex Docs"
 description: "Launch, manage, and connect to EC2-compatible virtual machines on Spinifex, with cloud-init, SSH key injection, VPC networking, and AWS lifecycle operations."
 category: "Compute"
 tags:

--- a/docs/compute/launching-instances/README.md
+++ b/docs/compute/launching-instances/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Launching Instances"
-description: "Launch, manage, and connect to EC2-compatible virtual machines on Spinifex."
+title: "Launching AWS EC2 Instances on Spinifex"
+description: "Launch, manage, and connect to EC2-compatible virtual machines on Spinifex, with cloud-init, SSH key injection, VPC networking, and AWS lifecycle operations."
 category: "Compute"
 tags:
   - ec2

--- a/docs/compute/placement-groups/README.md
+++ b/docs/compute/placement-groups/README.md
@@ -1,5 +1,6 @@
 ---
-title: "AWS EC2 Placement Groups on Spinifex"
+title: "Placement Groups"
+seoTitle: "AWS EC2 Placement Groups on Spinifex — Spinifex Docs"
 description: "Create and manage spread and cluster placement groups to control how Spinifex places EC2 instances across physical hosts for fault isolation or low latency."
 category: "Compute"
 tags:

--- a/docs/compute/placement-groups/README.md
+++ b/docs/compute/placement-groups/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Placement Groups"
-description: "Create and manage spread and cluster placement groups for hardware-level instance placement control."
+title: "AWS EC2 Placement Groups on Spinifex"
+description: "Create and manage spread and cluster placement groups to control how Spinifex places EC2 instances across physical hosts for fault isolation or low latency."
 category: "Compute"
 tags:
   - ec2

--- a/docs/compute/vpc-networking/README.md
+++ b/docs/compute/vpc-networking/README.md
@@ -1,6 +1,6 @@
 ---
-title: "VPC Networking"
-description: "How Spinifex implements AWS-compatible VPC networking with public and private subnets, security groups, and Elastic IPs using OVN."
+title: "AWS-Compatible VPC Networking with OVN"
+description: "How Spinifex implements AWS-compatible VPC networking on bare metal with OVN: public and private subnets, security groups, route tables, and Elastic IPs."
 category: "Compute"
 tags:
   - vpc

--- a/docs/compute/vpc-networking/README.md
+++ b/docs/compute/vpc-networking/README.md
@@ -1,5 +1,6 @@
 ---
-title: "AWS-Compatible VPC Networking with OVN"
+title: "VPC Networking"
+seoTitle: "AWS-Compatible VPC Networking with OVN — Spinifex Docs"
 description: "How Spinifex implements AWS-compatible VPC networking on bare metal with OVN: public and private subnets, security groups, route tables, and Elastic IPs."
 category: "Compute"
 tags:

--- a/docs/containers/ecr/README.md
+++ b/docs/containers/ecr/README.md
@@ -1,6 +1,6 @@
 ---
-title: "ECR (Container Registry)"
-description: "Store and serve container images from Spinifex's AWS-compatible Elastic Container Registry — create a repository, authenticate Docker, push and pull images, and let your EKS workers pull from it, using the AWS CLI, the Spinifex console, or Terraform."
+title: "AWS ECR Container Registry on Spinifex"
+description: "Store and serve container images from Spinifex's AWS-compatible ECR: create a repository, authenticate Docker, push and pull images, and let EKS workers pull."
 category: "Containers"
 tags:
   - ecr

--- a/docs/containers/ecr/README.md
+++ b/docs/containers/ecr/README.md
@@ -1,5 +1,6 @@
 ---
-title: "AWS ECR Container Registry on Spinifex"
+title: "ECR (Container Registry)"
+seoTitle: "AWS ECR Container Registry on Spinifex — Spinifex Docs"
 description: "Store and serve container images from Spinifex's AWS-compatible ECR: create a repository, authenticate Docker, push and pull images, and let EKS workers pull."
 category: "Containers"
 tags:

--- a/docs/containers/ecs/README.md
+++ b/docs/containers/ecs/README.md
@@ -1,5 +1,6 @@
 ---
-title: "AWS ECS Elastic Container Service Guide"
+title: "ECS (Elastic Container Service)"
+seoTitle: "AWS ECS Elastic Container Service Guide — Spinifex Docs"
 description: "Create an ECS cluster on Spinifex, register a task definition, boot container instances, run tasks, and front a service with an Application Load Balancer."
 category: "Containers"
 tags:

--- a/docs/containers/ecs/README.md
+++ b/docs/containers/ecs/README.md
@@ -1,6 +1,6 @@
 ---
-title: "ECS (Elastic Container Service)"
-description: "Run AWS-compatible ECS workloads on Spinifex — create a cluster, register a task definition, boot container instances from the ECS node image, run tasks, and front a long-running service with an Application Load Balancer, all via the AWS CLI, the Spinifex console, or Terraform."
+title: "AWS ECS Elastic Container Service Guide"
+description: "Create an ECS cluster on Spinifex, register a task definition, boot container instances, run tasks, and front a service with an Application Load Balancer."
 category: "Containers"
 tags:
   - ecs

--- a/docs/containers/eks/README.md
+++ b/docs/containers/eks/README.md
@@ -1,5 +1,6 @@
 ---
-title: "AWS EKS Managed Kubernetes on Spinifex"
+title: "EKS (Managed Kubernetes)"
+seoTitle: "AWS EKS Managed Kubernetes on Spinifex — Spinifex Docs"
 description: "Provision an AWS-compatible EKS control plane and managed node group on Spinifex, wire up the VPC, IAM, and security groups, then deploy your first workload."
 category: "Containers"
 tags:

--- a/docs/containers/eks/README.md
+++ b/docs/containers/eks/README.md
@@ -1,6 +1,6 @@
 ---
-title: "EKS (Managed Kubernetes)"
-description: "Run a managed, AWS-compatible Kubernetes cluster on Spinifex — provision the control plane and worker node group, wire up the VPC, IAM, and security groups it needs, and deploy your first workload via the AWS CLI, the Spinifex console, or Terraform."
+title: "AWS EKS Managed Kubernetes on Spinifex"
+description: "Provision an AWS-compatible EKS control plane and managed node group on Spinifex, wire up the VPC, IAM, and security groups, then deploy your first workload."
 category: "Containers"
 tags:
   - eks

--- a/docs/install/install-airgapped/README.md
+++ b/docs/install/install-airgapped/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Air-Gapped Install"
+title: "Install Spinifex in an Air-Gapped Network"
 description: "Deploy Spinifex in environments without internet connectivity. Covers using a pre-built release tarball, mirrored APT packages, and locally-staged cloud images."
 category: "Install"
 tags:

--- a/docs/install/install-airgapped/README.md
+++ b/docs/install/install-airgapped/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Install Spinifex in an Air-Gapped Network"
+title: "Air-Gapped Install"
+seoTitle: "Install Spinifex in an Air-Gapped Network — Spinifex Docs"
 description: "Deploy Spinifex in environments without internet connectivity. Covers using a pre-built release tarball, mirrored APT packages, and locally-staged cloud images."
 category: "Install"
 tags:

--- a/docs/install/install-multi-node/README.md
+++ b/docs/install/install-multi-node/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Multi-Node Install"
-description: "Deploy Spinifex across multiple servers to create an availability zone with high availability, data durability, and fault tolerance."
+title: "Multi-Node Spinifex Cluster Install"
+description: "Deploy Spinifex across several servers to form an availability zone with automatic cluster formation, high availability, data durability, and fault tolerance."
 category: "Install"
 tags:
   - install

--- a/docs/install/install-multi-node/README.md
+++ b/docs/install/install-multi-node/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Multi-Node Spinifex Cluster Install"
+title: "Multi-Node Install"
+seoTitle: "Multi-Node Spinifex Cluster Install — Spinifex Docs"
 description: "Deploy Spinifex across several servers to form an availability zone with automatic cluster formation, high availability, data durability, and fault tolerance."
 category: "Install"
 tags:

--- a/docs/install/install-source/README.md
+++ b/docs/install/install-source/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Source Install"
-description: "Build Spinifex from source for development, custom builds, or contributing."
+title: "Build and Install Spinifex from Source"
+description: "Build Spinifex from source on Ubuntu or Debian for development, custom builds, or contributing changes, then install and run the resulting binaries locally."
 category: "Install"
 tags:
   - install

--- a/docs/install/install-source/README.md
+++ b/docs/install/install-source/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Build and Install Spinifex from Source"
+title: "Source Install"
+seoTitle: "Build and Install Spinifex from Source — Spinifex Docs"
 description: "Build Spinifex from source on Ubuntu or Debian for development, custom builds, or contributing changes, then install and run the resulting binaries locally."
 category: "Install"
 tags:

--- a/docs/install/install-usb/README.md
+++ b/docs/install/install-usb/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Install Spinifex from a Bootable USB"
+title: "Bootable USB Install"
+seoTitle: "Install Spinifex from a Bootable USB — Spinifex Docs"
 description: "Install Spinifex on bare-metal x86 hardware by flashing the Spinifex ISO to a USB drive, booting the target server from it, and wiping the disk you select."
 category: "Install"
 sections:

--- a/docs/install/install-usb/README.md
+++ b/docs/install/install-usb/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Bootable USB Install"
-description: "Install Spinifex on bare-metal hardware by flashing the Spinifex ISO to a USB drive and booting the target device from it."
+title: "Install Spinifex from a Bootable USB"
+description: "Install Spinifex on bare-metal x86 hardware by flashing the Spinifex ISO to a USB drive, booting the target server from it, and wiping the disk you select."
 category: "Install"
 sections:
   - overview

--- a/docs/install/install/README.md
+++ b/docs/install/install/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Install Spinifex on a Single Server"
+title: "Single-Node Install"
+seoTitle: "Install Spinifex on a Single Server — Spinifex Docs"
 description: "Install Spinifex on one Ubuntu or Debian server with the binary installer and get an AWS-compatible EC2, S3, and VPC stack running on your own hardware."
 category: "Install"
 tags:

--- a/docs/install/install/README.md
+++ b/docs/install/install/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Single-Node Install"
-description: "Install Spinifex on a single server using the binary installer."
+title: "Install Spinifex on a Single Server"
+description: "Install Spinifex on one Ubuntu or Debian server with the binary installer and get an AWS-compatible EC2, S3, and VPC stack running on your own hardware."
 category: "Install"
 tags:
   - install

--- a/docs/migration/hybrid-sync/README.md
+++ b/docs/migration/hybrid-sync/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Hybrid Sync Between Spinifex and AWS"
+title: "Hybrid Sync"
+seoTitle: "Hybrid Sync Between Spinifex and AWS — Spinifex Docs"
 description: "Synchronise data bidirectionally between Spinifex and AWS when connectivity allows, so local infrastructure stays usable at intermittently connected sites."
 category: "Migration"
 tags:

--- a/docs/migration/hybrid-sync/README.md
+++ b/docs/migration/hybrid-sync/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Hybrid Sync"
-description: "Synchronize data between Spinifex and AWS when network connectivity is available."
+title: "Hybrid Sync Between Spinifex and AWS"
+description: "Synchronise data bidirectionally between Spinifex and AWS when connectivity allows, so local infrastructure stays usable at intermittently connected sites."
 category: "Migration"
 tags:
   - hybrid

--- a/docs/migration/moving-aws-workload/README.md
+++ b/docs/migration/moving-aws-workload/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Migrate an AWS Workload to Spinifex"
+title: "Moving an AWS Workload to Mulga"
+seoTitle: "Migrate an AWS Workload to Spinifex — Spinifex Docs"
 description: "Move existing AWS workloads onto Spinifex using compatible APIs, SDKs, and Terraform across EC2, VPC, EBS, S3, IAM, STS, ELBv2, ACM, ECR, ECS, and EKS."
 category: "Migration"
 tags:

--- a/docs/migration/moving-aws-workload/README.md
+++ b/docs/migration/moving-aws-workload/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Moving an AWS Workload to Mulga"
-description: "Migrate existing AWS workloads to Spinifex using compatible APIs, SDKs, and Terraform."
+title: "Migrate an AWS Workload to Spinifex"
+description: "Move existing AWS workloads onto Spinifex using compatible APIs, SDKs, and Terraform across EC2, VPC, EBS, S3, IAM, STS, ELBv2, ACM, ECR, ECS, and EKS."
 category: "Migration"
 tags:
   - migration

--- a/docs/reference-architectures/OnLogic-HX401-single-node/README.md
+++ b/docs/reference-architectures/OnLogic-HX401-single-node/README.md
@@ -1,6 +1,6 @@
 ---
 title: "Single-Node Spinifex on OnLogic HX401"
-description: "Run a complete EC2, EBS and S3 stack on one fanless OnLogic edge node, and measure what the platform costs against bare metal."
+description: "Run a complete EC2, EBS, and S3 stack on one fanless OnLogic HX401 edge node, and measure what the platform layer costs compared with bare-metal baselines."
 category: "Reference Architectures"
 tags:
   - onlogic

--- a/docs/reference-architectures/OnLogic-HX401-single-node/README.md
+++ b/docs/reference-architectures/OnLogic-HX401-single-node/README.md
@@ -1,5 +1,6 @@
 ---
 title: "Single-Node Spinifex on OnLogic HX401"
+seoTitle: "Single-Node Spinifex on OnLogic HX401 — Spinifex Docs"
 description: "Run a complete EC2, EBS, and S3 stack on one fanless OnLogic HX401 edge node, and measure what the platform layer costs compared with bare-metal baselines."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/RTX-Pro-6000-EKS/README.md
+++ b/docs/reference-architectures/RTX-Pro-6000-EKS/README.md
@@ -1,5 +1,6 @@
 ---
-title: "EKS AI Platform on Dual RTX Pro 6000"
+title: "Spinifex EKS AI Platform on Dual RTX Pro 6000 Baremetal"
+seoTitle: "EKS AI Platform on Dual RTX Pro 6000 — Spinifex Docs"
 description: "Deploy a GPU-accelerated AI inference platform — an OpenAI-compatible LLM API and a real-time CV stream — on Kubernetes on bare metal with standard AWS tooling."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/RTX-Pro-6000-EKS/README.md
+++ b/docs/reference-architectures/RTX-Pro-6000-EKS/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Spinifex EKS AI Platform on Dual RTX Pro 6000 Baremetal"
-description: "Deploy a GPU-accelerated AI inference platform — an OpenAI-compatible LLM API and a real-time CV stream — in Kubernetes on bare-metal hardware, managed entirely with standard AWS tooling."
+title: "EKS AI Platform on Dual RTX Pro 6000"
+description: "Deploy a GPU-accelerated AI inference platform — an OpenAI-compatible LLM API and a real-time CV stream — on Kubernetes on bare metal with standard AWS tooling."
 category: "Reference Architectures"
 tags:
   - nvidia

--- a/docs/reference-architectures/SMCI-H14-orchestration/README.md
+++ b/docs/reference-architectures/SMCI-H14-orchestration/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Multi-Tenant AI on Supermicro H14 MI350X"
+title: "Multi-Tenant AI on Supermicro H14 with AMD MI350X"
+seoTitle: "Multi-Tenant AI on Supermicro H14 MI350X — Spinifex Docs"
 description: "Provision isolated GPU VMs for simultaneous AI workloads on a Supermicro H14 bare-metal node with AMD MI350X GPUs, using Spinifex's EC2-compatible API."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/SMCI-H14-orchestration/README.md
+++ b/docs/reference-architectures/SMCI-H14-orchestration/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Multi-Tenant AI on Supermicro H14 with AMD MI350X"
-description: "Provision isolated GPU VMs for simultaneous AI workloads on a Supermicro H14 bare-metal node using Spinifex's EC2-compatible API."
+title: "Multi-Tenant AI on Supermicro H14 MI350X"
+description: "Provision isolated GPU VMs for simultaneous AI workloads on a Supermicro H14 bare-metal node with AMD MI350X GPUs, using Spinifex's EC2-compatible API."
 category: "Reference Architectures"
 tags:
   - supermicro

--- a/docs/reference-architectures/SMCI-MIG-orchestration/README.md
+++ b/docs/reference-architectures/SMCI-MIG-orchestration/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Mixed AI Workloads on a Single H200 Chassis: Guest-Managed MIG"
-description: "Install Spinifex from source, configure host-local networking, attach Predastore storage, and run four concurrent AI workloads across MIG partitions managed inside guest VMs."
+title: "Guest-Managed MIG on an H200 Chassis"
+description: "Install Spinifex from source, configure host-local networking, attach Predastore storage, and run four concurrent AI workloads across guest-managed MIG slices."
 category: "Reference Architectures"
 tags:
   - nvidia

--- a/docs/reference-architectures/SMCI-MIG-orchestration/README.md
+++ b/docs/reference-architectures/SMCI-MIG-orchestration/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Guest-Managed MIG on an H200 Chassis"
+title: "Mixed AI Workloads on a Single H200 Chassis: Guest-Managed MIG"
+seoTitle: "Guest-Managed MIG on an H200 Chassis — Spinifex Docs"
 description: "Install Spinifex from source, configure host-local networking, attach Predastore storage, and run four concurrent AI workloads across guest-managed MIG slices."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/arcee-trinity-mi350x/README.md
+++ b/docs/reference-architectures/arcee-trinity-mi350x/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Arcee Trinity 400B FP8 on AMD MI350X with Spinifex"
-description: "Provision, load, and benchmark arcee-ai/Trinity-Large-Preview-FP8 across two AMD MI350X GPUs on a Supermicro H14 using Spinifex's EC2-compatible API."
+title: "Arcee Trinity 400B FP8 on AMD MI350X"
+description: "Provision, load, and benchmark arcee-ai/Trinity-Large-Preview-FP8 across two AMD MI350X GPUs on a Supermicro H14 node using Spinifex's EC2-compatible API."
 category: "Reference Architectures"
 tags:
   - supermicro

--- a/docs/reference-architectures/arcee-trinity-mi350x/README.md
+++ b/docs/reference-architectures/arcee-trinity-mi350x/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Arcee Trinity 400B FP8 on AMD MI350X"
+title: "Arcee Trinity 400B FP8 on AMD MI350X with Spinifex"
+seoTitle: "Arcee Trinity 400B FP8 on AMD MI350X — Spinifex Docs"
 description: "Provision, load, and benchmark arcee-ai/Trinity-Large-Preview-FP8 across two AMD MI350X GPUs on a Supermicro H14 node using Spinifex's EC2-compatible API."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/cisco-ucs-llm-serving/README.md
+++ b/docs/reference-architectures/cisco-ucs-llm-serving/README.md
@@ -1,6 +1,6 @@
 ---
-title: "vLLM Serving on Cisco UCS: Intel AMX vs NVIDIA L4"
-description: "Qwen2.5-7B-Instruct served with vLLM on the same Cisco UCS Spinifex cluster, comparing Intel AMX-accelerated CPU serving against NVIDIA L4 GPU serving across input length and concurrency."
+title: "vLLM on Cisco UCS: Intel AMX vs NVIDIA L4"
+description: "Qwen2.5-7B-Instruct served with vLLM on a Cisco UCS Spinifex cluster, comparing Intel AMX-accelerated CPU serving with NVIDIA L4 GPU serving under concurrency."
 category: "Reference Architectures"
 tags:
   - cisco

--- a/docs/reference-architectures/cisco-ucs-llm-serving/README.md
+++ b/docs/reference-architectures/cisco-ucs-llm-serving/README.md
@@ -1,5 +1,6 @@
 ---
-title: "vLLM on Cisco UCS: Intel AMX vs NVIDIA L4"
+title: "vLLM Serving on Cisco UCS: Intel AMX vs NVIDIA L4"
+seoTitle: "vLLM on Cisco UCS: Intel AMX vs NVIDIA L4 — Spinifex Docs"
 description: "Qwen2.5-7B-Instruct served with vLLM on a Cisco UCS Spinifex cluster, comparing Intel AMX-accelerated CPU serving with NVIDIA L4 GPU serving under concurrency."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/cisco-ucs-platform-benchmark/README.md
+++ b/docs/reference-architectures/cisco-ucs-platform-benchmark/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Spinifex Benchmark on 3-Node Cisco UCS"
+title: "Spinifex Platform Benchmark on Cisco UCS (3-Node)"
+seoTitle: "Spinifex Benchmark on 3-Node Cisco UCS — Spinifex Docs"
 description: "Measured CPU, disk, network, and S3 performance of Spinifex on a 3-node Cisco Unified Edge cluster, comparing host against guest with Intel AMX confirmed."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/cisco-ucs-platform-benchmark/README.md
+++ b/docs/reference-architectures/cisco-ucs-platform-benchmark/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Spinifex Platform Benchmark on Cisco UCS (3-Node)"
-description: "Measured CPU, disk, network, and S3 performance of Spinifex on a 3-node Cisco Unified Edge cluster — host versus guest, Intel AMX confirmed executing at the ISA level, and EC2 instance worker concurrency limits."
+title: "Spinifex Benchmark on 3-Node Cisco UCS"
+description: "Measured CPU, disk, network, and S3 performance of Spinifex on a 3-node Cisco Unified Edge cluster, comparing host against guest with Intel AMX confirmed."
 category: "Reference Architectures"
 tags:
   - cisco

--- a/docs/reference-architectures/cisco-ucs-vision-pipeline/README.md
+++ b/docs/reference-architectures/cisco-ucs-vision-pipeline/README.md
@@ -1,5 +1,6 @@
 ---
 title: "Spinifex Vision Pipeline on Cisco UCS"
+seoTitle: "Spinifex Vision Pipeline on Cisco UCS — Spinifex Docs"
 description: "A YOLO11m detection and Qwen2-VL captioning pipeline streaming from a shared Predastore bucket across two EC2 instances, with Intel AMX and NVIDIA L4 compared."
 category: "Reference Architectures"
 tags:

--- a/docs/reference-architectures/cisco-ucs-vision-pipeline/README.md
+++ b/docs/reference-architectures/cisco-ucs-vision-pipeline/README.md
@@ -1,6 +1,6 @@
 ---
 title: "Spinifex Vision Pipeline on Cisco UCS"
-description: "A YOLO11m object-detection + Qwen2-VL scene-captioning pipeline on Spinifex, streaming from a shared Predastore bucket across two independent EC2-compatible instances, with Intel AMX and NVIDIA L4 acceleration compared head-to-head."
+description: "A YOLO11m detection and Qwen2-VL captioning pipeline streaming from a shared Predastore bucket across two EC2 instances, with Intel AMX and NVIDIA L4 compared."
 category: "Reference Architectures"
 tags:
   - cisco

--- a/docs/security/flaw-remediation-policy/README.md
+++ b/docs/security/flaw-remediation-policy/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Spinifex Flaw Remediation Policy (CVSS)"
+title: "Flaw Remediation Policy"
+seoTitle: "Spinifex Flaw Remediation Policy (CVSS) — Spinifex Docs"
 description: "CVSS-tiered SLAs for identifying, reporting, and correcting software flaws in Spinifex and its direct dependencies, for maintainers and CMMC Level 1 operators."
 category: "Security"
 sections:

--- a/docs/security/flaw-remediation-policy/README.md
+++ b/docs/security/flaw-remediation-policy/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Flaw Remediation Policy"
-description: "CVSS-tiered SLAs for identifying, reporting, and correcting software flaws in Spinifex"
+title: "Spinifex Flaw Remediation Policy (CVSS)"
+description: "CVSS-tiered SLAs for identifying, reporting, and correcting software flaws in Spinifex and its direct dependencies, for maintainers and CMMC Level 1 operators."
 category: "Security"
 sections:
   - overview

--- a/docs/security/malware-protection/README.md
+++ b/docs/security/malware-protection/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Malware Protection for Spinifex Nodes"
+title: "Malware Protection"
+seoTitle: "Malware Protection for Spinifex Nodes — Spinifex Docs"
 description: "Operator guide to host-based malware protection and file integrity monitoring on the Linux hosts running Spinifex services, aligned to CMMC Level 1 needs."
 category: "Security"
 sections:

--- a/docs/security/malware-protection/README.md
+++ b/docs/security/malware-protection/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Malware Protection"
-description: "Operator guide for host-based malware protection and file integrity monitoring on Spinifex nodes"
+title: "Malware Protection for Spinifex Nodes"
+description: "Operator guide to host-based malware protection and file integrity monitoring on the Linux hosts running Spinifex services, aligned to CMMC Level 1 needs."
 category: "Security"
 sections:
   - overview

--- a/docs/security/media-sanitization/README.md
+++ b/docs/security/media-sanitization/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Media Sanitization and Disposal"
-description: "Operator guide for sanitizing and disposing of storage media used by Spinifex nodes"
+title: "Media Sanitization and Disposal Guide"
+description: "Operator guide to sanitizing and disposing of storage media used by Spinifex nodes, covering system disks, Viperblock and Predastore volumes, and key tokens."
 category: "Security"
 sections:
   - overview

--- a/docs/security/media-sanitization/README.md
+++ b/docs/security/media-sanitization/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Media Sanitization and Disposal Guide"
+title: "Media Sanitization and Disposal"
+seoTitle: "Media Sanitization and Disposal Guide — Spinifex Docs"
 description: "Operator guide to sanitizing and disposing of storage media used by Spinifex nodes, covering system disks, Viperblock and Predastore volumes, and key tokens."
 category: "Security"
 sections:

--- a/docs/security/network-connections/README.md
+++ b/docs/security/network-connections/README.md
@@ -1,6 +1,6 @@
 ---
-title: "External Connection Inventory"
-description: "Operator inventory of inbound listeners and outbound connections on Spinifex nodes"
+title: "Spinifex External Connection Inventory"
+description: "Operator inventory of every inbound listener and outbound connection on Spinifex nodes, with ports, protocols, and purpose, for documented CMMC Level 1 sites."
 category: "Security"
 sections:
   - overview

--- a/docs/security/network-connections/README.md
+++ b/docs/security/network-connections/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Spinifex External Connection Inventory"
+title: "External Connection Inventory"
+seoTitle: "Spinifex External Connection Inventory — Spinifex Docs"
 description: "Operator inventory of every inbound listener and outbound connection on Spinifex nodes, with ports, protocols, and purpose, for documented CMMC Level 1 sites."
 category: "Security"
 sections:

--- a/docs/security/physical-security-guide/README.md
+++ b/docs/security/physical-security-guide/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Physical Security Guide for Operators"
+title: "Physical Security Operator Guide"
+seoTitle: "Physical Security Guide for Operators — Spinifex Docs"
 description: "Operator guide to physical access controls, visitor handling, access logging, and access-device management at sites hosting Spinifex nodes and network gear."
 category: "Security"
 sections:

--- a/docs/security/physical-security-guide/README.md
+++ b/docs/security/physical-security-guide/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Physical Security Operator Guide"
-description: "Operator guide for physical access controls, visitor handling, access logging, and access-device management at sites hosting Spinifex nodes"
+title: "Physical Security Guide for Operators"
+description: "Operator guide to physical access controls, visitor handling, access logging, and access-device management at sites hosting Spinifex nodes and network gear."
 category: "Security"
 sections:
   - overview

--- a/docs/terraform-workbooks/bastion-private-subnet/README.md
+++ b/docs/terraform-workbooks/bastion-private-subnet/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Terraform Bastion Host and Private Subnet"
+title: "Bastion with Private Subnet"
+seoTitle: "Terraform Bastion Host and Private Subnet — Spinifex Docs"
 description: "Deploy a VPC with public and private subnets on Spinifex, then use a bastion host as the only route to an isolated EC2 instance that has no internet access."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/bastion-private-subnet/README.md
+++ b/docs/terraform-workbooks/bastion-private-subnet/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Bastion with Private Subnet"
-description: "Deploy a bastion host to access an isolated private compute instance with no internet connectivity."
+title: "Terraform Bastion Host and Private Subnet"
+description: "Deploy a VPC with public and private subnets on Spinifex, then use a bastion host as the only route to an isolated EC2 instance that has no internet access."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/ecs-quickstart/README.md
+++ b/docs/terraform-workbooks/ecs-quickstart/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Terraform ECS Quickstart on Spinifex"
+title: "ECS Quickstart"
+seoTitle: "Terraform ECS Quickstart on Spinifex — Spinifex Docs"
 description: "Stand up a full AWS-compatible ECS stack with Terraform: a VPC, IAM roles, a cluster, a task definition, container instances, and a load-balanced service."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/ecs-quickstart/README.md
+++ b/docs/terraform-workbooks/ecs-quickstart/README.md
@@ -1,6 +1,6 @@
 ---
-title: "ECS Quickstart"
-description: "Stand up a complete AWS-compatible ECS stack on Spinifex with Terraform — a VPC, IAM roles, a cluster, a task definition with a task role, container instances launched from the ECS node image, and an awsvpc service fronted by an Application Load Balancer."
+title: "Terraform ECS Quickstart on Spinifex"
+description: "Stand up a full AWS-compatible ECS stack with Terraform: a VPC, IAM roles, a cluster, a task definition, container instances, and a load-balanced service."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/eks-gitops-argocd/README.md
+++ b/docs/terraform-workbooks/eks-gitops-argocd/README.md
@@ -1,5 +1,6 @@
 ---
-title: "GitOps on EKS with Argo CD and EBS-CSI"
+title: "GitOps on EKS (Argo CD + EBS-CSI)"
+seoTitle: "GitOps on EKS with Argo CD and EBS-CSI — Spinifex Docs"
 description: "Deliver an app to EKS with GitOps: the Argo CD addon syncs it from git, an EBS-CSI PersistentVolume holds its state, and HTTPS is served via LBC and ACM."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/eks-gitops-argocd/README.md
+++ b/docs/terraform-workbooks/eks-gitops-argocd/README.md
@@ -1,6 +1,6 @@
 ---
-title: "GitOps on EKS (Argo CD + EBS-CSI)"
-description: "Deliver a Spinifex-themed app to EKS with GitOps — the Argo CD addon syncs it from a git repo, an EBS-CSI (Viperblock) PersistentVolume holds its state, and it is served over HTTPS through the AWS Load Balancer Controller + ACM, using Terraform on Spinifex."
+title: "GitOps on EKS with Argo CD and EBS-CSI"
+description: "Deliver an app to EKS with GitOps: the Argo CD addon syncs it from git, an EBS-CSI PersistentVolume holds its state, and HTTPS is served via LBC and ACM."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/eks-https-ingress/README.md
+++ b/docs/terraform-workbooks/eks-https-ingress/README.md
@@ -1,5 +1,6 @@
 ---
-title: "EKS HTTPS Ingress with LBC and ACM"
+title: "EKS HTTPS Ingress (LBC + ACM)"
+seoTitle: "EKS HTTPS Ingress with LBC and ACM — Spinifex Docs"
 description: "Serve a demo app over HTTPS on EKS using the AWS Load Balancer Controller addon and an ACM certificate, with an internet-facing ALB built from an Ingress."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/eks-https-ingress/README.md
+++ b/docs/terraform-workbooks/eks-https-ingress/README.md
@@ -1,6 +1,6 @@
 ---
-title: "EKS HTTPS Ingress (LBC + ACM)"
-description: "Serve a Spinifex-themed demo app over HTTPS on EKS using the AWS Load Balancer Controller addon and an ACM certificate — an internet-facing ALB provisioned from a Kubernetes Ingress, using Terraform on Spinifex."
+title: "EKS HTTPS Ingress with LBC and ACM"
+description: "Serve a demo app over HTTPS on EKS using the AWS Load Balancer Controller addon and an ACM certificate, with an internet-facing ALB built from an Ingress."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/eks-quickstart/README.md
+++ b/docs/terraform-workbooks/eks-quickstart/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Terraform EKS Quickstart on Spinifex"
+title: "EKS Quickstart"
+seoTitle: "Terraform EKS Quickstart on Spinifex — Spinifex Docs"
 description: "Stand up a minimal managed Kubernetes cluster with Terraform: a VPC, IAM roles, an EKS cluster, a worker node group, an ECR repository, and a demo web app."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/eks-quickstart/README.md
+++ b/docs/terraform-workbooks/eks-quickstart/README.md
@@ -1,6 +1,6 @@
 ---
-title: "EKS Quickstart"
-description: "Stand up a minimal managed-Kubernetes cluster and a browsable Spinifex-themed demo app — VPC, IAM roles, an EKS cluster, a one- or three-worker node group, an ECR repository, and a load-balanced web page — using Terraform on Spinifex."
+title: "Terraform EKS Quickstart on Spinifex"
+description: "Stand up a minimal managed Kubernetes cluster with Terraform: a VPC, IAM roles, an EKS cluster, a worker node group, an ECR repository, and a demo web app."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/nginx-alb/README.md
+++ b/docs/terraform-workbooks/nginx-alb/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Load-Balanced Nginx Behind an AWS ALB"
+title: "Nginx Web Server (Load Balanced)"
+seoTitle: "Load-Balanced Nginx Behind an AWS ALB — Spinifex Docs"
 description: "Deploy a VPC with two private EC2 instances running Nginx behind an internet-facing Application Load Balancer on Spinifex, using Terraform or OpenTofu."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/nginx-alb/README.md
+++ b/docs/terraform-workbooks/nginx-alb/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Nginx Web Server (Load Balanced)"
-description: "Deploy a VPC with two private EC2 instances running Nginx, fronted by an internet-facing ALB using Terraform on Spinifex."
+title: "Load-Balanced Nginx Behind an AWS ALB"
+description: "Deploy a VPC with two private EC2 instances running Nginx behind an internet-facing Application Load Balancer on Spinifex, using Terraform or OpenTofu."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/nginx-webserver/README.md
+++ b/docs/terraform-workbooks/nginx-webserver/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Terraform Nginx Web Server on Spinifex"
+title: "Nginx Web Server"
+seoTitle: "Terraform Nginx Web Server on Spinifex — Spinifex Docs"
 description: "Provision a VPC, public subnet, internet gateway, route table, security group, and an EC2 instance that installs and starts Nginx from cloud-init user-data."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/nginx-webserver/README.md
+++ b/docs/terraform-workbooks/nginx-webserver/README.md
@@ -1,6 +1,6 @@
 ---
-title: "Nginx Web Server"
-description: "Deploy a VPC with a public subnet and an EC2 instance running Nginx using Terraform on Spinifex."
+title: "Terraform Nginx Web Server on Spinifex"
+description: "Provision a VPC, public subnet, internet gateway, route table, security group, and an EC2 instance that installs and starts Nginx from cloud-init user-data."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/rds-quickstart/README.md
+++ b/docs/terraform-workbooks/rds-quickstart/README.md
@@ -1,6 +1,6 @@
 ---
-title: "RDS Quickstart (PostgreSQL)"
-description: "Stand up a managed PostgreSQL database on Spinifex with Terraform — a VPC, a DB subnet group, a parameter group, an aws_db_instance, and a client VM inside the VPC that connects to it with psql."
+title: "Terraform RDS PostgreSQL Quickstart"
+description: "Stand up a managed PostgreSQL database on Spinifex with Terraform: a VPC, DB subnet group, parameter group, aws_db_instance, and a client VM that runs psql."
 category: "Terraform Workbooks"
 tags:
   - terraform

--- a/docs/terraform-workbooks/rds-quickstart/README.md
+++ b/docs/terraform-workbooks/rds-quickstart/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Terraform RDS PostgreSQL Quickstart"
+title: "RDS Quickstart (PostgreSQL)"
+seoTitle: "Terraform RDS PostgreSQL Quickstart — Spinifex Docs"
 description: "Stand up a managed PostgreSQL database on Spinifex with Terraform: a VPC, DB subnet group, parameter group, aws_db_instance, and a client VM that runs psql."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/s3-webapp/README.md
+++ b/docs/terraform-workbooks/s3-webapp/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Terraform S3-Backed Flask Web App on EC2"
+title: "S3-Backed Web App"
+seoTitle: "Terraform S3-Backed Flask Web App on EC2 — Spinifex Docs"
 description: "Deploy a Flask file-sharing app on EC2 backed by S3 (Predastore) with Terraform, using an IAM instance profile and short-lived STS credentials from IMDS."
 category: "Terraform Workbooks"
 tags:

--- a/docs/terraform-workbooks/s3-webapp/README.md
+++ b/docs/terraform-workbooks/s3-webapp/README.md
@@ -1,6 +1,6 @@
 ---
-title: "S3-Backed Web App"
-description: "Deploy a Flask file-sharing web application backed by S3 (Predastore) using Terraform on Spinifex."
+title: "Terraform S3-Backed Flask Web App on EC2"
+description: "Deploy a Flask file-sharing app on EC2 backed by S3 (Predastore) with Terraform, using an IAM instance profile and short-lived STS credentials from IMDS."
 category: "Terraform Workbooks"
 tags:
   - terraform


### PR DESCRIPTION
## Summary

Bing Webmaster flags a title tag outside 50-60 characters and a meta description outside 150-160 characters. Every published doc was outside at least one of those bounds except the five under `identity/`.

The docs site (`mulga-docs`) generates its page metadata from the frontmatter in this repo, so the fix belongs here.

## Changes

**`description`** is rewritten on 39 docs to land in 150-160 characters. This field is meta-only, so nothing visible on the page moves.

**`seoTitle`** is a new optional field holding the verbatim `<title>` tag, 50-60 characters including the ` — Spinifex Docs` suffix. It is added to the same 39 docs.

`title` is left untouched. It renders as the page H1 and the sidebar and card labels, so tuning it for search would have lengthened the visible navigation instead. Splitting the two fields keeps the headings short and the title tag long.

## Companion change

`mulga-docs` needs the matching branch of the same name to read `seoTitle`; without it the generator ignores the field and falls back to `title` plus the site suffix. That branch is merged after this one, because CI there clones `dev` and regenerates the page data from it.

## Testing

The docs site was built against this branch and all 45 rendered pages were parsed: every `<title>` is 50-60 characters and every `<meta name="description">` is 150-160. Display titles were diffed against `origin/main` of the docs repo and are unchanged.

## Not covered

The five `identity/` docs already pass, but only because their `title` is itself a long SEO string that renders as a long H1 and sidebar label. Giving them short display titles plus a `seoTitle` would change visible text, so it is left for a follow-up.