### PR TITLE
refactor: use the stdlib uuid package instead of github.com/google/uuid

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/ebsmetadata"
@@ -2645,7 +2645,7 @@ func runAccountCreate(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	reservationOwner := "spx-cli-" + uuid.NewString()
+	reservationOwner := "spx-cli-" + uuid.NewV4().String()
 	switch err := names.Reserve(ctx, name, reservationOwner); {
 	case errors.Is(err, handlers_iam.ErrNameTaken):
 		fmt.Fprintf(os.Stderr, "Error: account %q already exists\n", name)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/google/uuid v1.6.0
 	github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/cpuid/v2 v2.4.0
@@ -118,6 +117,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gookit/color v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/bluebottle v1.17.0
 	github.com/mulgadc/northstar v1.17.0
-	github.com/mulgadc/predastore v1.17.0
+	github.com/mulgadc/predastore v1.17.1-0.20260820015438-7883d5073cf0
 	github.com/mulgadc/viperblock v1.17.1-0.20260819232234-77b4fbe47481
 	github.com/nats-io/nats-server/v2 v2.14.5
 	github.com/nats-io/nats.go v1.53.1

--- a/go.sum
+++ b/go.sum
@@ -1333,8 +1333,6 @@ github.com/mulgadc/northstar v1.17.0 h1:bUkcGpKw06FcWyibkqP/O5J2gnXkM8EAtGX1AZjr
 github.com/mulgadc/northstar v1.17.0/go.mod h1:Qg559eZgF8GIsxhSyfDaZCnvhg1Ml66/nnsAQxE9ybg=
 github.com/mulgadc/predastore v1.17.0 h1:1xMFrzQU7dBaC5Q6qiAJx5ipj/yDubjtOJY7rjpryYo=
 github.com/mulgadc/predastore v1.17.0/go.mod h1:RM3hLSVsJAfwPJnmqbmcDgfdnP/RntXe+r1GOTD+S9c=
-github.com/mulgadc/viperblock v1.17.0 h1:ybcjcBf10jA1SiUkH5PTGFUZ9ZhGMljBff7iV06Vkg8=
-github.com/mulgadc/viperblock v1.17.0/go.mod h1:XYRmXrJ+k1P5nCxxTihcBUVM/4Srxc8zkFQp+a7ALNk=
 github.com/mulgadc/viperblock v1.17.1-0.20260819232234-77b4fbe47481 h1:kWiCPxfLURj6D06CA1rsaF2LP9EpwbJyqqTy/IdCCug=
 github.com/mulgadc/viperblock v1.17.1-0.20260819232234-77b4fbe47481/go.mod h1:XYRmXrJ+k1P5nCxxTihcBUVM/4Srxc8zkFQp+a7ALNk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/go.sum
+++ b/go.sum
@@ -1331,8 +1331,8 @@ github.com/mulgadc/bluebottle v1.17.0 h1:K+tGfqwI8nnjV2naG5EGpWMO3Y6XpCTl7/5d5Hm
 github.com/mulgadc/bluebottle v1.17.0/go.mod h1:kBSgbql3n7FY/emDWP2clK0jyEpOaPSCap+wggILwFQ=
 github.com/mulgadc/northstar v1.17.0 h1:bUkcGpKw06FcWyibkqP/O5J2gnXkM8EAtGX1AZjrmzc=
 github.com/mulgadc/northstar v1.17.0/go.mod h1:Qg559eZgF8GIsxhSyfDaZCnvhg1Ml66/nnsAQxE9ybg=
-github.com/mulgadc/predastore v1.17.0 h1:1xMFrzQU7dBaC5Q6qiAJx5ipj/yDubjtOJY7rjpryYo=
-github.com/mulgadc/predastore v1.17.0/go.mod h1:RM3hLSVsJAfwPJnmqbmcDgfdnP/RntXe+r1GOTD+S9c=
+github.com/mulgadc/predastore v1.17.1-0.20260820015438-7883d5073cf0 h1:AOe9Q6lwosNOnyE/KbagIcuAnmPjwDUUPmkZ1w+WvFE=
+github.com/mulgadc/predastore v1.17.1-0.20260820015438-7883d5073cf0/go.mod h1:jHKn9+aBQdvAygky1eIytf1f5hH3Pj1eTZUMlDJ5Dqw=
 github.com/mulgadc/viperblock v1.17.1-0.20260819232234-77b4fbe47481 h1:kWiCPxfLURj6D06CA1rsaF2LP9EpwbJyqqTy/IdCCug=
 github.com/mulgadc/viperblock v1.17.1-0.20260819232234-77b4fbe47481/go.mod h1:XYRmXrJ+k1P5nCxxTihcBUVM/4Srxc8zkFQp+a7ALNk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/spinifex/gateway/admin.go
+++ b/spinifex/gateway/admin.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"uuid"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -81,7 +81,7 @@ type adminErrorDetail struct {
 // Authorization is fail-closed at every step and every denial returns the same
 // AccessDenied, so a caller cannot probe which gate rejected it.
 func (gw *GatewayConfig) Admin_Request(w http.ResponseWriter, r *http.Request) {
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 	w.Header().Set("X-Amzn-Requestid", requestID)
 
 	method := chi.URLParam(r, "method")

--- a/spinifex/gateway/admin_deleteaccount.go
+++ b/spinifex/gateway/admin_deleteaccount.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/accountteardown"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
@@ -363,7 +363,7 @@ func claimDeletionJob(
 ) (*accountDeletionJob, *accountDeletionJob, error) {
 	now := time.Now().UTC()
 	job := &accountDeletionJob{
-		DeletionID:  uuid.NewString(),
+		DeletionID:  uuid.NewV4().String(),
 		AccountID:   req.AccountID,
 		AccountName: req.AccountName,
 		ClientToken: req.ClientToken,

--- a/spinifex/gateway/auth.go
+++ b/spinifex/gateway/auth.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/mulgadc/bluebottle/pkg/sigv4"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
@@ -380,7 +380,7 @@ func (gw *GatewayConfig) resolveSessionAKID(r *http.Request, accessKeyID, client
 // Every auth rejection funnels through here, a rate-limit lockout included, so
 // this is the one place that has to record the verdict onto the request.
 func (gw *GatewayConfig) writeSigV4Error(w http.ResponseWriter, r *http.Request, errorCode string) {
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 	auditFrom(r.Context()).setAuthError(errorCode)
 
 	errorMsg, exists := awserrors.ErrorLookup[errorCode]

--- a/spinifex/gateway/bedrock/converse_stream.go
+++ b/spinifex/gateway/bedrock/converse_stream.go
@@ -9,11 +9,11 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
@@ -105,7 +105,7 @@ func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, model
 	if recorder == nil {
 		recorder = NoopRecorder
 	}
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 	start := time.Now()
 
 	input := new(bedrockruntime.ConverseStreamInput)

--- a/spinifex/gateway/bedrock/guardrail.go
+++ b/spinifex/gateway/bedrock/guardrail.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrock"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/nats-io/nats.go/jetstream"
@@ -341,7 +341,7 @@ func CreateGuardrail(ctx context.Context, accountID string, store *GuardrailStor
 		return nil, err
 	}
 
-	id := uuid.NewString()
+	id := uuid.NewV4().String()
 	arn := FormatGuardrailARN(store.region, accountID, id)
 	now := time.Now().UTC()
 

--- a/spinifex/gateway/bedrock/invoke.go
+++ b/spinifex/gateway/bedrock/invoke.go
@@ -6,9 +6,9 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
@@ -89,7 +89,7 @@ func NewInvokeRouter(resolver CredentialResolver, endpointResolver EndpointResol
 // X-Amzn-Bedrock-Guardrail* headers; an empty guardrailIdent leaves behaviour
 // byte-identical to a request with no guardrail at all.
 func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID string, body []byte, guardrailIdent, guardrailVersion string) (respBody []byte, contentType string, err error) {
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 	start := time.Now()
 	var backend string
 	defer func() {

--- a/spinifex/gateway/bedrock/invoke_stream.go
+++ b/spinifex/gateway/bedrock/invoke_stream.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
@@ -37,7 +37,7 @@ func InvokeModelWithResponseStream(ctx context.Context, w http.ResponseWriter, a
 	if recorder == nil {
 		recorder = NoopRecorder
 	}
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 	start := time.Now()
 
 	// Resolved here too (InvokeStreamRouter below resolves it again for

--- a/spinifex/gateway/bedrock/provider.go
+++ b/spinifex/gateway/bedrock/provider.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
@@ -71,7 +71,7 @@ func NewRouter(resolver CredentialResolver, endpointResolver EndpointResolver, r
 // deferred closure, matching pumpConverseStream's treatment of the streaming
 // path.
 func (rt *Router) Converse(ctx context.Context, accountID, modelID string, input *bedrockruntime.ConverseInput) (out *bedrockruntime.ConverseOutput, err error) {
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 	start := time.Now()
 	var backend string
 	defer func() {

--- a/spinifex/gateway/bedrock/provisioned.go
+++ b/spinifex/gateway/bedrock/provisioned.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrock"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/nats-io/nats.go/jetstream"
@@ -200,7 +200,7 @@ func CreateProvisionedModelThroughput(ctx context.Context, accountID string, sto
 		return nil, err
 	}
 
-	id := uuid.NewString()
+	id := uuid.NewV4().String()
 	arn := FormatProvisionedModelARN(store.region, accountID, id)
 
 	if err := store.endpoint.EnsurePinned(ctx, accountID, modelID); err != nil {

--- a/spinifex/gateway/bedrockagent.go
+++ b/spinifex/gateway/bedrockagent.go
@@ -14,10 +14,10 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrockagent"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
 	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
@@ -369,7 +369,7 @@ func CreateKnowledgeBase(ctx context.Context, accountID, region string, kb *hand
 			"bedrock-agent: embeddingModelConfiguration.bedrockEmbeddingModelConfiguration.dimensions is required")
 	}
 
-	id := uuid.NewString()
+	id := uuid.NewV4().String()
 	indexResp, err := vector.CreateIndex(ctx, &handlers_ochrevector.CreateIndexRequest{
 		IndexID:        id,
 		Name:           aws.StringValue(input.Name),
@@ -594,7 +594,7 @@ func CreateDataSource(ctx context.Context, accountID, region string, kb *handler
 		}
 	}
 
-	id := uuid.NewString()
+	id := uuid.NewV4().String()
 	now := time.Now().UTC()
 	rec := handlers_ochrevector.DataSourceRecord{
 		ID:              id,

--- a/spinifex/gateway/bedrockagentruntime.go
+++ b/spinifex/gateway/bedrockagentruntime.go
@@ -11,11 +11,11 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrockagentruntime"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
 	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
@@ -583,7 +583,7 @@ func RetrieveAndGenerate(ctx context.Context, accountID string, kb *handlers_och
 
 	sessionID := aws.StringValue(input.SessionId)
 	if sessionID == "" {
-		sessionID = uuid.NewString()
+		sessionID = uuid.NewV4().String()
 	}
 
 	// One aggregate citation covering the whole generated answer: the

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awsec2query"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_ec2_account "github.com/mulgadc/spinifex/spinifex/gateway/ec2/account"
@@ -83,7 +83,7 @@ func marshalEC2Response(action string, output any) ([]byte, error) {
 	// empty one for a non-nil empty slice; AWS always renders the latter.
 	normalized := utils.NormalizeXMLOutput(output)
 	// The SDK's generated output structs never carry a RequestId field.
-	withRequestID := utils.WithRequestID(normalized, uuid.NewString())
+	withRequestID := utils.WithRequestID(normalized, uuid.NewV4().String())
 	payload := utils.GenerateXMLPayload(action+"Response", withRequestID)
 	xmlOutput, err := utils.MarshalToXML(payload)
 	if err != nil {

--- a/spinifex/gateway/ecr/registry.go
+++ b/spinifex/gateway/ecr/registry.go
@@ -17,10 +17,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/handlers/ecr"
 	"github.com/mulgadc/spinifex/spinifex/objectstore"
 )
@@ -279,7 +279,7 @@ func (reg *Registry) startUpload(w http.ResponseWriter, r *http.Request, name st
 		}
 	}
 
-	uploadID := uuid.NewString()
+	uploadID := uuid.NewV4().String()
 	h := sha256.New()
 	state, err := marshalHash(h)
 	if err != nil {
@@ -332,7 +332,7 @@ func (reg *Registry) patchUpload(w http.ResponseWriter, r *http.Request, name, u
 
 	prior := reg.readUploadBytesAt(ctx, st.BytesKey)
 	assembled := append(prior, chunk...)
-	newKey := ecr.UploadChunkKey(uploadID, uuid.NewString())
+	newKey := ecr.UploadChunkKey(uploadID, uuid.NewV4().String())
 	if err := reg.putUploadBytesAt(ctx, newKey, assembled); err != nil {
 		reg.internal(ctx, w, "store chunk", err)
 		return

--- a/spinifex/gateway/ecrauth/token.go
+++ b/spinifex/gateway/ecrauth/token.go
@@ -7,9 +7,9 @@ import (
 	"slices"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 )
 
 const (
@@ -129,7 +129,7 @@ func (i *Issuer) Mint(p Principal) (token string, expiresAt time.Time, err error
 			Audience:  jwt.ClaimStrings{i.audience},
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(exp),
-			ID:        uuid.NewString(),
+			ID:        uuid.NewV4().String(),
 		},
 		AccountID:     p.AccountID,
 		PrincipalType: p.Type,

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/google/uuid"
 	"github.com/mulgadc/bluebottle/pkg/auth"
 	"github.com/mulgadc/bluebottle/pkg/iampolicy"
 	bbotel "github.com/mulgadc/bluebottle/pkg/otelsetup"
@@ -334,7 +334,7 @@ const clusterUnavailableMsg = "cluster unavailable: NATS disconnected — check 
 // format. It emits XML directly (not via GenerateEC2ErrorResponse) to ensure the
 // /local/status hint is preserved in <Message>.
 func (gw *GatewayConfig) writeClusterUnavailable(w http.ResponseWriter, _ *http.Request, svc string) {
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 
 	// EKS and ECS use AWS JSON 1.1.
 	if svc == "eks" || svc == "ecs" {
@@ -379,7 +379,7 @@ func (gw *GatewayConfig) writeClusterUnavailable(w http.ResponseWriter, _ *http.
 
 // writeThrottleError writes the service-appropriate throttle rejection response.
 func (gw *GatewayConfig) writeThrottleError(w http.ResponseWriter, r *http.Request) {
-	requestID := uuid.NewString()
+	requestID := uuid.NewV4().String()
 	svc, _ := r.Context().Value(ctxService).(string)
 
 	errorCode := awserrors.ErrorRequestLimitExceeded
@@ -651,7 +651,7 @@ func (gw *GatewayConfig) ErrorHandler(w http.ResponseWriter, r *http.Request, er
 	svc, _ := gw.GetService(r)
 	slog.Debug("ErrorHandler", "service", svc, "error", err.Error())
 
-	var requestId = uuid.NewString()
+	var requestId = uuid.NewV4().String()
 	code, message, exists := awserrors.ResolveErrorDetail(err)
 	if !exists {
 		slog.Warn("Unknown error code", "error", err.Error())

--- a/spinifex/handlers/acm/service_impl.go
+++ b/spinifex/handlers/acm/service_impl.go
@@ -13,10 +13,10 @@ import (
 	"maps"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/nats-io/nats.go"
@@ -186,7 +186,7 @@ func (s *ACMServiceImpl) northstarHostsAll(domains []string) bool {
 
 // mintCertificateArn generates an ACM-style certificate ARN for accountID.
 func (s *ACMServiceImpl) mintCertificateArn(accountID string) string {
-	return fmt.Sprintf("arn:aws:acm:%s:%s:certificate/%s", s.region, accountID, uuid.NewString())
+	return fmt.Sprintf("arn:aws:acm:%s:%s:certificate/%s", s.region, accountID, uuid.NewV4().String())
 }
 
 // ImportCertificate validates the PEM material, parses the leaf for metadata,
@@ -315,7 +315,7 @@ func (s *ACMServiceImpl) RequestCertificate(ctx context.Context, input *acm.Requ
 		RenewalEligibility:      renewalEligibilityForMode(mode),
 		// Minted now regardless of mode so CNAME_DELEGATION, when it lands, has
 		// a stable target without changing an existing certificate's validation.
-		DelegationToken: uuid.NewString(),
+		DelegationToken: uuid.NewV4().String(),
 		Tags:            tagsToMap(input.Tags),
 	}
 

--- a/spinifex/handlers/ecs/deployments.go
+++ b/spinifex/handlers/ecs/deployments.go
@@ -5,10 +5,10 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/google/uuid"
 )
 
 // deploymentStartedByPrefix is the AWS StartedBy prefix a service stamps on its
@@ -110,7 +110,7 @@ func (r *ServiceRecord) ensurePrimaryDeployment() {
 // new PRIMARY for td, mirroring the taskdef onto the service record.
 func (r *ServiceRecord) startDeployment(td *TaskDefRecord) {
 	r.demotePrimary()
-	r.DeploymentID = uuid.NewString()
+	r.DeploymentID = uuid.NewV4().String()
 	r.TaskDefFamily = td.Family
 	r.TaskDefRevision = td.Revision
 	r.TaskDefARN = td.ARN
@@ -221,7 +221,7 @@ func (r *ServiceRecord) rollbackToLastGood() {
 	family, rev := parseTaskDefRef(r.LastGoodTaskDefARN)
 	r.demotePrimary()
 	now := time.Now().UTC()
-	r.DeploymentID = uuid.NewString()
+	r.DeploymentID = uuid.NewV4().String()
 	r.Deployments = append(r.Deployments, Deployment{
 		ID:              r.DeploymentID,
 		Status:          DeploymentStatusPrimary,

--- a/spinifex/handlers/ecs/services.go
+++ b/spinifex/handlers/ecs/services.go
@@ -6,12 +6,12 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_ec2_eip "github.com/mulgadc/spinifex/spinifex/handlers/ec2/eip"
 	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
@@ -177,7 +177,7 @@ func (s *Service) CreateService(ctx context.Context, input *ecs.CreateServiceInp
 		NetworkMode:        resolveNetworkMode(taskDef),
 		PlacementStrategy:  placementStrategyFromAWS(input.PlacementStrategy),
 		LoadBalancers:      loadBalancersFromAWS(input.LoadBalancers),
-		DeploymentID:       uuid.NewString(),
+		DeploymentID:       uuid.NewV4().String(),
 		Tags:               tagsToMap(input.Tags),
 		CreatedAt:          now,
 		UpdatedAt:          now,

--- a/spinifex/handlers/ecs/task_stop.go
+++ b/spinifex/handlers/ecs/task_stop.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/handlers/ecs/bus"
 	"github.com/nats-io/nats.go/jetstream"
@@ -81,7 +81,7 @@ func (s *Service) StartTask(ctx context.Context, input *ecs.StartTaskInput, acco
 	out := &ecs.StartTaskOutput{}
 	for _, ref := range awsStringSlice(input.ContainerInstances) {
 		instanceID := containerInstanceShortID(ref)
-		taskID := uuid.NewString()
+		taskID := uuid.NewV4().String()
 		inst, rerr := s.reserveOnInstance(ctx, kv, cluster, instanceID, taskID, cpu, mem, gpu)
 		if rerr != nil {
 			out.Failures = append(out.Failures, &ecs.Failure{

--- a/spinifex/handlers/ecs/tasks.go
+++ b/spinifex/handlers/ecs/tasks.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/handlers/ecs/bus"
 	"github.com/nats-io/nats.go/jetstream"
@@ -60,7 +60,7 @@ func (s *Service) RunTask(ctx context.Context, input *ecs.RunTaskInput, accountI
 
 	out := &ecs.RunTaskOutput{}
 	for i := 0; i < count; i++ {
-		taskID := uuid.NewString()
+		taskID := uuid.NewV4().String()
 		inst, err := s.reservePlacement(ctx, kv, cluster, taskID, cpu, mem, gpu, strategy)
 		if err != nil {
 			out.Failures = append(out.Failures, &ecs.Failure{

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -14,12 +14,12 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/instancetypes"
@@ -280,7 +280,7 @@ func (s *EKSServiceImpl) createNodegroup(ctx context.Context, acctKV jetstream.K
 	rec := &NodegroupRecord{
 		ClusterName:    cluster,
 		Name:           ng,
-		Arn:            NodegroupARN(s.deps.Region, accountID, cluster, ng, uuid.NewString()),
+		Arn:            NodegroupARN(s.deps.Region, accountID, cluster, ng, uuid.NewV4().String()),
 		Status:         eks.NodegroupStatusCreating,
 		Subnets:        subnets,
 		InstanceTypes:  instanceTypes,
@@ -574,7 +574,7 @@ func (s *EKSServiceImpl) launchOneWorker(ctx context.Context, rec *NodegroupReco
 		instanceType = rec.InstanceTypes[0]
 	}
 	subnet := rec.Subnets[0]
-	shortID := uuid.NewString()[:8]
+	shortID := uuid.NewV4().String()[:8]
 
 	region := s.deps.Region
 	suffix := s.deps.InternalSuffix
@@ -836,7 +836,7 @@ func (s *EKSServiceImpl) updateNodegroupConfig(ctx context.Context, acctKV jetst
 	}
 
 	return &eks.UpdateNodegroupConfigOutput{Update: &eks.Update{
-		Id:        aws.String(uuid.NewString()),
+		Id:        aws.String(uuid.NewV4().String()),
 		Status:    aws.String(eks.UpdateStatusSuccessful),
 		Type:      aws.String(eks.UpdateTypeConfigUpdate),
 		CreatedAt: aws.Time(rec.ModifiedAt),

--- a/spinifex/handlers/rds/commands.go
+++ b/spinifex/handlers/rds/commands.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 )
 
@@ -145,7 +145,7 @@ func (s *Service) issueCommand(ctx context.Context, accountID, dbInstanceIdentif
 	}
 	issuedAt := time.Now().UTC()
 	cmd := Command{
-		CommandID:  uuid.NewString(),
+		CommandID:  uuid.NewV4().String(),
 		Type:       commandType,
 		Parameters: params,
 		IssuedAt:   &issuedAt,


### PR DESCRIPTION
Go 1.27 ships a `uuid` package implementing RFC 9562. Spinifex used `github.com/google/uuid` in 23 files, exclusively through `uuid.NewString()` (31 call sites) — no `Parse`, no v5/v7, no `UUID` values held anywhere. That maps straight onto the stdlib API, so the external dependency no longer earns its place.

## Changes

- Import `uuid` from the standard library and drop `github.com/google/uuid`.
- Rewrite `uuid.NewString()` as `uuid.NewV4().String()`. The stdlib package has no `NewString` helper, and `New()` is documented only as "equivalent to `NewV4` at this time" — `NewV4()` pins v4 semantics explicitly rather than relying on that wording holding.