### PR TITLE
fix: make instance-profile role and tag writes atomic

### DIFF
--- a/spinifex/handlers/iam/instance_profiles.go
+++ b/spinifex/handlers/iam/instance_profiles.go
@@ -291,8 +291,9 @@ func parseInstanceProfileARN(arn string) (accountID, name string, err error) {
 	return parts[4], name, nil
 }
 
-// TagInstanceProfile upserts tags on an instance profile. Blind
-// read-modify-write Put like the other instance-profile writers (no CAS).
+// TagInstanceProfile upserts tags on an instance profile under CAS, like the
+// other instance-profile writers. A blind Put would write back a stale
+// RoleName and silently undo a concurrent role attach.
 func (s *IAMServiceImpl) TagInstanceProfile(accountID string, input *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error) {
 	ctx := context.Background()
 	if err := validateTags(input.Tags); err != nil {
@@ -300,23 +301,16 @@ func (s *IAMServiceImpl) TagInstanceProfile(accountID string, input *iam.TagInst
 	}
 
 	profileName := *input.InstanceProfileName
-	profile, err := s.getInstanceProfile(ctx, accountID, profileName)
+	err := s.updateInstanceProfileCAS(ctx, accountID, profileName, func(p *InstanceProfile) (bool, error) {
+		merged := mergeTags(p.Tags, input.Tags)
+		if len(merged) > maxTagsPerResource {
+			return false, errors.New(awserrors.ErrorIAMLimitExceeded)
+		}
+		p.Tags = merged
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	merged := mergeTags(profile.Tags, input.Tags)
-	if len(merged) > maxTagsPerResource {
-		return nil, errors.New(awserrors.ErrorIAMLimitExceeded)
-	}
-	profile.Tags = merged
-
-	data, err := json.Marshal(profile)
-	if err != nil {
-		return nil, fmt.Errorf("marshal instance profile: %w", err)
-	}
-	if _, err := s.instanceProfilesBucket.Put(ctx, accountID+"."+profileName, data); err != nil {
-		return nil, fmt.Errorf("update instance profile: %w", err)
 	}
 
 	slog.Info("IAM instance profile tagged", "accountID", accountID, "instanceProfileName", profileName)
@@ -328,19 +322,16 @@ func (s *IAMServiceImpl) TagInstanceProfile(accountID string, input *iam.TagInst
 func (s *IAMServiceImpl) UntagInstanceProfile(accountID string, input *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error) {
 	ctx := context.Background()
 	profileName := *input.InstanceProfileName
-	profile, err := s.getInstanceProfile(ctx, accountID, profileName)
+	err := s.updateInstanceProfileCAS(ctx, accountID, profileName, func(p *InstanceProfile) (bool, error) {
+		kept := removeTagKeys(p.Tags, input.TagKeys)
+		if len(kept) == len(p.Tags) {
+			return false, nil
+		}
+		p.Tags = kept
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	profile.Tags = removeTagKeys(profile.Tags, input.TagKeys)
-
-	data, err := json.Marshal(profile)
-	if err != nil {
-		return nil, fmt.Errorf("marshal instance profile: %w", err)
-	}
-	if _, err := s.instanceProfilesBucket.Put(ctx, accountID+"."+profileName, data); err != nil {
-		return nil, fmt.Errorf("update instance profile: %w", err)
 	}
 
 	slog.Info("IAM instance profile untagged", "accountID", accountID, "instanceProfileName", profileName)
@@ -377,11 +368,8 @@ func (s *IAMServiceImpl) getInstanceProfile(ctx context.Context, accountID, prof
 	return &profile, nil
 }
 
-// updateInstanceProfileCAS applies mutate to an instance profile under
-// optimistic concurrency: read the record with its revision, mutate, then
-// Update guarded by that revision, re-reading and re-running mutate when a
-// concurrent writer wins the race. A blind read-modify-Put lets two callers
-// pass the one-role guard from the same revision and clobber each other.
+// updateInstanceProfileCAS applies mutate under optimistic concurrency,
+// re-reading and re-running mutate when a concurrent writer wins the race.
 // mutate reports whether it changed the record; a false return commits nothing.
 func (s *IAMServiceImpl) updateInstanceProfileCAS(ctx context.Context, accountID, profileName string, mutate func(*InstanceProfile) (bool, error)) error {
 	key := accountID + "." + profileName
@@ -411,14 +399,19 @@ func (s *IAMServiceImpl) updateInstanceProfileCAS(ctx context.Context, accountID
 		if err != nil {
 			return fmt.Errorf("marshal instance profile: %w", err)
 		}
+		// ErrKeyRevisionMismatch is the only conflict signal that holds on both
+		// replicated and single-replica buckets; ErrKeyExists misses R>1.
 		if _, err := s.instanceProfilesBucket.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				continue // CAS conflict — another writer won, re-read and retry.
 			}
 			return fmt.Errorf("update instance profile: %w", err)
 		}
 		return nil
 	}
+
+	slog.Warn("IAM instance profile CAS exhausted retries",
+		"accountID", accountID, "instanceProfileName", profileName, "attempts", instanceProfileCASMaxRetries)
 	return errors.New(awserrors.ErrorServerInternal)
 }
 

--- a/spinifex/handlers/iam/instance_profiles.go
+++ b/spinifex/handlers/iam/instance_profiles.go
@@ -18,6 +18,10 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
+// Bound on optimistic-concurrency retries when a concurrent writer wins the
+// CAS race on an instance-profile record.
+const instanceProfileCASMaxRetries = 16
+
 func (s *IAMServiceImpl) CreateInstanceProfile(accountID string, input *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
 	ctx := context.Background()
 	profileName := *input.InstanceProfileName
@@ -176,22 +180,15 @@ func (s *IAMServiceImpl) AddRoleToInstanceProfile(accountID string, input *iam.A
 		return nil, err
 	}
 
-	profile, err := s.getInstanceProfile(ctx, accountID, profileName)
+	err := s.updateInstanceProfileCAS(ctx, accountID, profileName, func(p *InstanceProfile) (bool, error) {
+		if p.RoleName != "" {
+			return false, errors.New(awserrors.ErrorIAMLimitExceeded)
+		}
+		p.RoleName = roleName
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	if profile.RoleName != "" {
-		return nil, errors.New(awserrors.ErrorIAMLimitExceeded)
-	}
-
-	profile.RoleName = roleName
-	data, err := json.Marshal(profile)
-	if err != nil {
-		return nil, fmt.Errorf("marshal instance profile: %w", err)
-	}
-	if _, err := s.instanceProfilesBucket.Put(ctx, accountID+"."+profileName, data); err != nil {
-		return nil, fmt.Errorf("update instance profile: %w", err)
 	}
 
 	slog.Info("IAM role added to instance profile",
@@ -204,22 +201,15 @@ func (s *IAMServiceImpl) RemoveRoleFromInstanceProfile(accountID string, input *
 	profileName := *input.InstanceProfileName
 	roleName := *input.RoleName
 
-	profile, err := s.getInstanceProfile(ctx, accountID, profileName)
+	err := s.updateInstanceProfileCAS(ctx, accountID, profileName, func(p *InstanceProfile) (bool, error) {
+		if p.RoleName == "" || p.RoleName != roleName {
+			return false, errors.New(awserrors.ErrorIAMNoSuchEntity)
+		}
+		p.RoleName = ""
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	if profile.RoleName == "" || profile.RoleName != roleName {
-		return nil, errors.New(awserrors.ErrorIAMNoSuchEntity)
-	}
-
-	profile.RoleName = ""
-	data, err := json.Marshal(profile)
-	if err != nil {
-		return nil, fmt.Errorf("marshal instance profile: %w", err)
-	}
-	if _, err := s.instanceProfilesBucket.Put(ctx, accountID+"."+profileName, data); err != nil {
-		return nil, fmt.Errorf("update instance profile: %w", err)
 	}
 
 	slog.Info("IAM role removed from instance profile",
@@ -385,6 +375,51 @@ func (s *IAMServiceImpl) getInstanceProfile(ctx context.Context, accountID, prof
 		return nil, fmt.Errorf("unmarshal instance profile: %w", err)
 	}
 	return &profile, nil
+}
+
+// updateInstanceProfileCAS applies mutate to an instance profile under
+// optimistic concurrency: read the record with its revision, mutate, then
+// Update guarded by that revision, re-reading and re-running mutate when a
+// concurrent writer wins the race. A blind read-modify-Put lets two callers
+// pass the one-role guard from the same revision and clobber each other.
+// mutate reports whether it changed the record; a false return commits nothing.
+func (s *IAMServiceImpl) updateInstanceProfileCAS(ctx context.Context, accountID, profileName string, mutate func(*InstanceProfile) (bool, error)) error {
+	key := accountID + "." + profileName
+	for range instanceProfileCASMaxRetries {
+		entry, err := s.instanceProfilesBucket.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				return errors.New(awserrors.ErrorIAMNoSuchEntity)
+			}
+			return fmt.Errorf("get instance profile: %w", err)
+		}
+
+		var profile InstanceProfile
+		if err := json.Unmarshal(entry.Value(), &profile); err != nil {
+			return fmt.Errorf("unmarshal instance profile: %w", err)
+		}
+
+		changed, err := mutate(&profile)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			return nil
+		}
+
+		data, err := json.Marshal(&profile)
+		if err != nil {
+			return fmt.Errorf("marshal instance profile: %w", err)
+		}
+		if _, err := s.instanceProfilesBucket.Update(ctx, key, data, entry.Revision()); err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				continue // CAS conflict — another writer won, re-read and retry.
+			}
+			return fmt.Errorf("update instance profile: %w", err)
+		}
+		return nil
+	}
+	return errors.New(awserrors.ErrorServerInternal)
 }
 
 // profileToSDK converts the internal InstanceProfile to the AWS SDK shape.

--- a/spinifex/handlers/iam/instance_profiles_test.go
+++ b/spinifex/handlers/iam/instance_profiles_test.go
@@ -1,6 +1,7 @@
 package handlers_iam
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -295,6 +296,30 @@ func TestAddRoleToInstanceProfile_OneRoleLimit(t *testing.T) {
 	assert.Contains(t, err.Error(), awserrors.ErrorIAMLimitExceeded)
 }
 
+// raceRounds is how many times a concurrency test replays its race on a fresh
+// profile. One round can serialize and miss a lost update; a handful makes a
+// reintroduced blind Put fail reliably.
+const raceRounds = 8
+
+// runConcurrently calls fn n times in parallel, released together so the calls
+// overlap rather than serializing, and returns each call's error by index.
+func runConcurrently(n int, fn func(i int) error) []error {
+	start := make(chan struct{})
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = fn(i)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	return errs
+}
+
 // TestAddRoleToInstanceProfile_ConcurrentDistinctRoles pins the one-role
 // limit under concurrency: a blind read-modify-Put let both callers pass the
 // guard from the same revision, so the later write silently replaced the first
@@ -305,39 +330,37 @@ func TestAddRoleToInstanceProfile_ConcurrentDistinctRoles(t *testing.T) {
 	for _, r := range roles {
 		createTestRole(t, svc, r)
 	}
-	createTestInstanceProfile(t, svc, "race-profile")
 
-	var wg sync.WaitGroup
-	errs := make([]error, len(roles))
-	for i, roleName := range roles {
-		wg.Add(1)
-		go func(i int, roleName string) {
-			defer wg.Done()
-			_, errs[i] = svc.AddRoleToInstanceProfile(testAccountID, &iam.AddRoleToInstanceProfileInput{
-				InstanceProfileName: aws.String("race-profile"),
-				RoleName:            aws.String(roleName),
+	for round := range raceRounds {
+		profileName := fmt.Sprintf("race-profile-%d", round)
+		createTestInstanceProfile(t, svc, profileName)
+
+		errs := runConcurrently(len(roles), func(i int) error {
+			_, err := svc.AddRoleToInstanceProfile(testAccountID, &iam.AddRoleToInstanceProfileInput{
+				InstanceProfileName: aws.String(profileName),
+				RoleName:            aws.String(roles[i]),
 			})
-		}(i, roleName)
-	}
-	wg.Wait()
+			return err
+		})
 
-	var winner string
-	for i, err := range errs {
-		if err == nil {
-			require.Emptyf(t, winner, "both attaches succeeded: %v and %v", winner, roles[i])
-			winner = roles[i]
-			continue
+		var winner string
+		for i, err := range errs {
+			if err == nil {
+				require.Emptyf(t, winner, "both attaches succeeded: %v and %v", winner, roles[i])
+				winner = roles[i]
+				continue
+			}
+			assert.Containsf(t, err.Error(), awserrors.ErrorIAMLimitExceeded, "attach %s", roles[i])
 		}
-		assert.Containsf(t, err.Error(), awserrors.ErrorIAMLimitExceeded, "attach %s", roles[i])
-	}
-	require.NotEmpty(t, winner, "no attach succeeded: %v", errs)
+		require.NotEmptyf(t, winner, "no attach succeeded: %v", errs)
 
-	out, err := svc.GetInstanceProfile(testAccountID, &iam.GetInstanceProfileInput{
-		InstanceProfileName: aws.String("race-profile"),
-	})
-	require.NoError(t, err)
-	require.Len(t, out.InstanceProfile.Roles, 1)
-	assert.Equal(t, winner, *out.InstanceProfile.Roles[0].RoleName, "the profile must carry the attach that won")
+		out, err := svc.GetInstanceProfile(testAccountID, &iam.GetInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+		})
+		require.NoError(t, err)
+		require.Len(t, out.InstanceProfile.Roles, 1)
+		assert.Equal(t, winner, *out.InstanceProfile.Roles[0].RoleName, "the profile must carry the attach that won")
+	}
 }
 
 // TestRemoveRoleFromInstanceProfile_ConcurrentDetach is the mirror case: two
@@ -346,43 +369,108 @@ func TestAddRoleToInstanceProfile_ConcurrentDistinctRoles(t *testing.T) {
 func TestRemoveRoleFromInstanceProfile_ConcurrentDetach(t *testing.T) {
 	svc := setupTestIAMService(t)
 	createTestRole(t, svc, "detach-race-role")
-	createTestInstanceProfile(t, svc, "detach-race-profile")
 
-	_, err := svc.AddRoleToInstanceProfile(testAccountID, &iam.AddRoleToInstanceProfileInput{
-		InstanceProfileName: aws.String("detach-race-profile"),
-		RoleName:            aws.String("detach-race-role"),
-	})
-	require.NoError(t, err)
+	for round := range raceRounds {
+		profileName := fmt.Sprintf("detach-race-profile-%d", round)
+		createTestInstanceProfile(t, svc, profileName)
+		_, err := svc.AddRoleToInstanceProfile(testAccountID, &iam.AddRoleToInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+			RoleName:            aws.String("detach-race-role"),
+		})
+		require.NoError(t, err)
 
-	var wg sync.WaitGroup
-	errs := make([]error, 2)
-	for i := range errs {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			_, errs[i] = svc.RemoveRoleFromInstanceProfile(testAccountID, &iam.RemoveRoleFromInstanceProfileInput{
-				InstanceProfileName: aws.String("detach-race-profile"),
+		errs := runConcurrently(2, func(int) error {
+			_, err := svc.RemoveRoleFromInstanceProfile(testAccountID, &iam.RemoveRoleFromInstanceProfileInput{
+				InstanceProfileName: aws.String(profileName),
 				RoleName:            aws.String("detach-race-role"),
 			})
-		}(i)
-	}
-	wg.Wait()
+			return err
+		})
 
-	successes := 0
-	for _, err := range errs {
-		if err == nil {
-			successes++
-			continue
+		successes := 0
+		for _, err := range errs {
+			if err == nil {
+				successes++
+				continue
+			}
+			assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
 		}
-		assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
-	}
-	assert.Equal(t, 1, successes, "exactly one detach may succeed: %v", errs)
+		assert.Equalf(t, 1, successes, "exactly one detach may succeed: %v", errs)
 
-	out, err := svc.GetInstanceProfile(testAccountID, &iam.GetInstanceProfileInput{
-		InstanceProfileName: aws.String("detach-race-profile"),
+		out, err := svc.GetInstanceProfile(testAccountID, &iam.GetInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out.InstanceProfile.Roles)
+	}
+}
+
+// TestTagInstanceProfile_ConcurrentWithAttach pins the tag path against the
+// same lost update: a blind Put wrote back a stale RoleName and silently
+// undid a role attach that had already reported success.
+func TestTagInstanceProfile_ConcurrentWithAttach(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "tag-race-role")
+
+	for round := range raceRounds {
+		profileName := fmt.Sprintf("tag-race-profile-%d", round)
+		createTestInstanceProfile(t, svc, profileName)
+
+		errs := runConcurrently(2, func(i int) error {
+			if i == 0 {
+				_, err := svc.AddRoleToInstanceProfile(testAccountID, &iam.AddRoleToInstanceProfileInput{
+					InstanceProfileName: aws.String(profileName),
+					RoleName:            aws.String("tag-race-role"),
+				})
+				return err
+			}
+			_, err := svc.TagInstanceProfile(testAccountID, &iam.TagInstanceProfileInput{
+				InstanceProfileName: aws.String(profileName),
+				Tags:                []*iam.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+			})
+			return err
+		})
+
+		require.NoError(t, errs[0], "attach")
+		require.NoError(t, errs[1], "tag")
+
+		out, err := svc.GetInstanceProfile(testAccountID, &iam.GetInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+		})
+		require.NoError(t, err)
+		require.Len(t, out.InstanceProfile.Roles, 1, "tagging must not drop the attached role")
+		require.Len(t, out.InstanceProfile.Tags, 1, "the attach must not drop the tag")
+	}
+}
+
+// TestTagInstanceProfile_ConcurrentDistinctKeys pins tag writes against each
+// other: under a blind Put all but one of the racing keys were lost.
+func TestTagInstanceProfile_ConcurrentDistinctKeys(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestInstanceProfile(t, svc, "tag-keys-profile")
+
+	keys := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	errs := runConcurrently(len(keys), func(i int) error {
+		_, err := svc.TagInstanceProfile(testAccountID, &iam.TagInstanceProfileInput{
+			InstanceProfileName: aws.String("tag-keys-profile"),
+			Tags:                []*iam.Tag{{Key: aws.String(keys[i]), Value: aws.String("v")}},
+		})
+		return err
+	})
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "tag %s", keys[i])
+	}
+
+	out, err := svc.ListInstanceProfileTags(testAccountID, &iam.ListInstanceProfileTagsInput{
+		InstanceProfileName: aws.String("tag-keys-profile"),
 	})
 	require.NoError(t, err)
-	assert.Empty(t, out.InstanceProfile.Roles)
+	got := make([]string, 0, len(out.Tags))
+	for _, tag := range out.Tags {
+		got = append(got, *tag.Key)
+	}
+	assert.ElementsMatch(t, keys, got, "all concurrently-written tags must persist")
 }
 
 func TestRemoveRoleFromInstanceProfile(t *testing.T) {

--- a/spinifex/handlers/iam/instance_profiles_test.go
+++ b/spinifex/handlers/iam/instance_profiles_test.go
@@ -2,6 +2,7 @@ package handlers_iam
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -292,6 +293,96 @@ func TestAddRoleToInstanceProfile_OneRoleLimit(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), awserrors.ErrorIAMLimitExceeded)
+}
+
+// TestAddRoleToInstanceProfile_ConcurrentDistinctRoles pins the one-role
+// limit under concurrency: a blind read-modify-Put let both callers pass the
+// guard from the same revision, so the later write silently replaced the first
+// role. Exactly one attach may win; the loser must see LimitExceeded.
+func TestAddRoleToInstanceProfile_ConcurrentDistinctRoles(t *testing.T) {
+	svc := setupTestIAMService(t)
+	roles := []string{"race-role-a", "race-role-b"}
+	for _, r := range roles {
+		createTestRole(t, svc, r)
+	}
+	createTestInstanceProfile(t, svc, "race-profile")
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(roles))
+	for i, roleName := range roles {
+		wg.Add(1)
+		go func(i int, roleName string) {
+			defer wg.Done()
+			_, errs[i] = svc.AddRoleToInstanceProfile(testAccountID, &iam.AddRoleToInstanceProfileInput{
+				InstanceProfileName: aws.String("race-profile"),
+				RoleName:            aws.String(roleName),
+			})
+		}(i, roleName)
+	}
+	wg.Wait()
+
+	var winner string
+	for i, err := range errs {
+		if err == nil {
+			require.Emptyf(t, winner, "both attaches succeeded: %v and %v", winner, roles[i])
+			winner = roles[i]
+			continue
+		}
+		assert.Containsf(t, err.Error(), awserrors.ErrorIAMLimitExceeded, "attach %s", roles[i])
+	}
+	require.NotEmpty(t, winner, "no attach succeeded: %v", errs)
+
+	out, err := svc.GetInstanceProfile(testAccountID, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String("race-profile"),
+	})
+	require.NoError(t, err)
+	require.Len(t, out.InstanceProfile.Roles, 1)
+	assert.Equal(t, winner, *out.InstanceProfile.Roles[0].RoleName, "the profile must carry the attach that won")
+}
+
+// TestRemoveRoleFromInstanceProfile_ConcurrentDetach is the mirror case: two
+// callers detach the same role at once and exactly one may win, the loser
+// re-reading an empty profile and reporting NoSuchEntity.
+func TestRemoveRoleFromInstanceProfile_ConcurrentDetach(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "detach-race-role")
+	createTestInstanceProfile(t, svc, "detach-race-profile")
+
+	_, err := svc.AddRoleToInstanceProfile(testAccountID, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String("detach-race-profile"),
+		RoleName:            aws.String("detach-race-role"),
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = svc.RemoveRoleFromInstanceProfile(testAccountID, &iam.RemoveRoleFromInstanceProfileInput{
+				InstanceProfileName: aws.String("detach-race-profile"),
+				RoleName:            aws.String("detach-race-role"),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	successes := 0
+	for _, err := range errs {
+		if err == nil {
+			successes++
+			continue
+		}
+		assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+	}
+	assert.Equal(t, 1, successes, "exactly one detach may succeed: %v", errs)
+
+	out, err := svc.GetInstanceProfile(testAccountID, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String("detach-race-profile"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out.InstanceProfile.Roles)
 }
 
 func TestRemoveRoleFromInstanceProfile(t *testing.T) {


### PR DESCRIPTION
## Summary

`AddRoleToInstanceProfile` and `RemoveRoleFromInstanceProfile` read the profile, checked the one-role guard, then stored with a blind `Put`. Two concurrent callers both read `RoleName == ""`, both passed the guard, and the later write silently replaced the first role instead of one caller seeing `LimitExceeded`. `RemoveRoleFromInstanceProfile` had the same shape: its "already detached" guard could be lost the same way.

All four instance-profile writers now go through `updateInstanceProfileCAS`, which mirrors the existing `updateRoleCAS` in `roles.go`: read the record with its revision, mutate, `Update` guarded by that revision, and on a lost CAS re-read and re-run the guard rather than overwriting. Bounded at 16 retries, and it now logs before returning `ErrorServerInternal` on exhaustion.

## Tag writes were the other half of the same bug

`TagInstanceProfile` and `UntagInstanceProfile` read the whole record, mutated only `Tags`, and wrote the entire struct back with a blind `Put` — including `RoleName`. A `Put` carries no revision, so it beats a concurrent revision-guarded `Update`: a tag write that started before a role attach would put back a stale `RoleName` and silently undo an attach that had already returned success to its caller. Making only the attach path atomic would have left that door open, so both tag writers were converted too. `UntagInstanceProfile` now commits nothing when no key was actually removed.

This matches `TagRole` / `UntagRole`, which already used `updateRoleCAS`.

## Conflict detection on replicated buckets

The first version of this branch matched `jetstream.ErrKeyExists` in the retry branch, copied from `updateRoleCAS`. That is wrong, and the library says so at `jetstream/errors.go:388`: `ErrKeyExists` matches by error code 10071, and replicated (R>1) buckets report a revision conflict as 10164 instead. `kvs.Update` wraps conflicts with `ErrKeyRevisionMismatch`, which holds in both cases.

The IAM buckets are created with `replicas = max(clusterSize, 1)` and production passes `len(config.Nodes)`, so every multi-node cluster is R>1 — exactly where the race matters. Tests construct the service with `clusterSize: 1`, so they could never have caught it. The predicate is now `ErrKeyRevisionMismatch`.

The same `ErrKeyExists`-on-`Update` predicate still exists in `updateRoleCAS` (`roles.go`) and `service_impl.go`, plus several non-IAM packages. Those are untouched here and need a follow-up bead.

## Testing

Four concurrency tests, each replaying its race for several rounds on a fresh profile with the goroutines released together from a barrier:

- `TestAddRoleToInstanceProfile_ConcurrentDistinctRoles` — exactly one attach wins, the loser gets `LimitExceeded`, the profile carries the winner.
- `TestRemoveRoleFromInstanceProfile_ConcurrentDetach` — exactly one detach wins, the loser gets `NoSuchEntity`.
- `TestTagInstanceProfile_ConcurrentWithAttach` — a tag write racing an attach drops neither the role nor the tag.
- `TestTagInstanceProfile_ConcurrentDistinctKeys` — eight racing tag writes all persist.

Measured against the pre-CAS code, all four fail on every run. Without the barrier the attach and detach tests let the old code through in roughly 1 run in 15, since the goroutines could serialize completely.

`make preflight` passes; `handlers/iam`, `handlers/ecs` and `handlers/eks` pass under `-race`.

## Notes

The now-strict guard does not change the EKS/ECS launch paths: `iam/system_role.go`, `ecs/instancerole.go` and `eks/nodegroup.go` already treat `LimitExceeded` from a racing attach as success, and the mutate error is returned unwrapped so their exact-string comparison still matches.

`DeleteInstanceProfile` still does a read-check-then-unguarded-`Delete`, so its `DeleteConflict` guard has the same TOCTOU shape. It is out of scope here and needs its own bead.

Closes mulga-h414w