### PR TITLE
fix: authorize RDS snapshot source and target

### DIFF
--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -1971,7 +1971,7 @@ func setupPolicyResourceTestHandler(gw *GatewayConfig, service, action, resource
 	r := chi.NewRouter()
 	r.Use(gw.SigV4AuthMiddleware())
 	r.HandleFunc("/*", func(w http.ResponseWriter, req *http.Request) {
-		if err := gw.checkPolicyResource(req, service, action, resource); err != nil {
+		if err := gw.checkPolicyResources(req, service, action, []string{resource}); err != nil {
 			gw.ErrorHandler(w, req, err)
 			return
 		}

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -126,7 +126,7 @@ var ec2Actions = map[string]EC2Handler{
 	}),
 	"RunInstances": ec2HandlerWithReq(func(ctx context.Context, input *ec2.RunInstancesInput, gw *GatewayConfig, accountID string, r *http.Request) (any, error) {
 		passRoleCheck := func(roleARN string) error {
-			return gw.checkPolicyResource(r, "iam", "PassRole", roleARN)
+			return gw.checkPolicyResources(r, "iam", "PassRole", []string{roleARN})
 		}
 		launchQuotaCheck := func() error {
 			return gw.Quota.EnforceLaunch(ctx, accountID, aws.StringValue(input.InstanceType), int(aws.Int64Value(input.MaxCount)))
@@ -144,7 +144,7 @@ var ec2Actions = map[string]EC2Handler{
 	}),
 	"AssociateIamInstanceProfile": ec2HandlerWithReq(func(ctx context.Context, input *ec2.AssociateIamInstanceProfileInput, gw *GatewayConfig, accountID string, r *http.Request) (any, error) {
 		passRoleCheck := func(roleARN string) error {
-			return gw.checkPolicyResource(r, "iam", "PassRole", roleARN)
+			return gw.checkPolicyResources(r, "iam", "PassRole", []string{roleARN})
 		}
 		return gateway_ec2_instance.AssociateIamInstanceProfile(ctx, input, gw.NATSConn, gw.IAMService, accountID, passRoleCheck)
 	}),
@@ -153,7 +153,7 @@ var ec2Actions = map[string]EC2Handler{
 	}),
 	"ReplaceIamInstanceProfileAssociation": ec2HandlerWithReq(func(ctx context.Context, input *ec2.ReplaceIamInstanceProfileAssociationInput, gw *GatewayConfig, accountID string, r *http.Request) (any, error) {
 		passRoleCheck := func(roleARN string) error {
-			return gw.checkPolicyResource(r, "iam", "PassRole", roleARN)
+			return gw.checkPolicyResources(r, "iam", "PassRole", []string{roleARN})
 		}
 		return gateway_ec2_instance.ReplaceIamInstanceProfileAssociation(ctx, input, gw.NATSConn, gw.IAMService, gw.DiscoverActiveNodes(ctx), accountID, passRoleCheck)
 	}),
@@ -399,7 +399,7 @@ var ec2Actions = map[string]EC2Handler{
 	}),
 	"RequestSpotInstances": ec2HandlerWithReq(func(ctx context.Context, input *ec2.RequestSpotInstancesInput, gw *GatewayConfig, accountID string, r *http.Request) (any, error) {
 		passRoleCheck := func(roleARN string) error {
-			return gw.checkPolicyResource(r, "iam", "PassRole", roleARN)
+			return gw.checkPolicyResources(r, "iam", "PassRole", []string{roleARN})
 		}
 		return gateway_ec2_spotinstance.RequestSpotInstances(ctx, input, gw.NATSConn, gw.IAMService, accountID, gw.AZ, passRoleCheck, gw.Quota, gw.ExpectedNodes)
 	}),

--- a/spinifex/gateway/ecr_authorization.go
+++ b/spinifex/gateway/ecr_authorization.go
@@ -53,7 +53,9 @@ func (gw *GatewayConfig) ecrOperationAuthorization(next http.Handler) http.Handl
 				gateway_ecr.WriteError(w, http.StatusServiceUnavailable, "UNKNOWN", "authorization unavailable")
 				return
 			}
-			if err := gw.evaluatePrincipalPolicy(principal, policy.IAMAction("ecr", req.Action), resource); err != nil {
+			if err := gw.evaluatePrincipalPolicyResources(
+				principal, policy.IAMAction("ecr", req.Action), []string{resource},
+			); err != nil {
 				if err.Error() == awserrors.ErrorInternalError {
 					// IAM/STS/NATS dependency failure: fail closed, never dispatch.
 					gateway_ecr.WriteError(w, http.StatusServiceUnavailable, "UNKNOWN", "authorization unavailable")

--- a/spinifex/gateway/ecs.go
+++ b/spinifex/gateway/ecs.go
@@ -56,7 +56,7 @@ func (gw *GatewayConfig) ECS_Request(w http.ResponseWriter, r *http.Request) err
 	// enforce iam:PassRole against the caller's identity on this request, for
 	// whichever role ARN the action later resolves.
 	passRoleCheck := func(roleARN string) error {
-		return gw.checkPolicyResource(r, "iam", "PassRole", roleARN)
+		return gw.checkPolicyResources(r, "iam", "PassRole", []string{roleARN})
 	}
 
 	output, err := handler(r.Context(), gw.NATSConn, accountID, body, passRoleCheck)

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -515,21 +515,15 @@ func isNATSTransient(err error) bool {
 }
 
 // checkPolicy evaluates IAM policies against resource "*".
-// Shorthand for checkPolicyResource(r, service, action, "*").
 func (gw *GatewayConfig) checkPolicy(r *http.Request, service, action string) error {
-	return gw.checkPolicyResource(r, service, action, "*")
+	return gw.checkPolicyResources(r, service, action, []string{"*"})
 }
 
-// checkPolicyResource evaluates IAM policies against a specific resource ARN.
-// Root users bypass evaluation. A nil IAMService is a server fault and an
-// unauthenticated request is denied — neither can reach a gated handler through
-// the route tree. Used by EC2 paths that enforce iam:PassRole before attaching
-// an instance profile.
-func (gw *GatewayConfig) checkPolicyResource(r *http.Request, service, action, resource string) error {
+// checkPolicyResources evaluates every resource against one resolved policy
+// snapshot. Used when one API request authorizes multiple resource ARNs.
+func (gw *GatewayConfig) checkPolicyResources(r *http.Request, service, action string, resources []string) error {
 	// Every dispatcher — query-protocol and REST-JSON alike — reaches this
-	// point with its resolved action, so telemetry enrichment lives here
-	// rather than duplicated per REST-JSON handler. Runs before the IAM
-	// checks below so it still fires when IAM is unconfigured.
+	// point with its resolved action, so telemetry enrichment lives here.
 	recordResolvedAction(r.Context(), service, action)
 
 	if gw.IAMService == nil {
@@ -566,7 +560,7 @@ func (gw *GatewayConfig) checkPolicyResource(r *http.Request, service, action, r
 		assumedRoleID:     mustCtxString(r, ctxAssumedRoleID),
 		underlyingRoleARN: mustCtxString(r, ctxUnderlyingRoleARN),
 	}
-	return gw.evaluatePrincipalPolicy(principal, policy.IAMAction(service, action), resource)
+	return gw.evaluatePrincipalPolicyResources(principal, policy.IAMAction(service, action), resources)
 }
 
 // mustCtxString reads a string context value, defaulting to "" for an absent
@@ -576,12 +570,11 @@ func mustCtxString(r *http.Request, key contextKey) string {
 	return v
 }
 
-// evaluatePrincipalPolicy is the request-shape-independent core of policy
-// enforcement: given an already-resolved principal (from SigV4 or, for /v2/*
-// ECR requests, a freshly rehydrated token identity), it resolves the
-// principal's current policies and evaluates iamAction against resource.
-// A nil IAMService fails closed here, matching checkPolicyResource.
-func (gw *GatewayConfig) evaluatePrincipalPolicy(principal principalContext, iamAction, resource string) error {
+// evaluatePrincipalPolicyResources resolves policies once and evaluates every
+// resource in the request against that same snapshot.
+func (gw *GatewayConfig) evaluatePrincipalPolicyResources(
+	principal principalContext, iamAction string, resources []string,
+) error {
 	if gw.IAMService == nil {
 		slog.Error("evaluatePrincipalPolicy: IAM service not available", "action", iamAction)
 		return errors.New(awserrors.ErrorInternalError)
@@ -644,11 +637,13 @@ func (gw *GatewayConfig) evaluatePrincipalPolicy(principal principalContext, iam
 		return errors.New(awserrors.ErrorInternalError)
 	}
 
-	if iampolicy.Evaluate(iamAction, resource, policies) == iampolicy.Deny {
-		slog.Info("evaluatePrincipalPolicy: access denied", "identity", logIdentity, "action", iamAction, "resource", resource)
-		return errors.New(awserrors.ErrorAccessDenied)
+	for _, resource := range resources {
+		if iampolicy.Evaluate(iamAction, resource, policies) == iampolicy.Deny {
+			slog.Info("evaluatePrincipalPolicy: access denied",
+				"identity", logIdentity, "action", iamAction, "resource", resource)
+			return errors.New(awserrors.ErrorAccessDenied)
+		}
 	}
-
 	return nil
 }
 

--- a/spinifex/gateway/gateway_test.go
+++ b/spinifex/gateway/gateway_test.go
@@ -1122,8 +1122,8 @@ func TestCheckPolicy_PassRoleFailsClosed(t *testing.T) {
 	gw := &GatewayConfig{DisableLogging: true, IAMService: allowAllIAMService()}
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 
-	err := gw.checkPolicyResource(req, "iam", "PassRole",
-		"arn:aws:iam::123456789012:role/app")
+	err := gw.checkPolicyResources(req, "iam", "PassRole",
+		[]string{"arn:aws:iam::123456789012:role/app"})
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
 }

--- a/spinifex/gateway/rds.go
+++ b/spinifex/gateway/rds.go
@@ -42,12 +42,14 @@ func (gw *GatewayConfig) RDS_Request(w http.ResponseWriter, r *http.Request) err
 		return err
 	}
 
-	resource, err := gateway_rds.ResourceARN(action, gw.Region, caller.AccountID, queryArgs)
+	resources, err := gateway_rds.ResourceARN(action, gw.Region, caller.AccountID, queryArgs)
 	if err != nil {
 		return err
 	}
-	if err := gw.checkPolicyResource(r, "rds", action, resource); err != nil {
-		return err
+	for _, resource := range resources {
+		if err := gw.checkPolicyResource(r, "rds", action, resource); err != nil {
+			return err
+		}
 	}
 
 	if gw.NATSConn == nil {

--- a/spinifex/gateway/rds.go
+++ b/spinifex/gateway/rds.go
@@ -46,10 +46,8 @@ func (gw *GatewayConfig) RDS_Request(w http.ResponseWriter, r *http.Request) err
 	if err != nil {
 		return err
 	}
-	for _, resource := range resources {
-		if err := gw.checkPolicyResource(r, "rds", action, resource); err != nil {
-			return err
-		}
+	if err := gw.checkPolicyResources(r, "rds", action, resources); err != nil {
+		return err
 	}
 
 	if gw.NATSConn == nil {

--- a/spinifex/gateway/rds/authz.go
+++ b/spinifex/gateway/rds/authz.go
@@ -15,9 +15,8 @@ import (
 // address.
 const anyResource = "*"
 
-// Which query parameter names the single resource an action acts on, and the ARN
-// type it resolves to. An action naming no resource, or more than one, carries no
-// scope at all.
+// Which query parameter names a resource an action acts on, and the ARN type it
+// resolves to. Actions carry one scope for each resource IAM evaluates.
 type resourceScope struct {
 	param string
 	// Empty when param already carries a full ARN — the tag actions — which is
@@ -62,33 +61,39 @@ func requireAgentPrincipal(ctx context.Context, caller Caller) error {
 	return nil
 }
 
-// ResourceARN builds the resource the action's policy check evaluates against. A
+// ResourceARN builds every resource the action's policy checks evaluate. A
 // policy written for arn:aws:rds:*:*:db:prod-* but checked against "*" would
 // permit every instance in the account, which is worse than no policy at all.
-func ResourceARN(action, region, accountID string, q map[string]string) (string, error) {
+func ResourceARN(action, region, accountID string, q map[string]string) ([]string, error) {
 	def, ok := actions[action]
 	// Rejected here too, not just by the dispatcher: a caller that skipped the
 	// action check must not get a resource back for rds:<garbage>.
 	if !ok {
-		return "", errors.New(awserrors.ErrorInvalidAction)
+		return nil, errors.New(awserrors.ErrorInvalidAction)
 	}
-	if def.scope == nil {
-		return anyResource, nil
+	if len(def.scopes) == 0 {
+		return []string{anyResource}, nil
 	}
-	identifier := q[def.scope.param]
-	// An absent identifier is a validation fault the handler reports precisely;
-	// answering it with a denial here would hide the real reason.
-	if identifier == "" {
-		return anyResource, nil
-	}
-	if def.scope.kind == "" {
-		// Parsed rather than passed through, so a foreign account or region is an
-		// InvalidParameterValue before the evaluator sees it: cross-account sharing
-		// is out of v1, and a permissive parser is how it arrives anyway.
-		if _, err := handlers_rds.ParseARN(identifier, region, accountID); err != nil {
-			return "", err
+
+	resources := make([]string, 0, len(def.scopes))
+	for _, scope := range def.scopes {
+		identifier := q[scope.param]
+		// A missing member contributes "*" independently. It remains the handler's
+		// validation fault rather than becoming an ARN resolution failure here.
+		if identifier == "" {
+			resources = append(resources, anyResource)
+			continue
 		}
-		return identifier, nil
+		if scope.kind == "" {
+			// Parsed rather than passed through, so a foreign account or region is an
+			// InvalidParameterValue before the evaluator sees it.
+			if _, err := handlers_rds.ParseARN(identifier, region, accountID); err != nil {
+				return nil, err
+			}
+			resources = append(resources, identifier)
+			continue
+		}
+		resources = append(resources, handlers_rds.FormatARN(scope.kind, region, accountID, identifier))
 	}
-	return handlers_rds.FormatARN(def.scope.kind, region, accountID, identifier), nil
+	return resources, nil
 }

--- a/spinifex/gateway/rds/authz_test.go
+++ b/spinifex/gateway/rds/authz_test.go
@@ -108,13 +108,6 @@ func TestResourceARN_ScopesSingleResourceActions(t *testing.T) {
 			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db"},
 		{"DeleteDBSnapshot", map[string]string{"DBSnapshotIdentifier": "orders-db-pre-upgrade"},
 			"arn:aws:rds:ap-southeast-2:123456789012:snapshot:orders-db-pre-upgrade"},
-		// Both name a source and a target; each is scoped to its source.
-		{"CreateDBSnapshot", map[string]string{
-			"DBInstanceIdentifier": "orders-db", "DBSnapshotIdentifier": "orders-db-pre-upgrade"},
-			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db"},
-		{"RestoreDBInstanceFromDBSnapshot", map[string]string{
-			"DBInstanceIdentifier": "orders-db-restored", "DBSnapshotIdentifier": "orders-db-pre-upgrade"},
-			"arn:aws:rds:ap-southeast-2:123456789012:snapshot:orders-db-pre-upgrade"},
 		{"DeleteDBSubnetGroup", map[string]string{"DBSubnetGroupName": "db-private"},
 			"arn:aws:rds:ap-southeast-2:123456789012:subgrp:db-private"},
 		{"ModifyDBParameterGroup", map[string]string{"DBParameterGroupName": "pg16-tuned"},
@@ -127,6 +120,32 @@ func TestResourceARN_ScopesSingleResourceActions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.action, func(t *testing.T) {
 			got, err := ResourceARN(tt.action, testRegion, testAccountID, tt.params)
+			require.NoError(t, err)
+			assert.Equal(t, []string{tt.want}, got)
+		})
+	}
+}
+
+func TestResourceARN_ScopesSnapshotActionsToSourceAndTarget(t *testing.T) {
+	tests := []struct {
+		action string
+		want   []string
+	}{
+		{"CreateDBSnapshot", []string{
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db",
+			"arn:aws:rds:ap-southeast-2:123456789012:snapshot:orders-db-pre-upgrade",
+		}},
+		{"RestoreDBInstanceFromDBSnapshot", []string{
+			"arn:aws:rds:ap-southeast-2:123456789012:snapshot:orders-db-pre-upgrade",
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db",
+		}},
+	}
+	params := map[string]string{
+		"DBInstanceIdentifier": "orders-db", "DBSnapshotIdentifier": "orders-db-pre-upgrade",
+	}
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			got, err := ResourceARN(tt.action, testRegion, testAccountID, params)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -153,7 +172,7 @@ func TestResourceARN_UnscopedActions(t *testing.T) {
 				"DBSnapshotIdentifier": "orders-db-pre-upgrade",
 			})
 			require.NoError(t, err)
-			assert.Equal(t, anyResource, got)
+			assert.Equal(t, []string{anyResource}, got)
 		})
 	}
 }
@@ -196,9 +215,15 @@ func TestResourceARN_ResourceScopedDenyReachesTheSnapshotActions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resource, err := ResourceARN(tt.action, testRegion, testAccountID, tt.params)
+			resources, err := ResourceARN(tt.action, testRegion, testAccountID, tt.params)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, iampolicy.Evaluate(policy.IAMAction("rds", tt.action), resource, policies))
+			got := iampolicy.Allow
+			for _, resource := range resources {
+				if iampolicy.Evaluate(policy.IAMAction("rds", tt.action), resource, policies) == iampolicy.Deny {
+					got = iampolicy.Deny
+				}
+			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -211,7 +236,7 @@ func TestResourceARN_TagActionsUseTheSuppliedARN(t *testing.T) {
 		t.Run(action, func(t *testing.T) {
 			got, err := ResourceARN(action, testRegion, testAccountID, map[string]string{"ResourceName": arn})
 			require.NoError(t, err)
-			assert.Equal(t, arn, got)
+			assert.Equal(t, []string{arn}, got)
 		})
 	}
 }
@@ -237,16 +262,30 @@ func TestResourceARN_RejectsUnusableARNs(t *testing.T) {
 	}
 }
 
-// A missing identifier is the handler's validation fault to report. Answering it
-// with a denial here would tell the caller the wrong thing about their policy.
-func TestResourceARN_MissingIdentifierFallsBackToAnyResource(t *testing.T) {
-	for _, action := range []string{
-		"DeleteDBInstance", "DescribeDBParameters", "ListTagsForResource",
-		"CreateDBSnapshot", "RestoreDBInstanceFromDBSnapshot",
-	} {
-		got, err := ResourceARN(action, testRegion, testAccountID, map[string]string{})
-		require.NoError(t, err, "action %q", action)
-		assert.Equal(t, anyResource, got, "action %q", action)
+// A missing identifier is the handler's validation fault to report. Each absent
+// member contributes "*" instead of failing ARN resolution.
+func TestResourceARN_MissingIdentifierFallsBackToAnyResourcePerMember(t *testing.T) {
+	tests := []struct {
+		action string
+		params map[string]string
+		want   []string
+	}{
+		{"DeleteDBInstance", nil, []string{anyResource}},
+		{"DescribeDBParameters", nil, []string{anyResource}},
+		{"ListTagsForResource", nil, []string{anyResource}},
+		{"CreateDBSnapshot", map[string]string{"DBInstanceIdentifier": "orders-db"}, []string{
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db", anyResource,
+		}},
+		{"RestoreDBInstanceFromDBSnapshot", map[string]string{"DBSnapshotIdentifier": "orders-db-snapshot"}, []string{
+			"arn:aws:rds:ap-southeast-2:123456789012:snapshot:orders-db-snapshot", anyResource,
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			got, err := ResourceARN(tt.action, testRegion, testAccountID, tt.params)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 

--- a/spinifex/gateway/rds/handler.go
+++ b/spinifex/gateway/rds/handler.go
@@ -75,8 +75,8 @@ func typed[In any](handler func(context.Context, *In, *nats.Conn, Caller) (any, 
 }
 
 // One entry per action: what serves it, whether it is agent-only, and which
-// resource its policy check evaluates against. Both authorization facts live on
-// the table so a new action cannot be added without deciding either.
+// resources its policy checks evaluate against. Both authorization facts live
+// here so a new action cannot be added without deciding either.
 type actionDef struct {
 	handler Handler
 	// Agent-only: refused to every customer principal by class, before any
@@ -87,7 +87,7 @@ type actionDef struct {
 	unsupported bool
 	// nil evaluates against "*", which is right for creates and for describes
 	// that filter rather than address one resource.
-	scope *resourceScope
+	scopes []*resourceScope
 }
 
 // The whole namespace is registered from day one, so an action outside v1 stays
@@ -96,19 +96,20 @@ var actions = map[string]actionDef{
 	// Instance lifecycle.
 	"CreateDBInstance":    {handler: typed(CreateDBInstance)},
 	"DescribeDBInstances": {handler: typed(DescribeDBInstances)},
-	"ModifyDBInstance":    {handler: typed(ModifyDBInstance), scope: dbInstanceScope},
-	"DeleteDBInstance":    {handler: typed(DeleteDBInstance), scope: dbInstanceScope},
-	"RebootDBInstance":    {handler: typed(RebootDBInstance), scope: dbInstanceScope},
-	"StartDBInstance":     {handler: typed(StartDBInstance), scope: dbInstanceScope},
-	"StopDBInstance":      {handler: typed(StopDBInstance), scope: dbInstanceScope},
+	"ModifyDBInstance":    {handler: typed(ModifyDBInstance), scopes: []*resourceScope{dbInstanceScope}},
+	"DeleteDBInstance":    {handler: typed(DeleteDBInstance), scopes: []*resourceScope{dbInstanceScope}},
+	"RebootDBInstance":    {handler: typed(RebootDBInstance), scopes: []*resourceScope{dbInstanceScope}},
+	"StartDBInstance":     {handler: typed(StartDBInstance), scopes: []*resourceScope{dbInstanceScope}},
+	"StopDBInstance":      {handler: typed(StopDBInstance), scopes: []*resourceScope{dbInstanceScope}},
 
-	// Snapshots. A create and a restore each name two resources, and both are
-	// scoped to the source: a deny written on an instance has to stop it being
-	// snapshotted, and a deny on a snapshot has to stop it being restored.
-	"CreateDBSnapshot":                {handler: typed(CreateDBSnapshot), scope: dbInstanceScope},
-	"DescribeDBSnapshots":             {handler: typed(DescribeDBSnapshots)},
-	"DeleteDBSnapshot":                {handler: typed(DeleteDBSnapshot), scope: dbSnapshotScope},
-	"RestoreDBInstanceFromDBSnapshot": {handler: typed(RestoreDBInstanceFromDBSnapshot), scope: dbSnapshotScope},
+	// Snapshot creates and restores evaluate both the source and target. A deny
+	// on either resource must block the operation.
+	"CreateDBSnapshot": {handler: typed(CreateDBSnapshot),
+		scopes: []*resourceScope{dbInstanceScope, dbSnapshotScope}},
+	"DescribeDBSnapshots": {handler: typed(DescribeDBSnapshots)},
+	"DeleteDBSnapshot":    {handler: typed(DeleteDBSnapshot), scopes: []*resourceScope{dbSnapshotScope}},
+	"RestoreDBInstanceFromDBSnapshot": {handler: typed(RestoreDBInstanceFromDBSnapshot),
+		scopes: []*resourceScope{dbSnapshotScope, dbInstanceScope}},
 
 	// Automated backups.
 	"DescribeDBInstanceAutomatedBackups": {handler: typed(DescribeDBInstanceAutomatedBackups)},
@@ -116,21 +117,24 @@ var actions = map[string]actionDef{
 	// Subnet groups.
 	"CreateDBSubnetGroup":    {handler: typed(CreateDBSubnetGroup)},
 	"DescribeDBSubnetGroups": {handler: typed(DescribeDBSubnetGroups)},
-	"DeleteDBSubnetGroup":    {handler: typed(DeleteDBSubnetGroup), scope: dbSubnetGroupScope},
+	"DeleteDBSubnetGroup":    {handler: typed(DeleteDBSubnetGroup), scopes: []*resourceScope{dbSubnetGroupScope}},
 
 	// Parameter groups. DescribeDBParameters is scoped despite being a describe:
 	// its parameter group is required and singular, so it addresses one resource.
 	"CreateDBParameterGroup":    {handler: typed(CreateDBParameterGroup)},
 	"DescribeDBParameterGroups": {handler: typed(DescribeDBParameterGroups)},
-	"ModifyDBParameterGroup":    {handler: typed(ModifyDBParameterGroup), scope: dbParameterGroupScope},
-	"DescribeDBParameters":      {handler: typed(DescribeDBParameters), scope: dbParameterGroupScope},
-	"DeleteDBParameterGroup":    {handler: typed(DeleteDBParameterGroup), scope: dbParameterGroupScope},
+	"ModifyDBParameterGroup": {handler: typed(ModifyDBParameterGroup),
+		scopes: []*resourceScope{dbParameterGroupScope}},
+	"DescribeDBParameters": {handler: typed(DescribeDBParameters),
+		scopes: []*resourceScope{dbParameterGroupScope}},
+	"DeleteDBParameterGroup": {handler: typed(DeleteDBParameterGroup),
+		scopes: []*resourceScope{dbParameterGroupScope}},
 
 	// Tags. The request names its resource by ARN, so the scope validates one
 	// rather than building it.
-	"AddTagsToResource":      {handler: typed(AddTagsToResource), scope: taggedResourceScope},
-	"RemoveTagsFromResource": {handler: typed(RemoveTagsFromResource), scope: taggedResourceScope},
-	"ListTagsForResource":    {handler: typed(ListTagsForResource), scope: taggedResourceScope},
+	"AddTagsToResource":      {handler: typed(AddTagsToResource), scopes: []*resourceScope{taggedResourceScope}},
+	"RemoveTagsFromResource": {handler: typed(RemoveTagsFromResource), scopes: []*resourceScope{taggedResourceScope}},
+	"ListTagsForResource":    {handler: typed(ListTagsForResource), scopes: []*resourceScope{taggedResourceScope}},
 
 	// Events. The ring is per-account and a filter names no single resource.
 	"DescribeEvents": {handler: typed(DescribeEvents)},

--- a/spinifex/gateway/rds_test.go
+++ b/spinifex/gateway/rds_test.go
@@ -231,10 +231,31 @@ func TestRDSRequest_SnapshotActionsAuthorizeSourceAndTarget(t *testing.T) {
 			gw, probe := newRDSPolicyGateway(policies)
 			err := gw.RDS_Request(httptest.NewRecorder(), setupRDSUserRequest(tt.query, rdsTestAccountID))
 			require.Error(t, err)
-			assert.Equal(t, 2, probe.consulted)
+			assert.Equal(t, 1, probe.consulted)
 			assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 		})
 	}
+}
+
+func TestRDSRequest_SnapshotActionsUseOnePolicySnapshot(t *testing.T) {
+	source := handlers_rds.DBInstanceARN("ap-southeast-2", rdsTestAccountID, "orders-db")
+	target := handlers_rds.DBSnapshotARN("ap-southeast-2", rdsTestAccountID, "orders-db-nightly")
+	resolution := 0
+	gw, probe := newRDSGatewayWithResolver(func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		resolution++
+		if resolution == 1 {
+			return allowPolicyResource("rds:CreateDBSnapshot", source), nil
+		}
+		return allowPolicyResource("rds:CreateDBSnapshot", target), nil
+	})
+
+	err := gw.RDS_Request(httptest.NewRecorder(), setupRDSUserRequest(
+		"Action=CreateDBSnapshot&DBInstanceIdentifier=orders-db&DBSnapshotIdentifier=orders-db-nightly",
+		rdsTestAccountID,
+	))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+	assert.Equal(t, 1, probe.consulted)
 }
 
 func TestRDSRequest_SnapshotActionsHonorTargetDeny(t *testing.T) {
@@ -269,7 +290,7 @@ func TestRDSRequest_SnapshotActionsHonorTargetDeny(t *testing.T) {
 			gw, probe := newRDSPolicyGateway(policies)
 			err := gw.RDS_Request(httptest.NewRecorder(), setupRDSUserRequest(tt.query, rdsTestAccountID))
 			require.Error(t, err)
-			assert.Equal(t, 2, probe.consulted)
+			assert.Equal(t, 1, probe.consulted)
 			assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
 		})
 	}

--- a/spinifex/gateway/rds_test.go
+++ b/spinifex/gateway/rds_test.go
@@ -192,6 +192,89 @@ func TestRDSRequest_ResourceScopedPolicyRestrictsByIdentifier(t *testing.T) {
 	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
 }
 
+func TestRDSRequest_SnapshotActionsAuthorizeSourceAndTarget(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    string
+		query     string
+		resources handlers_iam.StringOrArr
+	}{
+		{
+			name:   "create snapshot",
+			action: "rds:CreateDBSnapshot",
+			query: "Action=CreateDBSnapshot&DBInstanceIdentifier=orders-db" +
+				"&DBSnapshotIdentifier=orders-db-nightly",
+			resources: handlers_iam.StringOrArr{
+				handlers_rds.DBInstanceARN("ap-southeast-2", rdsTestAccountID, "orders-db"),
+				handlers_rds.DBSnapshotARN("ap-southeast-2", rdsTestAccountID, "orders-db-nightly"),
+			},
+		},
+		{
+			name:   "restore snapshot",
+			action: "rds:RestoreDBInstanceFromDBSnapshot",
+			query: "Action=RestoreDBInstanceFromDBSnapshot&DBSnapshotIdentifier=orders-db-nightly" +
+				"&DBInstanceIdentifier=orders-db-restored",
+			resources: handlers_iam.StringOrArr{
+				handlers_rds.DBSnapshotARN("ap-southeast-2", rdsTestAccountID, "orders-db-nightly"),
+				handlers_rds.DBInstanceARN("ap-southeast-2", rdsTestAccountID, "orders-db-restored"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policies := []handlers_iam.PolicyDocument{{
+				Version: "2012-10-17",
+				Statement: []handlers_iam.Statement{{
+					Effect: "Allow", Action: handlers_iam.StringOrArr{tt.action}, Resource: tt.resources,
+				}},
+			}}
+			gw, probe := newRDSPolicyGateway(policies)
+			err := gw.RDS_Request(httptest.NewRecorder(), setupRDSUserRequest(tt.query, rdsTestAccountID))
+			require.Error(t, err)
+			assert.Equal(t, 2, probe.consulted)
+			assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+		})
+	}
+}
+
+func TestRDSRequest_SnapshotActionsHonorTargetDeny(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		query  string
+		target string
+	}{
+		{
+			name: "create snapshot", action: "rds:CreateDBSnapshot",
+			query: "Action=CreateDBSnapshot&DBInstanceIdentifier=orders-db" +
+				"&DBSnapshotIdentifier=orders-db-nightly",
+			target: handlers_rds.DBSnapshotARN("ap-southeast-2", rdsTestAccountID, "orders-db-nightly"),
+		},
+		{
+			name: "restore snapshot", action: "rds:RestoreDBInstanceFromDBSnapshot",
+			query: "Action=RestoreDBInstanceFromDBSnapshot&DBSnapshotIdentifier=orders-db-nightly" +
+				"&DBInstanceIdentifier=orders-db-restored",
+			target: handlers_rds.DBInstanceARN("ap-southeast-2", rdsTestAccountID, "orders-db-restored"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policies := []handlers_iam.PolicyDocument{{
+				Version: "2012-10-17",
+				Statement: []handlers_iam.Statement{
+					{Effect: "Allow", Action: handlers_iam.StringOrArr{tt.action}, Resource: handlers_iam.StringOrArr{"*"}},
+					{Effect: "Deny", Action: handlers_iam.StringOrArr{tt.action}, Resource: handlers_iam.StringOrArr{tt.target}},
+				},
+			}}
+			gw, probe := newRDSPolicyGateway(policies)
+			err := gw.RDS_Request(httptest.NewRecorder(), setupRDSUserRequest(tt.query, rdsTestAccountID))
+			require.Error(t, err)
+			assert.Equal(t, 2, probe.consulted)
+			assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+		})
+	}
+}
+
 // Creates and plural describes name no one resource, so a policy scoped to a
 // single instance must not be read as permitting them.
 func TestRDSRequest_UnscopedActionsEvaluateAgainstAnyResource(t *testing.T) {


### PR DESCRIPTION
## Summary
- resolve every declared RDS authorization scope instead of a single ARN
- authorize snapshot creates against the source instance and target snapshot
- authorize snapshot restores against the source snapshot and target instance
- preserve per-member `*` fallback for missing identifiers and existing source Deny behavior