### PR TITLE
fix: keep the RDS endpoint ENI alive across a DB instance replace

### DIFF
--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -52,6 +52,25 @@ func (d *Daemon) recordENIInstanceOwner(eniAccountID, eniID, instanceOwnerID str
 	}
 }
 
+// attachExtraENI attaches one pre-created extra ENI and, when the caller asked
+// for an explicit DeleteOnTermination, persists it onto the record. An ENI that
+// has to outlive its VM is only safe once that flag is stored, so a failed stamp
+// fails the attach rather than leaving a disposable NIC behind.
+func (d *Daemon) attachExtraENI(eniAccountID string, extra sysinstance.ExtraENIInput, instanceID string, deviceIndex int64) error {
+	if _, err := d.vpcService.AttachENI(eniAccountID, extra.ENIID, instanceID, deviceIndex); err != nil {
+		return err
+	}
+	if extra.DeleteOnTermination == nil {
+		return nil
+	}
+	if err := d.vpcService.UpdateENI(eniAccountID, extra.ENIID, func(r *handlers_ec2_vpc.ENIRecord) {
+		r.DeleteOnTermination = extra.DeleteOnTermination
+	}); err != nil {
+		return fmt.Errorf("set DeleteOnTermination on ENI %s: %w", extra.ENIID, err)
+	}
+	return nil
+}
+
 // LaunchSystemInstance creates and starts a system-managed VM (ELBv2 LB).
 // The VM is owned by the system account (GlobalAccountID), is not visible to
 // customer DescribeInstances calls, and always boots via direct kernel boot
@@ -160,7 +179,7 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 				// customer-VPC ENI) lives in its own account; the ENI record is
 				// account-keyed, so attach under extra.AccountID when set.
 				extraAccount := resolveENIAccount(extra.AccountID, eniAccountID)
-				if _, attachErr := d.vpcService.AttachENI(extraAccount, extra.ENIID, instance.ID, int64(idx+1)); attachErr != nil {
+				if attachErr := d.attachExtraENI(extraAccount, extra, instance.ID, int64(idx+1)); attachErr != nil {
 					slog.Error("LaunchSystemInstance: failed to attach extra ENI", "eniId", extra.ENIID, "instanceId", instance.ID, "err", attachErr)
 					d.cleanupFailedSystemInstance(instance, instanceType)
 					return nil, fmt.Errorf("attach extra ENI %s: %w", extra.ENIID, attachErr)
@@ -488,7 +507,7 @@ func (d *Daemon) launchAMISystemInstance(input *sysinstance.SystemInstanceInput)
 	for idx, extra := range input.ExtraENIs {
 		if d.vpcService != nil {
 			extraAccount := resolveENIAccount(extra.AccountID, input.AccountID)
-			if _, attachErr := d.vpcService.AttachENI(extraAccount, extra.ENIID, inst.ID, int64(idx+1)); attachErr != nil {
+			if attachErr := d.attachExtraENI(extraAccount, extra, inst.ID, int64(idx+1)); attachErr != nil {
 				slog.Error("launchAMISystemInstance: failed to attach extra ENI", "eniId", extra.ENIID, "instanceId", inst.ID, "err", attachErr)
 				d.vmMgr.MarkFailed(context.Background(), inst, "extra_eni_attach_failed")
 				return nil, fmt.Errorf("attach extra ENI %s: %w", extra.ENIID, attachErr)

--- a/spinifex/daemon/daemon_system_instance_test.go
+++ b/spinifex/daemon/daemon_system_instance_test.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_ec2_eip "github.com/mulgadc/spinifex/spinifex/handlers/ec2/eip"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/mulgadc/spinifex/spinifex/handlers/sysinstance"
 	"github.com/mulgadc/spinifex/spinifex/network/external"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
@@ -876,4 +878,51 @@ func TestReleaseSystemInstanceEIP_ReleasesEipServiceAllocation(t *testing.T) {
 	assert.Empty(t, inst.PublicIP, "instance public IP must be cleared")
 	assert.Empty(t, inst.PublicIPAllocID, "instance alloc ID must be cleared so externalIPAM teardown does not double-release")
 	assert.Empty(t, inst.PublicIPAssocID)
+}
+
+// --- attachExtraENI: DeleteOnTermination ---
+
+// TestAttachExtraENI_DeleteOnTerminationFalseSurvivesTerminate covers the RDS
+// replace: the customer/endpoint ENI is attached as an extra NIC and has to
+// outlive the VM, because a replacement launch resolves the endpoint by that
+// ENI ID. Without the explicit flag the terminate sweep deletes it and the
+// replacement fails with InvalidNetworkInterfaceID.NotFound.
+func TestAttachExtraENI_DeleteOnTerminationFalseSurvivesTerminate(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+
+	require.NoError(t, f.daemon.attachExtraENI(testAccountID, sysinstance.ExtraENIInput{
+		ENIID:               f.eniID,
+		DeleteOnTermination: aws.Bool(false),
+	}, f.vmInst.ID, 1))
+
+	rec, err := f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.NoError(t, err)
+	require.NotNil(t, rec.DeleteOnTermination, "the attach must stamp the flag, not leave the attach-time default")
+	assert.False(t, *rec.DeleteOnTermination)
+
+	require.NoError(t, newInstanceCleanerAdapter(f.daemon).DetachAndDeleteENI(f.vmInst))
+
+	rec, err = f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.NoError(t, err, "the endpoint ENI must survive the terminate half of a replace")
+	assert.Equal(t, "available", rec.Status, "it must be detached, so the replacement VM can re-attach it")
+	assert.Empty(t, rec.InstanceId)
+}
+
+// TestAttachExtraENI_NilDeleteOnTerminationStaysDisposable holds the ELBv2
+// multi-subnet ALB and EKS cross-account NLB extras at their current behaviour:
+// they carry no flag and are deleted with the VM.
+func TestAttachExtraENI_NilDeleteOnTerminationStaysDisposable(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+
+	require.NoError(t, f.daemon.attachExtraENI(testAccountID, sysinstance.ExtraENIInput{
+		ENIID: f.eniID,
+	}, f.vmInst.ID, 1))
+
+	require.NoError(t, newInstanceCleanerAdapter(f.daemon).DetachAndDeleteENI(f.vmInst))
+
+	_, err := f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.Error(t, err, "an extra ENI with no explicit flag stays disposable")
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceIDNotFound))
 }

--- a/spinifex/handlers/rds/launch.go
+++ b/spinifex/handlers/rds/launch.go
@@ -239,6 +239,10 @@ func LaunchDBInstanceVM(ctx context.Context, deps LaunchDeps, in LaunchInput) (o
 			ENIIP:     customerENI.ip,
 			SubnetID:  in.SubnetID,
 			AccountID: in.AccountID,
+			// The endpoint is the ENI's address, so it has to survive the
+			// terminate half of a replace the way the datadir volume does.
+			// A DeleteDBInstance deletes it explicitly once the VM is gone.
+			DeleteOnTermination: aws.Bool(false),
 		}},
 		UserData:              in.UserData,
 		IamInstanceProfileArn: in.IamInstanceProfileArn,

--- a/spinifex/handlers/rds/launch_test.go
+++ b/spinifex/handlers/rds/launch_test.go
@@ -598,6 +598,9 @@ func TestLaunchDBInstanceVMWiresBothNICs(t *testing.T) {
 		ENIIP:     out.CustomerENIIP,
 		SubnetID:  testDBSubnet,
 		AccountID: testCustomerAccount,
+		// The endpoint address lives on this NIC, so it has to survive the
+		// terminate half of a replace the way the datadir volume does.
+		DeleteOnTermination: aws.Bool(false),
 	}, in.ExtraENIs[0], "the extra NIC must carry the customer account, or the daemon updates the wrong ENI record")
 	assert.Equal(t, "#cloud-config\n", in.UserData)
 	assert.Equal(t, "arn:aws:iam::000000000000:instance-profile/rdsInstanceRole", in.IamInstanceProfileArn)

--- a/spinifex/handlers/sysinstance/launcher.go
+++ b/spinifex/handlers/sysinstance/launcher.go
@@ -100,6 +100,11 @@ type ExtraENIInput struct {
 	// LB VM lives in the system CP VPC but fronts a customer-VPC ENI). Empty
 	// falls back to the primary AccountID — back-compat for same-account extras.
 	AccountID string `json:"account_id,omitempty"`
+	// DeleteOnTermination stamps an explicit value on the attached ENI record,
+	// for an ENI that has to outlive the VM it is plugged into (an RDS endpoint
+	// ENI across a class-change replace). Nil keeps the attach-time default,
+	// which deletes the ENI with the VM.
+	DeleteOnTermination *bool `json:"delete_on_termination,omitempty"`
 }
 
 // NICConfig describes a single network interface for a BootDirect microVM.


### PR DESCRIPTION
## Summary

A class-change `ModifyDBInstance`, or an auto-recovery replace, terminates the DB VM and launches a replacement against the same endpoint ENI and the same data volume. The data volume survived that terminate because it carries `DeleteOnTermination=false`. The endpoint ENI did not.

The ENI is attached as a `sysinstance` extra NIC, and `ExtraENIInput` had no field to express the flag, so `attachENI` stamped its default of `true` and the terminate sweep deleted the ENI along with the VM. `launchReplacementVM` then called `resolveCustomerENI` against an ID that no longer existed, the replace failed with `InvalidNetworkInterfaceID.NotFound`, and the DB instance lost the address its DNS record and serving cert name.

Observed on wattle at 2026-08-17 15:20 for `ochre-vector-pg`: `"Deleted attached ENI on termination" eni-f420bbbc55d4d0e44` at 15:20:13, then `"launch the replacement VM ...: read the endpoint ENI eni-f420bbbc55d4d0e44: InvalidNetworkInterfaceID.NotFound"`. The corpus on `vol-1c269dea076706d9a` was preserved and detached, which is exactly the behaviour the ENI should have had.

The mechanism to fix this was already in place and already tested — `releaseAttachedENIs` honours `DeleteOnTermination=false` by detaching only, covered by `TestInstanceCleanerAdapter_DetachAndDeleteENI_DeleteOnTerminationFalseDetachesOnly`. The endpoint ENI simply had no way to opt in.

## Changes

**`ExtraENIInput` gains `DeleteOnTermination *bool`.** Nil means "leave the attach-time default alone", so every existing caller keeps its current behaviour: the ELBv2 multi-subnet ALB extras built by `buildExtraENIInputs` and the EKS cross-account NLB extras both stay disposable, and the recovery path that rebuilds those inputs from `DescribeNetworkInterfaces` continues to produce nil.

**A single `attachExtraENI` helper on the daemon** does the attach and, on a non-nil flag, persists it onto the `ENIRecord` through the existing `VPCServiceImpl.UpdateENI`. Both extras loops route through it — the `BootDirect` branch in `LaunchSystemInstance` and the `BootAMI` branch in `launchAMISystemInstance`, which is the one RDS uses. A failed stamp fails the launch the same way a failed attach already does: an ENI that has to outlive its VM is only safe once the flag is stored, and warning-and-continuing there would silently reproduce this bug.

**RDS attaches the customer NIC with `false`.** The system NIC stays disposable — it is the primary interface, a replace mints a fresh one, and `replace.go` deletes the old one. Deleting the endpoint ENI on a real `DeleteDBInstance` is still correct and still happens: `delete.go` deletes both ENIs explicitly via `deleteLaunchENI` once the VM is gone, independently of the terminate sweep.

`attachENI` already preserves an explicit value across a re-attach, so the flag set on the first launch also survives host-reboot recovery and the replace's own re-attach — it does not need re-stamping per launch, though the RDS path stamps it anyway so a record written before this change is corrected by the next replace.

## Testing

Two new daemon tests exercise `attachExtraENI` against a real `VPCServiceImpl` and then run the terminate sweep, which is the sysinstance/RDS boundary the bug lives on. The ENI attached with `false` comes back `available` with an empty `InstanceId`, ready for the replacement VM to re-attach; an extra attached with a nil flag comes back `InvalidNetworkInterfaceID.NotFound`, holding the ELBv2 and EKS behaviour where it was. `TestLaunchDBInstanceVMWiresBothNICs` now pins the flag on the RDS customer extra.

`make preflight` passes.

## Not covered

Recovering the already-orphaned `ochre-vector-pg`, whose `rec.ENIID` still points at the deleted ENI. This change stops new occurrences but does not repair that record. The corpus is safe on `vol-1c269dea076706d9a`, and the recovery needs its own bead.