### PR TITLE
fix: detect KV CAS conflicts on replicated buckets

### DIFF
--- a/spinifex/daemon/cas_conflict_test.go
+++ b/spinifex/daemon/cas_conflict_test.go
@@ -1,0 +1,160 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wrongLastSequence builds the error nats.go returns for a lost CAS race on a
+// bucket whose stream reports the conflict under code. Single-replica streams
+// report 10071, replicated ones 10164. Update and revision-guarded Delete wrap
+// both with ErrKeyRevisionMismatch; only 10071 also satisfies ErrKeyExists, so
+// a predicate written against ErrKeyExists alone is blind on a real cluster.
+func wrongLastSequence(code jetstream.ErrorCode) error {
+	apiErr := &jetstream.APIError{
+		ErrorCode:   code,
+		Code:        400,
+		Description: "wrong last sequence: 3",
+	}
+	return fmt.Errorf("%w: %w", apiErr, jetstream.ErrKeyRevisionMismatch)
+}
+
+// casConflictKV forces the next failuresLeft writes of each kind to fail with a
+// wrong-last-sequence response, so the CAS primitives can be driven against a
+// replicated bucket's error shape without standing up a real cluster.
+type casConflictKV struct {
+	jetstream.KeyValue
+
+	conflictCode   jetstream.ErrorCode
+	updateFailures int
+	deleteFailures int
+}
+
+func (k *casConflictKV) Update(ctx context.Context, key string, value []byte, last uint64) (uint64, error) {
+	if k.updateFailures > 0 {
+		k.updateFailures--
+		return 0, wrongLastSequence(k.conflictCode)
+	}
+	return k.KeyValue.Update(ctx, key, value, last)
+}
+
+func (k *casConflictKV) Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error {
+	if k.deleteFailures > 0 {
+		k.deleteFailures--
+		return wrongLastSequence(k.conflictCode)
+	}
+	return k.KeyValue.Delete(ctx, key, opts...)
+}
+
+// conflictCodes names the two wrong-last-sequence codes a bucket can report, so
+// every CAS test covers a replicated bucket as well as a single-replica one.
+var conflictCodes = map[string]jetstream.ErrorCode{
+	"single replica": jetstream.JSErrCodeStreamWrongLastSequence,
+	"replicated":     jetstream.JSErrCodeStreamWrongLastSequenceConstant,
+}
+
+func casTestBucket(t *testing.T, name string) jetstream.KeyValue {
+	t.Helper()
+	nc, err := nats.Connect(sharedJSNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	kv, err := js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{Bucket: name, History: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = js.DeleteKeyValue(context.Background(), name) })
+	return kv
+}
+
+type casRecord struct {
+	Counter int `json:"counter"`
+}
+
+// A lost Update race must be retried on both replica counts. Matching only
+// jetstream.ErrKeyExists passes the single-replica case and surfaces a raw
+// "wrong last sequence" error on the replicated one.
+func TestCASUpdate_RetriesRevisionConflict(t *testing.T) {
+	for name, code := range conflictCodes {
+		t.Run(name, func(t *testing.T) {
+			kv := casTestBucket(t, "cas-update-"+jetstreamCodeSuffix(code))
+			_, err := kv.Put(t.Context(), "key", []byte(`{"counter":1}`))
+			require.NoError(t, err)
+
+			stub := &casConflictKV{KeyValue: kv, conflictCode: code, updateFailures: maxCASRetries - 1}
+			got, err := casUpdate(t.Context(), stub, "key", func(r *casRecord) { r.Counter++ }, false)
+			require.NoError(t, err)
+			assert.Equal(t, 2, got.Counter)
+			assert.Zero(t, stub.updateFailures, "all injected conflicts must have been consumed")
+		})
+	}
+}
+
+func TestCASUpdate_ExhaustsRetriesOnSustainedConflict(t *testing.T) {
+	for name, code := range conflictCodes {
+		t.Run(name, func(t *testing.T) {
+			kv := casTestBucket(t, "cas-exhaust-"+jetstreamCodeSuffix(code))
+			_, err := kv.Put(t.Context(), "key", []byte(`{"counter":1}`))
+			require.NoError(t, err)
+
+			stub := &casConflictKV{KeyValue: kv, conflictCode: code, updateFailures: maxCASRetries + 1}
+			_, err = casUpdate(t.Context(), stub, "key", func(r *casRecord) { r.Counter++ }, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "CAS update exhausted")
+			assert.ErrorIs(t, err, jetstream.ErrKeyRevisionMismatch)
+		})
+	}
+}
+
+func TestCASPut_RetriesRevisionConflict(t *testing.T) {
+	for name, code := range conflictCodes {
+		t.Run(name, func(t *testing.T) {
+			kv := casTestBucket(t, "cas-put-"+jetstreamCodeSuffix(code))
+			_, err := kv.Put(t.Context(), "key", []byte(`{"counter":1}`))
+			require.NoError(t, err)
+
+			stub := &casConflictKV{KeyValue: kv, conflictCode: code, updateFailures: maxCASRetries - 1}
+			require.NoError(t, casPut(t.Context(), stub, "key", []byte(`{"counter":9}`), false))
+			assert.Zero(t, stub.updateFailures, "all injected conflicts must have been consumed")
+
+			entry, err := kv.Get(t.Context(), "key")
+			require.NoError(t, err)
+			assert.JSONEq(t, `{"counter":9}`, string(entry.Value()))
+		})
+	}
+}
+
+// casClaim's write is a revision-guarded Delete, which reports a lost race only
+// as ErrKeyRevisionMismatch — ErrKeyExists never matches it on any replica count
+// once the conflict carries the replicated code.
+func TestCASClaim_RetriesRevisionConflict(t *testing.T) {
+	for name, code := range conflictCodes {
+		t.Run(name, func(t *testing.T) {
+			kv := casTestBucket(t, "cas-claim-"+jetstreamCodeSuffix(code))
+			_, err := kv.Put(t.Context(), "key", []byte(`{"counter":7}`))
+			require.NoError(t, err)
+
+			stub := &casConflictKV{KeyValue: kv, conflictCode: code, deleteFailures: maxCASRetries - 1}
+			got, notFound, err := casClaim[casRecord](t.Context(), stub, "key")
+			require.NoError(t, err)
+			require.False(t, notFound)
+			require.NotNil(t, got)
+			assert.Equal(t, 7, got.Counter)
+			assert.Zero(t, stub.deleteFailures, "all injected conflicts must have been consumed")
+
+			_, err = kv.Get(t.Context(), "key")
+			assert.ErrorIs(t, err, jetstream.ErrKeyNotFound, "the claim must have removed the key")
+		})
+	}
+}
+
+func jetstreamCodeSuffix(code jetstream.ErrorCode) string {
+	return fmt.Sprintf("%d", code)
+}

--- a/spinifex/daemon/daemon_mgmt_ip.go
+++ b/spinifex/daemon/daemon_mgmt_ip.go
@@ -38,7 +38,9 @@ func updateMgmtIPAMWithRetry(jsManager *JetStreamManager, subnet string, mutate 
 		if err == nil {
 			return record, nil
 		}
-		if !errors.Is(err, jetstream.ErrKeyExists) {
+		// casUpdate commits with Create or Update depending on whether the key
+		// existed, so exhaustion can wrap either conflict sentinel.
+		if !errors.Is(err, jetstream.ErrKeyExists) && !errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return nil, err
 		}
 		lastErr = err

--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -263,15 +263,6 @@ func (m *JetStreamManager) recoverTerminatedKVBucket(ctx context.Context) (jetst
 // the key, not a single overlapping update — callers should surface an error.
 const maxCASRetries = 5
 
-// isRevisionConflict reports whether err is the nats.go "wrong last
-// sequence" error that KeyValue.Update/Create return when the key's
-// revision no longer matches what the caller expected, i.e. a concurrent
-// writer won the race. The jetstream package surfaces this as
-// jetstream.ErrKeyExists for both Update (stale revision) and Create (key already present).
-func isRevisionConflict(err error) bool {
-	return errors.Is(err, jetstream.ErrKeyExists)
-}
-
 // casUpdate performs an optimistic-concurrency read-modify-write against kv:
 // Get the current entry (or start from a zero value when absent and
 // createIfAbsent is set), apply mutate to the decoded value, then commit via
@@ -312,7 +303,10 @@ func casUpdate[T any](ctx context.Context, kv jetstream.KeyValue, key string, mu
 		if err == nil {
 			return &value, nil
 		}
-		if isRevisionConflict(err) {
+		// Create reports a lost race as ErrKeyExists, Update as
+		// ErrKeyRevisionMismatch — and only the latter holds on a replicated
+		// bucket, where the conflict carries a different API error code.
+		if errors.Is(err, jetstream.ErrKeyExists) || errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			lastErr = err
 			continue
 		}
@@ -351,7 +345,10 @@ func casPut(ctx context.Context, kv jetstream.KeyValue, key string, data []byte,
 		if err == nil {
 			return nil
 		}
-		if isRevisionConflict(err) {
+		// Create reports a lost race as ErrKeyExists, Update as
+		// ErrKeyRevisionMismatch — and only the latter holds on a replicated
+		// bucket, where the conflict carries a different API error code.
+		if errors.Is(err, jetstream.ErrKeyExists) || errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			lastErr = err
 			continue
 		}
@@ -386,7 +383,9 @@ func casClaim[T any](ctx context.Context, kv jetstream.KeyValue, key string) (va
 		}
 
 		if derr := kv.Delete(ctx, key, jetstream.LastRevision(entry.Revision())); derr != nil {
-			if isRevisionConflict(derr) {
+			// A revision-guarded Delete reports a lost race only as
+			// ErrKeyRevisionMismatch; ErrKeyExists never matches on R>1.
+			if errors.Is(derr, jetstream.ErrKeyRevisionMismatch) {
 				lastErr = derr
 				continue
 			}

--- a/spinifex/gateway/bedrock/usage.go
+++ b/spinifex/gateway/bedrock/usage.go
@@ -239,7 +239,10 @@ func (s *UsageStore) Apply(ctx context.Context, rec InvocationRecord, price Pric
 		if err == nil {
 			return nil
 		}
-		if !isUsageCASConflict(err) {
+		// Create reports a lost race as ErrKeyExists, Update as
+		// ErrKeyRevisionMismatch — and only the latter holds on a replicated
+		// bucket, where the conflict carries a different API error code.
+		if !errors.Is(err, jetstream.ErrKeyExists) && !errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return fmt.Errorf("kv write usage counters for %s: %w", key, err)
 		}
 	}
@@ -284,20 +287,6 @@ func (s *UsageStore) TokensThisPeriod(ctx context.Context, accountID string) (in
 		total += counters.InputTokens + counters.OutputTokens
 	}
 	return total, nil
-}
-
-// isUsageCASConflict reports whether err is a lost optimistic-concurrency
-// race on the usage counter: a Create on an existing key or an Update
-// against a stale revision. Mirrors handlers_quota.isCASConflict — the two
-// packages don't share an import for this one four-line check.
-func isUsageCASConflict(err error) bool {
-	if errors.Is(err, jetstream.ErrKeyExists) {
-		return true
-	}
-	if apiErr, ok := errors.AsType[*jetstream.APIError](err); ok {
-		return apiErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence
-	}
-	return false
 }
 
 // EnsureUsageConsumer idempotently creates (or updates) this package's

--- a/spinifex/handlers/acm/store.go
+++ b/spinifex/handlers/acm/store.go
@@ -484,7 +484,7 @@ func (s *Store) updateInUseByCAS(ctx context.Context, certArn string, mutate fun
 			return fmt.Errorf("marshal cert: %w", err)
 		}
 		if _, err := s.kv.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				// Another writer updated the record between our Get and
 				// Update; back off briefly (jittered, so contending writers
 				// don't all re-collide on the same revision) and retry
@@ -541,7 +541,7 @@ func (s *Store) AcquireLease(ctx context.Context, certArn, holderID string, ttl 
 		return false, fmt.Errorf("marshal cert: %w", err)
 	}
 	if _, err := s.kv.Update(ctx, key, data, entry.Revision()); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			// Lost the race to a concurrent acquirer between Get and Update;
 			// the caller skips this tick rather than retrying immediately.
 			return false, nil
@@ -578,7 +578,7 @@ func (s *Store) ReleaseLease(ctx context.Context, certArn, holderID string) erro
 		return fmt.Errorf("marshal cert: %w", err)
 	}
 	if _, err := s.kv.Update(ctx, key, data, entry.Revision()); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return nil // record changed concurrently; nothing to clean up
 		}
 		return err

--- a/spinifex/handlers/bedrock/reaper.go
+++ b/spinifex/handlers/bedrock/reaper.go
@@ -311,7 +311,7 @@ func (r *Reaper) persistObservation(ctx context.Context, kv jetstream.KeyValue, 
 	}
 	next.Generation = current.Generation + 1
 	if err := updateJSON(ctx, kv, key, rev, next); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return nil
 		}
 		return err

--- a/spinifex/handlers/dns/zonelock.go
+++ b/spinifex/handlers/dns/zonelock.go
@@ -111,9 +111,11 @@ func (l *zoneLocker) lockZone(ctx context.Context, zone string) (*zoneLock, erro
 	deadline := time.Now().Add(zoneLockWaitFor)
 	step := zoneLockStep
 	for {
+		// Create maps a taken zone to ErrKeyExists on every replica count,
+		// which is the retryable case; anything else is a real failure.
 		if _, err := kv.Create(ctx, key, []byte(l.holder)); err == nil {
 			return &zoneLock{locker: l, kv: kv, key: key, zone: zone, acquired: time.Now()}, nil
-		} else if !isZoneLockHeld(err) {
+		} else if !errors.Is(err, jetstream.ErrKeyExists) {
 			return nil, fmt.Errorf("acquire dns zone lock %s: %w", zone, err)
 		}
 		if time.Now().After(deadline) {
@@ -194,19 +196,6 @@ func (l *zoneLocker) bucket(ctx context.Context) (jetstream.KeyValue, error) {
 
 	l.kv = kv
 	return kv, nil
-}
-
-// isZoneLockHeld reports whether the create failed because another writer holds
-// the zone, which is the retryable case. Mirrors the CAS-conflict test used by
-// the vCPU quota store.
-func isZoneLockHeld(err error) bool {
-	if errors.Is(err, jetstream.ErrKeyExists) {
-		return true
-	}
-	if apiErr, ok := errors.AsType[*jetstream.APIError](err); ok {
-		return apiErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence
-	}
-	return false
 }
 
 // zoneLockKey maps a zone to a NATS KV key. DNS names are already within the

--- a/spinifex/handlers/ec2/routetable/service_impl.go
+++ b/spinifex/handlers/ec2/routetable/service_impl.go
@@ -161,7 +161,7 @@ func (s *RouteTableServiceImpl) mutateRouteTableCAS(ctx context.Context, account
 			return errors.New(awserrors.ErrorServerInternal)
 		}
 		if _, err := s.rtbKV.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				continue // CAS conflict — another writer won, re-read and retry.
 			}
 			slog.ErrorContext(ctx, "Failed to write route table to KV", "routeTableId", rtbID, "err", err)

--- a/spinifex/handlers/ec2/routetable/service_impl.go
+++ b/spinifex/handlers/ec2/routetable/service_impl.go
@@ -169,6 +169,10 @@ func (s *RouteTableServiceImpl) mutateRouteTableCAS(ctx context.Context, account
 		}
 		return nil
 	}
+	// Only a CAS conflict reaches here, so the record is contended rather than
+	// broken; say so, or the caller's InternalError has no cause anywhere.
+	slog.ErrorContext(ctx, "Route table CAS retries exhausted under contention",
+		"routeTableId", rtbID, "attempts", rtbCASMaxRetries)
 	return errors.New(awserrors.ErrorServerInternal)
 }
 

--- a/spinifex/handlers/ecr/meta.go
+++ b/spinifex/handlers/ecr/meta.go
@@ -461,7 +461,7 @@ func (s *KVMetaStore) UpdateUpload(ctx context.Context, accountID, uploadID stri
 	}
 	newRev, err := kv.Update(ctx, KVUploadKey(uploadID), data, rev)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return 0, ErrConflict
 		}
 		return 0, err

--- a/spinifex/handlers/eks/access_entry.go
+++ b/spinifex/handlers/eks/access_entry.go
@@ -160,7 +160,7 @@ func casUpdateAccessEntry(ctx context.Context, kv jetstream.KeyValue, cluster, p
 		if err == nil {
 			return &rec, nil
 		}
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			continue
 		}
 		return nil, fmt.Errorf("kv update %s: %w", key, err)

--- a/spinifex/handlers/eks/addon_state.go
+++ b/spinifex/handlers/eks/addon_state.go
@@ -173,7 +173,7 @@ func casUpdateAddon(ctx context.Context, kv jetstream.KeyValue, cluster, addon s
 		if err == nil {
 			return &rec, nil
 		}
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			continue
 		}
 		return nil, fmt.Errorf("kv update %s: %w", key, err)

--- a/spinifex/handlers/eks/cluster_state.go
+++ b/spinifex/handlers/eks/cluster_state.go
@@ -238,7 +238,7 @@ func casUpdateMeta(ctx context.Context, kv jetstream.KeyValue, name string, muta
 		if err == nil {
 			return nil
 		}
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			continue
 		}
 		return fmt.Errorf("kv update %s: %w", ClusterMetaKey(name), err)

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -1037,7 +1037,7 @@ func (s *EKSServiceImpl) casPutNodegroup(ctx context.Context, kv jetstream.KeyVa
 		return false, fmt.Errorf("marshal nodegroup %s: %w", rec.Name, err)
 	}
 	if _, err := kv.Update(ctx, NodegroupKey(rec.ClusterName, rec.Name), data, rev); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return false, nil
 		}
 		return false, fmt.Errorf("kv update nodegroup %s: %w", rec.Name, err)

--- a/spinifex/handlers/elbv2/store.go
+++ b/spinifex/handlers/elbv2/store.go
@@ -143,7 +143,7 @@ func (s *Store) ClaimLBName(ctx context.Context, name, accountID, lbID string) (
 		}
 		// Orphaned (crashed prior create, past its TTL) or already ours: CAS-take.
 		if _, uerr := s.kv.Update(ctx, key, claimBytes, entry.Revision()); uerr != nil {
-			if errors.Is(uerr, jetstream.ErrKeyExists) {
+			if errors.Is(uerr, jetstream.ErrKeyRevisionMismatch) {
 				continue // lost the CAS race; re-read
 			}
 			return false, false, fmt.Errorf("kv update %s: %w", key, uerr)

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -606,6 +606,10 @@ func (s *IAMServiceImpl) updateRoleCAS(ctx context.Context, accountID, roleName 
 		}
 		return nil
 	}
+	// Only a CAS conflict reaches here, so the role is contended rather than
+	// broken; say so, or the caller's InternalError has no cause anywhere.
+	slog.Error("IAM role CAS retries exhausted under contention",
+		"accountID", accountID, "roleName", roleName, "attempts", roleCASMaxRetries)
 	return errors.New(awserrors.ErrorServerInternal)
 }
 

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -599,7 +599,7 @@ func (s *IAMServiceImpl) updateRoleCAS(ctx context.Context, accountID, roleName 
 			return fmt.Errorf("marshal role: %w", err)
 		}
 		if _, err := s.rolesBucket.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				continue // CAS conflict — another writer won, re-read and retry.
 			}
 			return fmt.Errorf("update role: %w", err)

--- a/spinifex/handlers/iam/service_impl.go
+++ b/spinifex/handlers/iam/service_impl.go
@@ -981,7 +981,7 @@ func (s *IAMServiceImpl) CreateAccount(name string) (*Account, error) {
 
 		newVal := []byte(strconv.FormatInt(nextID+1, 10))
 		if _, err := s.accountCounterBucket.Update(ctx, "next_id", newVal, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				continue // CAS conflict, retry
 			}
 			return nil, fmt.Errorf("update account counter: %w", err)

--- a/spinifex/handlers/quota/vcpu.go
+++ b/spinifex/handlers/quota/vcpu.go
@@ -64,7 +64,10 @@ func (s *Service) casVCPU(ctx context.Context, accountID string, next func(curre
 		if err == nil {
 			return nil
 		}
-		if !isCASConflict(err) {
+		// Create reports a lost race as ErrKeyExists, Update as
+		// ErrKeyRevisionMismatch — and only the latter holds on a replicated
+		// bucket, where the conflict carries a different API error code.
+		if !errors.Is(err, jetstream.ErrKeyExists) && !errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return err
 		}
 	}
@@ -111,20 +114,6 @@ func (s *Service) reconcileVCPU(ctx context.Context, accountID string, value int
 		return nil
 	}
 	return s.setVCPU(ctx, accountID, value)
-}
-
-// isCASConflict reports whether err is a lost optimistic-concurrency race: a
-// Create on an existing key or an Update against a stale revision. Both map to
-// JetStream's wrong-last-sequence code and are retryable; any other error is a
-// genuine failure the caller must surface.
-func isCASConflict(err error) bool {
-	if errors.Is(err, jetstream.ErrKeyExists) {
-		return true
-	}
-	if apiErr, ok := errors.AsType[*jetstream.APIError](err); ok {
-		return apiErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence
-	}
-	return false
 }
 
 // EnforceLaunch is the check-before gate for RunInstances: it rejects when the

--- a/spinifex/handlers/rds/backup.go
+++ b/spinifex/handlers/rds/backup.go
@@ -364,7 +364,7 @@ func (s *Service) runMaintenanceWindow(ctx context.Context, kv jetstream.KeyValu
 	rec.Status = StatusModifying
 	rec.UpdatedAt = now
 	if err := updateJSON(ctx, kv, DBInstanceKey(rec.DBInstanceIdentifier), rev, rec); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			// Something else moved the record between the read and here; the next
 			// pass re-reads and the window is still open.
 			return false, nil

--- a/spinifex/handlers/rds/create.go
+++ b/spinifex/handlers/rds/create.go
@@ -270,7 +270,7 @@ func (s *Service) rollbackDBInstanceReservation(ctx context.Context, kv jetstrea
 		if rollbackErr == nil || errors.Is(rollbackErr, jetstream.ErrKeyNotFound) {
 			return
 		}
-		if !errors.Is(rollbackErr, jetstream.ErrKeyExists) {
+		if !errors.Is(rollbackErr, jetstream.ErrKeyRevisionMismatch) {
 			break
 		}
 

--- a/spinifex/handlers/rds/delete.go
+++ b/spinifex/handlers/rds/delete.go
@@ -84,7 +84,7 @@ func (s *Service) DeleteDBInstance(ctx context.Context, input *rds.DeleteDBInsta
 			if reservation.creator {
 				s.rollbackFinalSnapshotReservation(ctx, kv, finalSnapshot, reservation.revision)
 			}
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				return nil, awserrors.Errorf(awserrors.ErrorDBInstanceInvalidState,
 					"DB instance %s changed state concurrently; retry the delete", id)
 			}
@@ -428,7 +428,7 @@ func (s *Service) completeFinalSnapshot(ctx context.Context, kv jetstream.KeyVal
 		record.Status = SnapshotStatusAvailable
 		if err := updateJSON(ctx, kv, key, rev, &record); err == nil {
 			return true, nil
-		} else if !errors.Is(err, jetstream.ErrKeyExists) {
+		} else if !errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return false, err
 		}
 	}

--- a/spinifex/handlers/rds/events.go
+++ b/spinifex/handlers/rds/events.go
@@ -128,8 +128,9 @@ func (s *Service) appendEvent(ctx context.Context, accountID, sourceType, source
 		if err == nil {
 			return nil
 		}
-		// jetstream.ErrKeyExists on Update is a revision mismatch, not a duplicate.
-		if !errors.Is(err, jetstream.ErrKeyExists) {
+		// A revision mismatch is a lost race with another appender, not a
+		// duplicate: re-read the ring and append to what they wrote.
+		if !errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return err
 		}
 	}

--- a/spinifex/handlers/rds/lifecycle.go
+++ b/spinifex/handlers/rds/lifecycle.go
@@ -303,7 +303,7 @@ func (s *Service) beginTransition(ctx context.Context, accountID, id string, to 
 	rec.TransitionStartedAt = &now
 	rec.UpdatedAt = now
 	if err := updateJSON(ctx, kv, DBInstanceKey(id), rev, rec); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return nil, nil, awserrors.Errorf(awserrors.ErrorDBInstanceInvalidState,
 				"DB instance %s changed state concurrently; retry the operation", id)
 		}
@@ -372,7 +372,7 @@ func (s *Service) updateInstanceIf(ctx context.Context, kv jetstream.KeyValue, i
 		if err == nil {
 			return true, nil
 		}
-		if !errors.Is(err, jetstream.ErrKeyExists) {
+		if !errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return false, err
 		}
 	}

--- a/spinifex/handlers/rds/reconciler.go
+++ b/spinifex/handlers/rds/reconciler.go
@@ -662,7 +662,7 @@ func (r *Reconciler) resolveCreatingSnapshot(ctx context.Context, kv jetstream.K
 	if snapshotID == "" {
 		if err := kv.Delete(ctx, DBSnapshotKey(rec.DBSnapshotIdentifier), jetstream.LastRevision(rev)); err != nil {
 			switch {
-			case errors.Is(err, jetstream.ErrKeyNotFound), errors.Is(err, jetstream.ErrKeyExists):
+			case errors.Is(err, jetstream.ErrKeyNotFound), errors.Is(err, jetstream.ErrKeyRevisionMismatch):
 				// A concurrent completion or delete owns the newer revision.
 				return nil
 			default:
@@ -683,7 +683,7 @@ func (r *Reconciler) resolveCreatingSnapshot(ctx context.Context, kv jetstream.K
 	// conservative reading is the one that never overstates the snapshot.
 	rec.CrashConsistent = true
 	if err := updateJSON(ctx, kv, DBSnapshotKey(rec.DBSnapshotIdentifier), rev, rec); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return nil
 		}
 		return err
@@ -785,7 +785,7 @@ func (r *Reconciler) transition(ctx context.Context, kv jetstream.KeyValue, rev 
 	rec.UpdatedAt = time.Now().UTC()
 
 	if err := updateJSON(ctx, kv, DBInstanceKey(rec.DBInstanceIdentifier), rev, rec); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			slog.DebugContext(ctx, "rds reconciler: transition lost a revision race; retrying next pass",
 				"dbInstance", rec.DBInstanceIdentifier, "to", to)
 			return nil

--- a/spinifex/handlers/rds/recovery.go
+++ b/spinifex/handlers/rds/recovery.go
@@ -154,7 +154,7 @@ func (r *Reconciler) recordFailure(ctx context.Context, kv jetstream.KeyValue, r
 func (r *Reconciler) persistFailureClock(ctx context.Context, kv jetstream.KeyValue, rev uint64, rec *DBInstanceRecord) error {
 	rec.UpdatedAt = time.Now().UTC()
 	err := updateJSON(ctx, kv, DBInstanceKey(rec.DBInstanceIdentifier), rev, rec)
-	if errors.Is(err, jetstream.ErrKeyExists) {
+	if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 		slog.DebugContext(ctx, "rds reconciler: failure clock lost a revision race; retrying next pass",
 			"dbInstance", rec.DBInstanceIdentifier)
 		return nil

--- a/spinifex/handlers/rds/snapshot.go
+++ b/spinifex/handlers/rds/snapshot.go
@@ -649,7 +649,7 @@ func (s *Service) beginSnapshotOperation(ctx context.Context, kv jetstream.KeyVa
 	rec.UpdatedAt = now
 
 	if err := updateJSON(ctx, kv, DBInstanceKey(rec.DBInstanceIdentifier), rev, rec); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return "", awserrors.Errorf(awserrors.ErrorDBInstanceInvalidState,
 				"DB instance %s changed state concurrently; retry the snapshot", rec.DBInstanceIdentifier)
 		}

--- a/spinifex/handlers/rds/tags.go
+++ b/spinifex/handlers/rds/tags.go
@@ -212,8 +212,9 @@ func mutateTags(ctx context.Context, kv jetstream.KeyValue, resource taggableRes
 		if err == nil {
 			return nil
 		}
-		// jetstream.ErrKeyExists is a revision mismatch on Update, not a duplicate.
-		if !errors.Is(err, jetstream.ErrKeyExists) {
+		// A revision mismatch is a lost race with another writer, not a
+		// duplicate: re-read the record and re-apply the tag mutation.
+		if !errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 			return err
 		}
 	}

--- a/spinifex/migrate/001_security_group.go
+++ b/spinifex/migrate/001_security_group.go
@@ -110,8 +110,8 @@ func backfillSGRuleIDs(ctx context.Context, kvc KVContext, key string) error {
 			return fmt.Errorf("marshal %s: %w", key, err)
 		}
 		if _, err := kvc.KV.Update(ctx, key, data, entry.Revision()); err != nil {
-			// jetstream.ErrKeyExists = revision mismatch (JSStreamWrongLastSequence).
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			// A concurrent writer moved the record between the Get and here.
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				kvc.Logger.Warn("SG migration CAS conflict, retrying", "key", key, "attempt", attempt+1)
 				lastErr = err
 				continue

--- a/spinifex/migrate/001_security_group_test.go
+++ b/spinifex/migrate/001_security_group_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -141,21 +142,43 @@ func TestSGMigration_EmptyBucket(t *testing.T) {
 	runSGMigration(t, kv)
 }
 
+// wrongLastSequence builds the error kvs.Update returns for a lost CAS race on
+// a bucket whose stream reports the conflict under code. Single-replica streams
+// report 10071, replicated ones 10164; both are wrapped with
+// ErrKeyRevisionMismatch, and only 10071 also satisfies ErrKeyExists.
+func wrongLastSequence(code jetstream.ErrorCode) error {
+	apiErr := &jetstream.APIError{
+		ErrorCode:   code,
+		Code:        400,
+		Description: "wrong last sequence: 3",
+	}
+	return fmt.Errorf("%w: %w", apiErr, jetstream.ErrKeyRevisionMismatch)
+}
+
 // casConflictKV wraps a jetstream.KeyValue and forces the next failuresLeft
-// Update calls to return jetstream.ErrKeyExists, simulating the JetStream
-// wrong-last-sequence response that backfillSGRuleIDs retries on.
+// Update calls to fail with a wrong-last-sequence response, simulating the
+// concurrent writer that backfillSGRuleIDs retries on.
 type casConflictKV struct {
 	jetstream.KeyValue
 
 	failuresLeft int
+	conflictCode jetstream.ErrorCode
 }
 
 func (k *casConflictKV) Update(ctx context.Context, key string, value []byte, last uint64) (uint64, error) {
 	if k.failuresLeft > 0 {
 		k.failuresLeft--
-		return 0, jetstream.ErrKeyExists
+		return 0, wrongLastSequence(k.conflictCode)
 	}
 	return k.KeyValue.Update(ctx, key, value, last)
+}
+
+// conflictCodes names the two wrong-last-sequence codes a KV bucket can report,
+// so every CAS test runs against a replicated bucket as well as a single-replica
+// one. A predicate that only matches ErrKeyExists passes R1 and fails R3.
+var conflictCodes = map[string]jetstream.ErrorCode{
+	"single replica": jetstream.JSErrCodeStreamWrongLastSequence,
+	"replicated":     jetstream.JSErrCodeStreamWrongLastSequenceConstant,
 }
 
 func seedSGRecord(t *testing.T, kv jetstream.KeyValue) string {
@@ -178,35 +201,44 @@ func seedSGRecord(t *testing.T, kv jetstream.KeyValue) string {
 }
 
 func TestSGMigration_RetriesOnCASConflict(t *testing.T) {
-	kv := sgMigrationKV(t)
-	key := seedSGRecord(t, kv)
+	for name, code := range conflictCodes {
+		t.Run(name, func(t *testing.T) {
+			kv := sgMigrationKV(t)
+			key := seedSGRecord(t, kv)
 
-	stub := &casConflictKV{KeyValue: kv, failuresLeft: sgMigrationMaxRetries - 1}
-	err := backfillSGRuleIDs(t.Context(), KVContext{KV: stub, Logger: slog.Default()}, key)
-	require.NoError(t, err)
-	assert.Equal(t, 0, stub.failuresLeft, "all injected conflicts must have been consumed")
+			stub := &casConflictKV{KeyValue: kv, failuresLeft: sgMigrationMaxRetries - 1, conflictCode: code}
+			err := backfillSGRuleIDs(t.Context(), KVContext{KV: stub, Logger: slog.Default()}, key)
+			require.NoError(t, err)
+			assert.Equal(t, 0, stub.failuresLeft, "all injected conflicts must have been consumed")
 
-	entry, err := kv.Get(t.Context(), key)
-	require.NoError(t, err)
-	var got sgRecord
-	require.NoError(t, json.Unmarshal(entry.Value(), &got))
-	require.Len(t, got.IngressRules, 1)
-	assert.Regexp(t, `^sgr-[0-9a-f]{17}$`, got.IngressRules[0].RuleId)
+			entry, err := kv.Get(t.Context(), key)
+			require.NoError(t, err)
+			var got sgRecord
+			require.NoError(t, json.Unmarshal(entry.Value(), &got))
+			require.Len(t, got.IngressRules, 1)
+			assert.Regexp(t, `^sgr-[0-9a-f]{17}$`, got.IngressRules[0].RuleId)
+		})
+	}
 }
 
 func TestSGMigration_FailsAfterCASRetryExhaustion(t *testing.T) {
-	kv := sgMigrationKV(t)
-	key := seedSGRecord(t, kv)
+	for name, code := range conflictCodes {
+		t.Run(name, func(t *testing.T) {
+			kv := sgMigrationKV(t)
+			key := seedSGRecord(t, kv)
 
-	stub := &casConflictKV{KeyValue: kv, failuresLeft: sgMigrationMaxRetries + 1}
-	err := backfillSGRuleIDs(t.Context(), KVContext{KV: stub, Logger: slog.Default()}, key)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeded 3 CAS retries")
-	assert.ErrorIs(t, err, jetstream.ErrKeyExists, "exhaustion error must wrap the underlying CAS conflict")
+			stub := &casConflictKV{KeyValue: kv, failuresLeft: sgMigrationMaxRetries + 1, conflictCode: code}
+			err := backfillSGRuleIDs(t.Context(), KVContext{KV: stub, Logger: slog.Default()}, key)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "exceeded 3 CAS retries")
+			assert.ErrorIs(t, err, jetstream.ErrKeyRevisionMismatch,
+				"exhaustion error must wrap the underlying CAS conflict")
 
-	entry, err := kv.Get(t.Context(), key)
-	require.NoError(t, err)
-	var got sgRecord
-	require.NoError(t, json.Unmarshal(entry.Value(), &got))
-	assert.Empty(t, got.IngressRules[0].RuleId, "record must be untouched after retry exhaustion")
+			entry, err := kv.Get(t.Context(), key)
+			require.NoError(t, err)
+			var got sgRecord
+			require.NoError(t, json.Unmarshal(entry.Value(), &got))
+			assert.Empty(t, got.IngressRules[0].RuleId, "record must be untouched after retry exhaustion")
+		})
+	}
 }

--- a/spinifex/migrate/002_external_ipam_purpose.go
+++ b/spinifex/migrate/002_external_ipam_purpose.go
@@ -122,7 +122,7 @@ func renameExternalIPAMType(ctx context.Context, kvc KVContext, key string) erro
 			return fmt.Errorf("marshal %s: %w", key, err)
 		}
 		if _, err := kvc.KV.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				kvc.Logger.Warn("external IPAM migration CAS conflict, retrying", "key", key, "attempt", attempt+1)
 				lastErr = err
 				continue

--- a/spinifex/migrate/003_ipam_purpose.go
+++ b/spinifex/migrate/003_ipam_purpose.go
@@ -189,7 +189,7 @@ func convertIPAMRecord(ctx context.Context, kvc KVContext, key string, ownerInde
 			return fmt.Errorf("marshal %s: %w", key, err)
 		}
 		if _, err := kvc.KV.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyExists) {
+			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
 				kvc.Logger.Warn("internal IPAM migration CAS conflict, retrying", "key", key, "attempt", attempt+1)
 				lastErr = err
 				continue

--- a/spinifex/services/viperblockd/volume_lease.go
+++ b/spinifex/services/viperblockd/volume_lease.go
@@ -290,7 +290,9 @@ func (lease *volumeLease) renew(ctx context.Context) bool {
 		return true
 	case errors.Is(err, context.Canceled):
 		return false
-	case errors.Is(err, jetstream.ErrKeyExists), errors.Is(err, jetstream.ErrKeyNotFound), isWrongLastSequence(err):
+	// Update reports a lost race as ErrKeyRevisionMismatch on every replica
+	// count; ErrKeyExists only ever matched it by code on a single replica.
+	case errors.Is(err, jetstream.ErrKeyRevisionMismatch), errors.Is(err, jetstream.ErrKeyNotFound):
 		lease.mu.Lock()
 		lease.lost = true
 		lease.mu.Unlock()
@@ -302,13 +304,6 @@ func (lease *volumeLease) renew(ctx context.Context) bool {
 		slog.Warn("volume lease: renewal failed", "volume", lease.volume, "err", err)
 		return true
 	}
-}
-
-// isWrongLastSequence reports whether err is JetStream refusing a write whose
-// expected revision no longer matches, which is how a lost lease presents.
-func isWrongLastSequence(err error) bool {
-	var apiErr *jetstream.APIError
-	return errors.As(err, &apiErr) && apiErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence
 }
 
 // leaseOwner names this node in the lease entries it writes. A daemon with no

--- a/spinifex/services/viperblockd/volume_lease_test.go
+++ b/spinifex/services/viperblockd/volume_lease_test.go
@@ -1,9 +1,12 @@
 package viperblockd
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,6 +118,51 @@ func TestVolumeLease_OpenRefusesWithoutALeaseStore(t *testing.T) {
 	lease, err := cfg.acquireVolumeLease(t.Context(), "vol-nostore00000001")
 	require.Error(t, err, "no lease store must refuse the open, not wave it through")
 	assert.Nil(t, lease)
+}
+
+// conflictKV fails every Update with a wrong-last-sequence response under the
+// given code, which is how a renewal presents once another node has taken the
+// lease over. Single-replica streams report 10071, replicated ones 10164.
+type conflictKV struct {
+	jetstream.KeyValue
+
+	code jetstream.ErrorCode
+}
+
+func (k *conflictKV) Update(context.Context, string, []byte, uint64) (uint64, error) {
+	apiErr := &jetstream.APIError{
+		ErrorCode:   k.code,
+		Code:        400,
+		Description: "wrong last sequence: 3",
+	}
+	return 0, fmt.Errorf("%w: %w", apiErr, jetstream.ErrKeyRevisionMismatch)
+}
+
+// TestVolumeLease_RenewalConflictLosesTheLease is the multi-node regression: a
+// renewal refused on a replicated bucket must mark the lease lost, not shrug it
+// off as transient and keep renewing over whoever now holds the volume.
+func TestVolumeLease_RenewalConflictLosesTheLease(t *testing.T) {
+	for name, code := range map[string]jetstream.ErrorCode{
+		"single replica": jetstream.JSErrCodeStreamWrongLastSequence,
+		"replicated":     jetstream.JSErrCodeStreamWrongLastSequenceConstant,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, natsURL := setupEmbeddedNATS(t)
+			leases := newTestLeases(t, natsURL, "node-a")
+
+			lease, err := leases.acquire(t.Context(), "vol-renewconflict1")
+			require.NoError(t, err)
+			lease.stop()
+			<-lease.done
+
+			leases.kv = &conflictKV{KeyValue: leases.kv, code: code}
+			assert.False(t, lease.renew(t.Context()), "a refused renewal must not report the lease as still held")
+
+			lease.mu.Lock()
+			defer lease.mu.Unlock()
+			assert.True(t, lease.lost, "a refused renewal must mark the lease lost so the renew loop stops")
+		})
+	}
 }
 
 // TestVolumeLease_RejectsUnsafeKeys pins that a volume name off the wire


### PR DESCRIPTION
## Problem

Every optimistic-concurrency loop that inspected a `KeyValue.Update` result detected the lost race with `errors.Is(err, jetstream.ErrKeyExists)`. That sentinel matches by API error code 10071, which only a single-replica stream returns.

`kvs.Update`, and `Delete`/`Purge` with `jetstream.LastRevision`, wrap a conflict with `ErrKeyRevisionMismatch` only. On R=1 the underlying 10071 error incidentally still satisfies `errors.Is(err, ErrKeyExists)`; on a replicated bucket the code is 10164 and the match fails. nats.go v1.53.1 says so on the sentinel itself: *"Do not use ErrKeyExists to detect revision conflicts - use ErrKeyRevisionMismatch."*

So on any multi-node cluster the loser of a CAS race skipped its retry branch and returned a raw `wrong last sequence` error in place of whatever the guard was supposed to decide. Unit tests missed it because they build services at `clusterSize` 1, which yields R=1 and code 10071.

## Changes

- Match `ErrKeyRevisionMismatch` at every site whose error came from an `Update` or a revision-guarded `Delete` — 23 call sites across `migrate`, `acm`, `ec2/routetable`, `ecr`, `eks`, `elbv2`, `iam`, `bedrock`, `rds` and `viperblockd`.
- `Create` maps **both** codes onto `ErrKeyExists`, so `Create`-derived checks are correct as they stand and are left alone.
- Inline the five named predicates that wrapped this check (`daemon.isRevisionConflict`, `handlers/quota.isCASConflict`, `gateway/bedrock.isUsageCASConflict`, `handlers/dns.isZoneLockHeld`, `viperblockd.isWrongLastSequence`), each naming the sentinels its originating write can actually produce. Loops that commit with `Create` or `Update` depending on whether the key existed — the generic CAS primitives, the vCPU counter, the Bedrock usage counter — match both.

### Audited, unchanged

The remaining `LastRevision` deletes (`volume_lease.go:239`, `network/reconcile/lock.go:110`, `rds/delete.go:293`, `rds/agent.go:574`, `ec2/vpc/eni.go:353`) either log the failure without branching on the conflict, or already retry on any error, so the predicate does not decide their behaviour.

## Testing

Every CAS test runs as a subtest over both wrong-last-sequence codes. The injected error is built exactly as `kvs.Update` builds it — an `APIError` under the given code, wrapped with `ErrKeyRevisionMismatch`.

- `spinifex/daemon/cas_conflict_test.go` (new) — `casUpdate`, `casPut` and `casClaim`, covering both retry and retry-exhaustion.
- `spinifex/migrate/001_security_group_test.go` — the existing `casConflictKV` stub now takes a code.
- `spinifex/services/viperblockd/volume_lease_test.go` — a refused renewal must mark the lease lost rather than treat it as transient and keep writing over whichever node now holds the volume.

Each guard was confirmed by reverting the corresponding production check to `ErrKeyExists`: the `replicated` subtest fails, `single replica` passes.

`make preflight` passes.