### PR TITLE
feat: rerank KB retrieve candidates with a cross-encoder; size ingest chunks to embedder limit

### DIFF
--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -324,6 +324,14 @@ type OchreVectorConfig struct {
 	// on every index record. Empty takes gateway_bedrock.DefaultEmbeddingModel
 	// ("nomic-embed-text-v1.5").
 	EmbeddingModel string `json:"EmbeddingModel" mapstructure:"embedding_model"`
+	// RerankEndpoint is the base URL of the self-hosted TEI-compatible
+	// cross-encoder rerank endpoint (gateway_bedrock.Reranker). Empty
+	// disables reranking: Query falls back to plain KNN top-k.
+	RerankEndpoint string `json:"RerankEndpoint" mapstructure:"rerank_endpoint"`
+	// RerankModel documents the cross-encoder served at RerankEndpoint (e.g.
+	// "bge-reranker-v2-m3"). Not sent on the wire: a rerank deployment
+	// serves exactly one model per endpoint, selected by RerankEndpoint alone.
+	RerankModel string `json:"RerankModel" mapstructure:"rerank_model"`
 	// PostgresImage names the appliance's Postgres image. Currently
 	// informational only: RDS's CreateDBInstanceInput has no image-selection
 	// field, so this is not yet threaded into the appliance launch.

--- a/spinifex/daemon/ochre_deps.go
+++ b/spinifex/daemon/ochre_deps.go
@@ -117,6 +117,14 @@ func (d *Daemon) startOchreVector() {
 		embedModel: cfg.EmbeddingsEndpoint,
 	}))
 
+	// reranker is left nil when no endpoint is configured, so Query stays
+	// on plain KNN top-k -- rerank is a feature dependency, never a hard
+	// one, matching how the vector store itself is gated by Enabled alone.
+	var reranker handlers_ochrevector.Reranker
+	if cfg.RerankEndpoint != "" {
+		reranker = gateway_bedrock.NewReranker(cfg.RerankEndpoint)
+	}
+
 	store := objectstore.NewS3ObjectStoreFromConfig(admin.DialTarget(d.config.Predastore.Host),
 		d.config.Predastore.Region, d.config.Predastore.AccessKey, d.config.Predastore.SecretKey)
 
@@ -125,7 +133,7 @@ func (d *Daemon) startOchreVector() {
 	service := handlers_ochrevector.NewService(registry, backend)
 	ingest := handlers_ochrevector.NewIngestService(jobs, registry, backend, store, embedder)
 
-	vectorService := handlers_ochrevector.NewVectorService(service, ingest, jobs, registry, backend, embedder)
+	vectorService := handlers_ochrevector.NewVectorService(service, ingest, jobs, registry, backend, embedder, reranker)
 
 	// A shutdown that lands in the gap between Connect succeeding above and
 	// this check does not leave anything to unwind: nothing has been

--- a/spinifex/gateway/bedrock/embeddings.go
+++ b/spinifex/gateway/bedrock/embeddings.go
@@ -8,11 +8,27 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync"
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
-const embeddingsPath = "/v1/embeddings"
+const (
+	embeddingsPath = "/v1/embeddings"
+	infoPath       = "/info"
+	tokenizePath   = "/tokenize"
+
+	// defaultMaxInputLength is the conservative token budget assumed when an
+	// endpoint's TEI /info is unavailable, times out, or omits
+	// max_input_length (e.g. a plain OpenAI-compatible endpoint with no TEI
+	// introspection support) -- bge-base-en-v1.5's own 512-token cap, so a
+	// pre-introspection or non-TEI endpoint still guards chunk sizing.
+	defaultMaxInputLength = 512
+
+	// maxIntrospectionResponseBytes bounds the /info and /tokenize response
+	// bodies read into memory, mirroring the ingest path's bounded reads.
+	maxIntrospectionResponseBytes = 1 << 20
+)
 
 // DefaultEmbeddingModel is Ochre's CPU-served embedding model. Callers pin a
 // dimension per vector index; the adapter itself never hardcodes one and
@@ -23,6 +39,36 @@ const DefaultEmbeddingModel = "nomic-embed-text-v1.5"
 // endpoint, returning vectors ordered to match the caller's input slice.
 type Embedder interface {
 	Embed(ctx context.Context, modelID string, inputs []string) ([][]float32, error)
+}
+
+// TokenLimiter is implemented by Embedders that can report the served
+// model's real token budget, so callers (the ingest chunker) can size chunks
+// to it instead of a fixed rune guess. It is optional -- a caller type-
+// asserts for it rather than requiring it on Embedder, so a non-TEI or test
+// double Embedder still satisfies Embedder alone.
+type TokenLimiter interface {
+	// MaxInputLength returns modelID's served max_input_length in tokens,
+	// querying and caching TEI GET /info once per resolved base URL. It
+	// never errors: an unreachable or non-TEI endpoint logs at debug and
+	// returns defaultMaxInputLength, since introspection is best-effort and
+	// must never block ingestion.
+	MaxInputLength(ctx context.Context, modelID string) int
+	// CountTokens returns text's exact token count via TEI POST /tokenize.
+	// ok is false when the endpoint doesn't support /tokenize or the call
+	// fails, telling the caller to fall back to its own estimate.
+	CountTokens(ctx context.Context, modelID, text string) (count int, ok bool)
+}
+
+// infoResponse is the subset of TEI's GET /info payload this adapter reads;
+// every other field (model id, dtype, etc.) is ignored.
+type infoResponse struct {
+	MaxInputLength int `json:"max_input_length"`
+}
+
+// tokenizeToken is one element of TEI's POST /tokenize response array --
+// only the array's length (the token count) is used here.
+type tokenizeToken struct {
+	ID int `json:"id"`
 }
 
 type embeddingsRequest struct {
@@ -52,9 +98,15 @@ type embeddingsResponse struct {
 type embeddingsProvider struct {
 	endpointResolver EndpointResolver
 	httpClient       *http.Client
+	// infoCache holds baseURL -> max_input_length (int), populated once per
+	// endpoint the first time MaxInputLength resolves it. TEI /info never
+	// changes for a running server, so this is cached for the process
+	// lifetime rather than re-fetched per call.
+	infoCache sync.Map
 }
 
 var _ Embedder = (*embeddingsProvider)(nil)
+var _ TokenLimiter = (*embeddingsProvider)(nil)
 
 // newEmbeddingsProvider constructs an embeddingsProvider resolving endpoints
 // via the shared EndpointResolver — the same static/registry-backed resolver
@@ -135,6 +187,100 @@ func (p *embeddingsProvider) Embed(ctx context.Context, modelID string, inputs [
 		return nil, errors.New(awserrors.ErrorModelErrorException)
 	}
 	return vectors, nil
+}
+
+// MaxInputLength implements TokenLimiter: it resolves modelID's endpoint and
+// returns its cached (or freshly fetched) TEI /info max_input_length,
+// falling back to defaultMaxInputLength whenever the endpoint can't be
+// resolved or /info can't be read -- introspection is best-effort and must
+// never fail ingestion.
+func (p *embeddingsProvider) MaxInputLength(ctx context.Context, modelID string) int {
+	baseURL, ok, err := p.endpointResolver.Endpoint(ctx, modelID)
+	if err != nil || !ok {
+		return defaultMaxInputLength
+	}
+	if cached, ok := p.infoCache.Load(baseURL); ok {
+		if limit, ok := cached.(int); ok {
+			return limit
+		}
+	}
+	limit := p.fetchMaxInputLength(ctx, baseURL)
+	p.infoCache.Store(baseURL, limit)
+	return limit
+}
+
+// fetchMaxInputLength queries baseURL's TEI GET /info once. Any failure --
+// unreachable endpoint, non-2xx status, or a response missing/zeroing
+// max_input_length -- logs at debug and returns defaultMaxInputLength rather
+// than propagating an error, since a non-TEI endpoint (no /info at all) is a
+// normal, supported configuration, not a fault.
+func (p *embeddingsProvider) fetchMaxInputLength(ctx context.Context, baseURL string) int {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+infoPath, nil)
+	if err != nil {
+		slog.Debug("embeddings: failed to build /info request, using default max_input_length", "endpoint", baseURL, "default", defaultMaxInputLength, "err", err)
+		return defaultMaxInputLength
+	}
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		slog.Debug("embeddings: /info request failed, using default max_input_length", "endpoint", baseURL, "default", defaultMaxInputLength, "err", err)
+		return defaultMaxInputLength
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Debug("embeddings: /info returned non-OK status, using default max_input_length", "endpoint", baseURL, "status", resp.StatusCode, "default", defaultMaxInputLength)
+		return defaultMaxInputLength
+	}
+
+	var info infoResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxIntrospectionResponseBytes)).Decode(&info); err != nil || info.MaxInputLength <= 0 {
+		slog.Debug("embeddings: /info missing or invalid max_input_length, using default", "endpoint", baseURL, "default", defaultMaxInputLength)
+		return defaultMaxInputLength
+	}
+	return info.MaxInputLength
+}
+
+// CountTokens implements TokenLimiter: it POSTs text to baseURL's TEI
+// /tokenize and returns the response array's length as the exact token
+// count. Any failure returns ok=false rather than a guessed count, so the
+// caller falls back to its own conservative estimate instead of trusting a
+// wrong one.
+func (p *embeddingsProvider) CountTokens(ctx context.Context, modelID, text string) (int, bool) {
+	baseURL, ok, err := p.endpointResolver.Endpoint(ctx, modelID)
+	if err != nil || !ok {
+		return 0, false
+	}
+
+	reqBody, err := json.Marshal(map[string]string{"inputs": text})
+	if err != nil {
+		return 0, false
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+tokenizePath, bytes.NewReader(reqBody))
+	if err != nil {
+		return 0, false
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		slog.Debug("embeddings: /tokenize request failed", "endpoint", baseURL, "err", err)
+		return 0, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Debug("embeddings: /tokenize returned non-OK status", "endpoint", baseURL, "status", resp.StatusCode)
+		return 0, false
+	}
+
+	var tokens []tokenizeToken
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxIntrospectionResponseBytes)).Decode(&tokens); err != nil {
+		slog.Debug("embeddings: /tokenize response decode failed", "endpoint", baseURL, "err", err)
+		return 0, false
+	}
+	return len(tokens), true
 }
 
 // orderEmbeddings sorts a batch response's vectors back to the caller's

--- a/spinifex/gateway/bedrock/embeddings_test.go
+++ b/spinifex/gateway/bedrock/embeddings_test.go
@@ -171,3 +171,123 @@ func TestEmbeddingsProvider_Embed_CountMismatchReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelErrorException, err.Error())
 }
+
+func TestEmbeddingsProvider_MaxInputLength_ReadsAndCachesInfo(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, infoPath, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"model_id":"bge-base-en-v1.5","max_input_length":512}`))
+	}))
+	defer ts.Close()
+
+	modelID := DefaultEmbeddingModel
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(map[string]string{modelID: ts.URL}))
+	p.httpClient = ts.Client()
+
+	assert.Equal(t, 512, p.MaxInputLength(context.Background(), modelID))
+	// A second call for the same endpoint must be served from cache, not a
+	// second /info round trip.
+	assert.Equal(t, 512, p.MaxInputLength(context.Background(), modelID))
+	assert.Equal(t, 1, calls, "MaxInputLength must cache per endpoint")
+}
+
+func TestEmbeddingsProvider_MaxInputLength_InfoUnavailableFallsBackToDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	modelID := DefaultEmbeddingModel
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(map[string]string{modelID: ts.URL}))
+	p.httpClient = ts.Client()
+
+	assert.Equal(t, defaultMaxInputLength, p.MaxInputLength(context.Background(), modelID))
+}
+
+func TestEmbeddingsProvider_MaxInputLength_MalformedInfoFallsBackToDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not-json`))
+	}))
+	defer ts.Close()
+
+	modelID := DefaultEmbeddingModel
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(map[string]string{modelID: ts.URL}))
+	p.httpClient = ts.Client()
+
+	assert.Equal(t, defaultMaxInputLength, p.MaxInputLength(context.Background(), modelID))
+}
+
+func TestEmbeddingsProvider_MaxInputLength_ZeroFieldFallsBackToDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// No max_input_length field at all, e.g. a non-TEI OpenAI-compatible
+		// /info that doesn't advertise one.
+		_, _ = w.Write([]byte(`{"model_id":"some-model"}`))
+	}))
+	defer ts.Close()
+
+	modelID := DefaultEmbeddingModel
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(map[string]string{modelID: ts.URL}))
+	p.httpClient = ts.Client()
+
+	assert.Equal(t, defaultMaxInputLength, p.MaxInputLength(context.Background(), modelID))
+}
+
+func TestEmbeddingsProvider_MaxInputLength_ResolverMissFallsBackToDefault(t *testing.T) {
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(nil))
+	assert.Equal(t, defaultMaxInputLength, p.MaxInputLength(context.Background(), DefaultEmbeddingModel))
+}
+
+func TestEmbeddingsProvider_CountTokens_HappyPath(t *testing.T) {
+	var capturedBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, tokenizePath, r.URL.Path)
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody)) {
+			http.Error(w, "decode request body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":101,"text":"[CLS]"},{"id":7592,"text":"hello"},{"id":2088,"text":"world"},{"id":102,"text":"[SEP]"}]`))
+	}))
+	defer ts.Close()
+
+	modelID := DefaultEmbeddingModel
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(map[string]string{modelID: ts.URL}))
+	p.httpClient = ts.Client()
+
+	count, ok := p.CountTokens(context.Background(), modelID, "hello world")
+	require.True(t, ok)
+	assert.Equal(t, 4, count)
+	assert.Equal(t, "hello world", capturedBody["inputs"])
+}
+
+func TestEmbeddingsProvider_CountTokens_UnavailableReturnsNotOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	modelID := DefaultEmbeddingModel
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(map[string]string{modelID: ts.URL}))
+	p.httpClient = ts.Client()
+
+	count, ok := p.CountTokens(context.Background(), modelID, "hello world")
+	assert.False(t, ok)
+	assert.Zero(t, count)
+}
+
+func TestEmbeddingsProvider_CountTokens_ResolverMissReturnsNotOK(t *testing.T) {
+	p := newEmbeddingsProvider(NewStaticEndpointResolver(nil))
+	count, ok := p.CountTokens(context.Background(), DefaultEmbeddingModel, "hello world")
+	assert.False(t, ok)
+	assert.Zero(t, count)
+}

--- a/spinifex/gateway/bedrock/reranker.go
+++ b/spinifex/gateway/bedrock/reranker.go
@@ -1,0 +1,148 @@
+package gateway_bedrock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+const (
+	rerankPath = "/rerank"
+
+	// maxRerankResponseBytes bounds the /rerank response body read into
+	// memory, mirroring the embeddings introspection endpoints' bound.
+	maxRerankResponseBytes = 1 << 20
+)
+
+// Reranker reorders a candidate document set against a query using a
+// self-hosted cross-encoder (TEI-compatible POST /rerank), returning doc
+// indices into the caller's docs slice, best match first.
+type Reranker interface {
+	Rerank(ctx context.Context, query string, docs []string) ([]int, error)
+}
+
+// rerankRequest is TEI's own POST /rerank request wire shape: a query plus
+// the candidate texts to score against it.
+type rerankRequest struct {
+	Query string   `json:"query"`
+	Texts []string `json:"texts"`
+}
+
+// rerankResult is one candidate's score, keyed back to the caller's docs
+// slice by Index. TEI does not document the response as pre-sorted, so this
+// adapter sorts by Score itself rather than trusting response order.
+type rerankResult struct {
+	Index int     `json:"index"`
+	Score float64 `json:"score"`
+}
+
+// rerankProvider serves cross-encoder reranking over a TEI-compatible
+// POST /rerank endpoint: one fixed URL, no modelID or EndpointResolver,
+// since a rerank deployment serves one cross-encoder per process.
+type rerankProvider struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+var _ Reranker = (*rerankProvider)(nil)
+
+// newRerankProvider constructs a rerankProvider bound to baseURL.
+func newRerankProvider(baseURL string) *rerankProvider {
+	return &rerankProvider{
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: providerHTTPTimeout},
+	}
+}
+
+// NewReranker is newRerankProvider's exported constructor, for callers
+// outside this package (e.g. the daemon's Ochre vector store wiring) that
+// need a Reranker without reaching into gateway_bedrock's unexported types.
+func NewReranker(baseURL string) Reranker {
+	return newRerankProvider(baseURL)
+}
+
+// Rerank POSTs query and docs to the configured /rerank endpoint and returns
+// doc indices ordered best-match first by the endpoint's own score. An empty
+// docs slice returns an empty result without calling the endpoint.
+func (p *rerankProvider) Rerank(ctx context.Context, query string, docs []string) ([]int, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
+	reqBody, err := json.Marshal(rerankRequest{Query: query, Texts: docs})
+	if err != nil {
+		slog.Error("rerank: failed to marshal request", "err", err)
+		return nil, errors.New(awserrors.ErrorInternalError)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+rerankPath, bytes.NewReader(reqBody))
+	if err != nil {
+		slog.Error("rerank: failed to build request", "err", err)
+		return nil, errors.New(awserrors.ErrorInternalError)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		slog.Debug("rerank: request failed", "endpoint", p.baseURL, "err", err)
+		return nil, errors.New(awserrors.ErrorServiceUnavailableException)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxRerankResponseBytes))
+	if err != nil {
+		slog.Debug("rerank: failed to read response body", "err", err)
+		return nil, errors.New(awserrors.ErrorServiceUnavailableException)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Debug("rerank: upstream error", "status", resp.StatusCode, "body", string(respBody))
+		return nil, errors.New(mapUpstreamStatus(resp.StatusCode))
+	}
+
+	var results []rerankResult
+	if err := json.Unmarshal(respBody, &results); err != nil {
+		slog.Debug("rerank: failed to parse response", "err", err)
+		return nil, errors.New(awserrors.ErrorModelErrorException)
+	}
+
+	indices, err := orderByScore(len(docs), results)
+	if err != nil {
+		slog.Debug("rerank: malformed response shape", "err", err)
+		return nil, errors.New(awserrors.ErrorModelErrorException)
+	}
+	return indices, nil
+}
+
+// orderByScore validates one result per doc index in [0,n) with no
+// duplicates -- guarding against unrequested top_n truncation -- then
+// returns indices sorted by descending score.
+func orderByScore(n int, results []rerankResult) ([]int, error) {
+	if len(results) != n {
+		return nil, errors.New("rerank result count mismatch")
+	}
+	seen := make([]bool, n)
+	for _, r := range results {
+		if r.Index < 0 || r.Index >= n || seen[r.Index] {
+			return nil, errors.New("rerank index out of range or duplicated")
+		}
+		seen[r.Index] = true
+	}
+
+	sorted := make([]rerankResult, len(results))
+	copy(sorted, results)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Score > sorted[j].Score })
+
+	indices := make([]int, len(sorted))
+	for i, r := range sorted {
+		indices[i] = r.Index
+	}
+	return indices, nil
+}

--- a/spinifex/gateway/bedrock/reranker_test.go
+++ b/spinifex/gateway/bedrock/reranker_test.go
@@ -1,0 +1,155 @@
+// Exercises the unexported reranker adapter internals with no exported
+// surface to drive them through.
+//
+//test:in-package
+package gateway_bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRerankProvider_Rerank_RequestShape(t *testing.T) {
+	var captured rerankRequest
+	var capturedPath, capturedMethod string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&captured)) {
+			http.Error(w, "decode request body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"index":0,"score":0.9}]`))
+	}))
+	defer ts.Close()
+
+	p := newRerankProvider(ts.URL)
+	p.httpClient = ts.Client()
+
+	_, err := p.Rerank(context.Background(), "what is spinifex?", []string{"spinifex is a control plane"})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Equal(t, rerankPath, capturedPath)
+	assert.Equal(t, "what is spinifex?", captured.Query)
+	assert.Equal(t, []string{"spinifex is a control plane"}, captured.Texts)
+}
+
+func TestRerankProvider_Rerank_HappyPathOrdersByDescendingScore(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Deliberately unsorted, and not in request order.
+		_, _ = w.Write([]byte(`[
+			{"index": 2, "score": 0.1},
+			{"index": 0, "score": 0.95},
+			{"index": 1, "score": 0.5}
+		]`))
+	}))
+	defer ts.Close()
+
+	p := newRerankProvider(ts.URL)
+	p.httpClient = ts.Client()
+
+	order, err := p.Rerank(context.Background(), "query", []string{"doc0", "doc1", "doc2"})
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 1, 2}, order)
+}
+
+func TestRerankProvider_Rerank_EmptyDocsSkipsHTTPCall(t *testing.T) {
+	called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	p := newRerankProvider(ts.URL)
+	p.httpClient = ts.Client()
+
+	order, err := p.Rerank(context.Background(), "query", nil)
+	require.NoError(t, err)
+	assert.Empty(t, order)
+	assert.False(t, called, "Rerank must not call the endpoint for an empty doc set")
+}
+
+func TestRerankProvider_Rerank_NonOKStatusReturnsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer ts.Close()
+
+	p := newRerankProvider(ts.URL)
+	p.httpClient = ts.Client()
+
+	_, err := p.Rerank(context.Background(), "query", []string{"doc0"})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorThrottlingException, err.Error())
+}
+
+func TestRerankProvider_Rerank_MalformedJSONReturnsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not-json`))
+	}))
+	defer ts.Close()
+
+	p := newRerankProvider(ts.URL)
+	p.httpClient = ts.Client()
+
+	_, err := p.Rerank(context.Background(), "query", []string{"doc0"})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorModelErrorException, err.Error())
+}
+
+func TestRerankProvider_Rerank_CountMismatchReturnsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"index":0,"score":0.9}]`))
+	}))
+	defer ts.Close()
+
+	p := newRerankProvider(ts.URL)
+	p.httpClient = ts.Client()
+
+	_, err := p.Rerank(context.Background(), "query", []string{"doc0", "doc1"})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorModelErrorException, err.Error())
+}
+
+func TestRerankProvider_Rerank_OutOfRangeIndexReturnsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"index":5,"score":0.9}]`))
+	}))
+	defer ts.Close()
+
+	p := newRerankProvider(ts.URL)
+	p.httpClient = ts.Client()
+
+	_, err := p.Rerank(context.Background(), "query", []string{"doc0"})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorModelErrorException, err.Error())
+}
+
+func TestRerankProvider_Rerank_ConnectionRefusedReturnsServiceUnavailable(t *testing.T) {
+	p := newRerankProvider("http://127.0.0.1:1")
+
+	_, err := p.Rerank(context.Background(), "query", []string{"doc0"})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServiceUnavailableException, err.Error())
+}

--- a/spinifex/gateway/bedrockagent.go
+++ b/spinifex/gateway/bedrockagent.go
@@ -549,9 +549,10 @@ func dataSourceRecordToOutput(rec handlers_ochrevector.DataSourceRecord) *bedroc
 // sources are supported (WEB/CONFLUENCE/SALESFORCE/SHAREPOINT are not
 // stubbed -- there is no engine behind them to accept-and-ignore against, so
 // they are rejected rather than silently accepted and never ingested).
-// ChunkSize/ChunkOverlap are left zero when fixedSizeChunkingConfiguration is
-// omitted, so .9's own ingest path applies DefaultChunkSize/
-// DefaultChunkOverlap (D3). Data-source-level Metadata is left empty: AWS's
+// ChunkSize/ChunkOverlap (token counts, not runes) are left zero when
+// fixedSizeChunkingConfiguration is omitted, so .9's own ingest path clamps
+// to the served embedder's advertised max_input_length instead (D3).
+// Data-source-level Metadata is left empty: AWS's
 // CreateDataSourceInput carries no arbitrary metadata map to source it from
 // (real per-document metadata comes from S3 .metadata.json sidecar files at
 // ingest time, out of scope for Pass 1).

--- a/spinifex/handlers/ochrevector/api.go
+++ b/spinifex/handlers/ochrevector/api.go
@@ -184,6 +184,9 @@ type vectorService struct {
 	registry indexGetter
 	backend  VectorBackend
 	embedder Embedder
+	// reranker is optional: nil leaves Query at plain KNN top-k, matching
+	// every deployment that has not configured a rerank endpoint.
+	reranker Reranker
 }
 
 var _ VectorService = (*vectorService)(nil)
@@ -192,9 +195,10 @@ var _ VectorService = (*vectorService)(nil)
 // dependencies. index/ingest/jobs/registry/backend/embedder are accepted as
 // the minimal interfaces above, so a *Service/*IngestService/*JobStore/
 // *Registry/VectorBackend/Embedder wired for the rest of the daemon can be
-// passed directly.
-func NewVectorService(index indexService, ingest ingestStarter, jobs jobGetter, registry indexGetter, backend VectorBackend, embedder Embedder) VectorService {
-	return &vectorService{index: index, ingest: ingest, jobs: jobs, registry: registry, backend: backend, embedder: embedder}
+// passed directly. reranker is optional -- a nil reranker leaves Query at
+// plain KNN top-k, so an existing caller passing nil is unaffected.
+func NewVectorService(index indexService, ingest ingestStarter, jobs jobGetter, registry indexGetter, backend VectorBackend, embedder Embedder, reranker Reranker) VectorService {
+	return &vectorService{index: index, ingest: ingest, jobs: jobs, registry: registry, backend: backend, embedder: embedder, reranker: reranker}
 }
 
 func (s *vectorService) CreateIndex(ctx context.Context, req *CreateIndexRequest, accountID string) (*CreateIndexResponse, error) {
@@ -282,8 +286,9 @@ func (s *vectorService) ListJobs(ctx context.Context, _ *ListJobsRequest, accoun
 
 // Query resolves IndexID's pinned embedding model from the registry (D8),
 // embeds Text against it, then runs the similarity search directly against
-// backend. A non-READY index (CREATING/DELETING/STALE) returns empty results
-// rather than an error (D4): it is not yet, or no longer, queryable.
+// backend, optionally over-fetching and reranking (rerankTopK). A non-READY
+// index (CREATING/DELETING/STALE) returns empty results rather than an
+// error (D4): it is not yet, or no longer, queryable.
 func (s *vectorService) Query(ctx context.Context, req *QueryRequest, accountID string) (*QueryResponse, error) {
 	if req == nil || req.IndexID == "" || req.Text == "" {
 		return nil, fmt.Errorf("ochrevector: query requires an indexId and text")
@@ -307,10 +312,17 @@ func (s *vectorService) Query(ctx context.Context, req *QueryRequest, accountID 
 		return nil, fmt.Errorf("ochrevector: query: embed returned %d vectors for 1 input", len(vectors))
 	}
 
-	results, err := s.backend.Query(ctx, accountID, req.IndexID, vectors[0], req.K, req.Filter)
+	finalK := clampQueryK(req.K)
+	fetchK := finalK
+	if s.reranker != nil {
+		fetchK = rerankFetchK(finalK)
+	}
+
+	results, err := s.backend.Query(ctx, accountID, req.IndexID, vectors[0], fetchK, req.Filter)
 	if err != nil {
 		return nil, fmt.Errorf("ochrevector: query: %w", err)
 	}
+	results = rerankTopK(ctx, s.reranker, req.Text, results, finalK)
 	for i := range results {
 		results[i].Chunk = truncateChunkForResponse(results[i].Chunk)
 	}

--- a/spinifex/handlers/ochrevector/api_test.go
+++ b/spinifex/handlers/ochrevector/api_test.go
@@ -47,8 +47,12 @@ func newAPITestSetup(t *testing.T) *apiTestSetup {
 	embedder := &stubEmbedder{}
 	ingestSvc := NewIngestService(jobs, registry, backend, nil, embedder)
 
+	// reranker is nil by default: every existing Query test exercises the
+	// no-reranker-configured path, so their result order/count is
+	// unaffected. Rerank-specific tests build their own setup with an
+	// explicit reranker (see rerank_test.go).
 	return &apiTestSetup{
-		svc:      NewVectorService(indexSvc, ingestSvc, jobs, registry, backend, embedder),
+		svc:      NewVectorService(indexSvc, ingestSvc, jobs, registry, backend, embedder, nil),
 		registry: registry,
 		backend:  backend,
 		embedder: embedder,
@@ -363,7 +367,7 @@ func TestNATSVectorService_RoundTrip(t *testing.T) {
 	jobs := NewJobStore(js)
 	embedder := &stubEmbedder{}
 	ingestSvc := NewIngestService(jobs, registry, backend, nil, embedder)
-	svc := NewVectorService(indexSvc, ingestSvc, jobs, registry, backend, embedder)
+	svc := NewVectorService(indexSvc, ingestSvc, jobs, registry, backend, embedder, nil)
 
 	subscribeVectorService(t, nc, svc)
 	client := NewNATSVectorService(nc)
@@ -417,7 +421,7 @@ func TestNATSVectorService_AccountIsolation(t *testing.T) {
 	jobs := NewJobStore(js)
 	embedder := &stubEmbedder{}
 	ingestSvc := NewIngestService(jobs, registry, backend, nil, embedder)
-	svc := NewVectorService(indexSvc, ingestSvc, jobs, registry, backend, embedder)
+	svc := NewVectorService(indexSvc, ingestSvc, jobs, registry, backend, embedder, nil)
 
 	subscribeVectorService(t, nc, svc)
 	client := NewNATSVectorService(nc)

--- a/spinifex/handlers/ochrevector/chunk.go
+++ b/spinifex/handlers/ochrevector/chunk.go
@@ -1,6 +1,9 @@
 package handlers_ochrevector
 
 import (
+	"context"
+	"log/slog"
+	"math"
 	"strings"
 	"unicode/utf8"
 )
@@ -8,15 +11,51 @@ import (
 // approxCharsPerToken is the documented, deliberately simple chars/token
 // ratio behind DefaultChunkSize/DefaultChunkOverlap. There is no true
 // tokenizer here -- sizing is in RUNES, not model tokens -- so both defaults
-// are an approximation; a per-model tokenizer is a later refinement.
+// are an approximation; ChunkTextForModel is the tokenizer-aware entry point
+// that replaces this guess with the served embedder's real budget.
 const approxCharsPerToken = 4
 
 // DefaultChunkSize and DefaultChunkOverlap approximate ~512 tokens and ~64
-// overlap tokens (D10) in runes, via approxCharsPerToken.
+// overlap tokens (D10) in runes, via approxCharsPerToken. They remain
+// ChunkText's own rune-domain fallback for direct callers; ChunkTextForModel
+// never relies on them.
 const (
 	DefaultChunkSize    = 512 * approxCharsPerToken
 	DefaultChunkOverlap = 64 * approxCharsPerToken
 )
+
+// codeCharsPerToken is a conservative, worst-case chars-per-token ratio for
+// source code, used by ChunkTextForModel to size chunks against a real token
+// budget without a live tokenizer. Dense code tokenizes as low as ~2.6-2.8
+// chars/token; this sits below that floor deliberately, so a chunk sized
+// against it undershoots the real token budget rather than risking a 413.
+const codeCharsPerToken = 2.5
+
+// chunkSafetyMargin shrinks the advertised token budget before sizing
+// chunks, absorbing BPE merge variance and any special tokens ([CLS]/[SEP])
+// the embedder prepends/appends that a raw max_input_length doesn't budget
+// for.
+const chunkSafetyMargin = 0.9
+
+// DefaultMaxInputTokens is the token budget ChunkTextForModel falls back to
+// when the caller has no embedder-advertised max_input_length at all --
+// bge-base-en-v1.5's 512-token cap, Ochre's original served embedder.
+const DefaultMaxInputTokens = 512
+
+// DefaultChunkOverlapTokens is the token overlap ChunkTextForModel falls
+// back to absent an operator override.
+const DefaultChunkOverlapTokens = 64
+
+// maxResplitDepth bounds resplitChunk's recursion: verification keeps
+// halving a chunk that still exceeds budget, but a pathological input (or a
+// TokenCounter that never agrees a chunk is small enough) must not recurse
+// forever.
+const maxResplitDepth = 8
+
+// minResplitRunes floors resplitChunk's recursion: below this there is
+// nothing meaningful left to split, so a chunk still measuring over budget
+// here is returned as-is rather than looping.
+const minResplitRunes = 8
 
 // chunkSeparators is the recursive-split hierarchy (D10): paragraph, line,
 // sentence (three terminators), then word. A span still over size after
@@ -183,4 +222,110 @@ func packChunks(pieces []piece, size, overlap int) []Chunk {
 		i = k
 	}
 	return chunks
+}
+
+// TokenCounter counts text's real token count against a specific served
+// model, e.g. via TEI POST /tokenize. ok is false when the endpoint can't or
+// didn't answer, telling the caller to fall back to a conservative estimate
+// instead of trusting a wrong count. gateway_bedrock's TokenLimiter
+// satisfies this structurally, the same way ingest's Embedder mirrors
+// gateway_bedrock.Embedder, so this package never imports gateway_bedrock.
+type TokenCounter interface {
+	CountTokens(ctx context.Context, modelID, text string) (count int, ok bool)
+}
+
+// ChunkTextForModel sizes chunks against maxInputTokens -- the served
+// embedder's real max_input_length (from TEI /info), clamped by any operator
+// override -- rather than a fixed rune guess. It first splits at a rune size
+// derived from a conservative chars/token ratio the same way ChunkText's
+// caller used to, then verifies every resulting chunk's real token count via
+// counter and recursively re-splits any chunk still over budget.
+//
+// This is the guarantee rune sizing alone cannot make: a separator-less
+// dense code span can tokenize denser than any fixed chars/token guess, and
+// only a real per-chunk check catches that before it reaches the embedder.
+// counter may be nil (embedder doesn't support /tokenize) -- every chunk
+// then relies solely on the initial conservative rune sizing, which by
+// construction never exceeds maxInputTokens*chunkSafetyMargin as long as
+// codeCharsPerToken is a true floor on the served tokenizer's density.
+func ChunkTextForModel(ctx context.Context, text, modelID string, maxInputTokens, overlapTokens int, counter TokenCounter) []Chunk {
+	if maxInputTokens <= 0 {
+		maxInputTokens = DefaultMaxInputTokens
+	}
+	if overlapTokens < 0 {
+		overlapTokens = DefaultChunkOverlapTokens
+	}
+
+	budget := max(int(float64(maxInputTokens)*chunkSafetyMargin), 1)
+	size := int(float64(budget) * codeCharsPerToken)
+	overlapRunes := int(float64(overlapTokens) * codeCharsPerToken)
+
+	chunks := ChunkText(text, size, overlapRunes)
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	out := make([]Chunk, 0, len(chunks))
+	for _, c := range chunks {
+		out = append(out, resplitChunk(ctx, c, modelID, budget, overlapRunes, counter, 0)...)
+	}
+	return out
+}
+
+// resplitChunk verifies c's real token count against budget and, if it still
+// exceeds it, re-splits c.Text at a smaller rune size derived from its
+// measured token density and recurses -- the belt-and-suspenders check for
+// when the initial conservative sizing wasn't conservative enough. depth
+// bounds the recursion (maxResplitDepth); a chunk at or below
+// minResplitRunes is returned as-is regardless of its measured count, since
+// there is nothing left to usefully split.
+func resplitChunk(ctx context.Context, c Chunk, modelID string, budget, overlapRunes int, counter TokenCounter, depth int) []Chunk {
+	count := estimateTokens(ctx, c.Text, modelID, counter)
+	if count <= budget {
+		return []Chunk{c}
+	}
+
+	runes := utf8.RuneCountInString(c.Text)
+	if depth >= maxResplitDepth || runes <= minResplitRunes {
+		slog.WarnContext(ctx, "ochrevector: chunk still exceeds token budget after max re-split depth",
+			"model", modelID, "budget_tokens", budget, "measured_tokens", count, "runes", runes)
+		return []Chunk{c}
+	}
+
+	// Measured density (tokens/rune) sizes the retry directly from what this
+	// chunk actually measured, rather than guessing again -- and halves the
+	// rune target outright if that still wouldn't shrink it, so depth always
+	// makes progress even against a degenerate density estimate.
+	density := float64(count) / float64(runes)
+	newSize := int(float64(budget) / density)
+	if newSize >= runes {
+		newSize = runes / 2
+	}
+	newSize = max(newSize, 1)
+	subOverlap := overlapRunes
+	if subOverlap >= newSize {
+		subOverlap = newSize - 1
+	}
+	subOverlap = max(subOverlap, 0)
+
+	subChunks := ChunkText(c.Text, newSize, subOverlap)
+	out := make([]Chunk, 0, len(subChunks))
+	for _, sc := range subChunks {
+		sc.Offset += c.Offset
+		out = append(out, resplitChunk(ctx, sc, modelID, budget, overlapRunes, counter, depth+1)...)
+	}
+	return out
+}
+
+// estimateTokens counts text's real tokens via counter when available,
+// falling back to the same conservative codeCharsPerToken ratio
+// ChunkTextForModel used to size chunks in the first place when counter is
+// nil or misses.
+func estimateTokens(ctx context.Context, text, modelID string, counter TokenCounter) int {
+	if counter != nil {
+		if n, ok := counter.CountTokens(ctx, modelID, text); ok {
+			return n
+		}
+	}
+	return int(math.Ceil(float64(utf8.RuneCountInString(text)) / codeCharsPerToken))
 }

--- a/spinifex/handlers/ochrevector/chunk_test.go
+++ b/spinifex/handlers/ochrevector/chunk_test.go
@@ -5,13 +5,38 @@
 package handlers_ochrevector
 
 import (
+	"context"
+	"math"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fixedDensityCounter simulates a served tokenizer with a fixed tokens/rune
+// density, standing in for TEI POST /tokenize without a live endpoint --
+// e.g. tokensPerRune > 1/codeCharsPerToken simulates a tokenizer denser than
+// ChunkTextForModel's conservative sizing assumed.
+type fixedDensityCounter struct {
+	tokensPerRune float64
+}
+
+func (f fixedDensityCounter) CountTokens(_ context.Context, _, text string) (int, bool) {
+	n := max(int(math.Ceil(float64(utf8.RuneCountInString(text))*f.tokensPerRune)), 1)
+	return n, true
+}
+
+// alwaysOverBudgetCounter reports a token count no chunk can ever satisfy,
+// exercising resplitChunk's depth/minResplitRunes safety valve rather than
+// its normal convergence.
+type alwaysOverBudgetCounter struct{}
+
+func (alwaysOverBudgetCounter) CountTokens(_ context.Context, _, _ string) (int, bool) {
+	return 1_000_000, true
+}
 
 func TestChunkText_Empty(t *testing.T) {
 	assert.Nil(t, ChunkText("", 50, 10))
@@ -161,4 +186,139 @@ func TestChunkText_NegativeAndZeroInputsClamp(t *testing.T) {
 	// overlap>=size clamps to size-1 rather than stalling the packer forever.
 	chunks = ChunkText(text, 20, 100)
 	require.NotEmpty(t, chunks)
+}
+
+// TestChunkTextForModel_DefaultsAreTokenCounts documents that
+// ChunkTextForModel's defaults, unlike ChunkText's, are real token counts:
+// DefaultMaxInputTokens mirrors bge-base-en-v1.5's 512-token cap and
+// DefaultChunkOverlapTokens mirrors D10's ~64-token overlap.
+func TestChunkTextForModel_DefaultsAreTokenCounts(t *testing.T) {
+	assert.Equal(t, 512, DefaultMaxInputTokens)
+	assert.Equal(t, 64, DefaultChunkOverlapTokens)
+	assert.Less(t, DefaultChunkOverlapTokens, DefaultMaxInputTokens)
+}
+
+// TestChunkTextForModel_ZeroAndNegativeInputsDefault proves maxInputTokens<=0
+// and overlapTokens<0 fall back to DefaultMaxInputTokens/
+// DefaultChunkOverlapTokens rather than misbehaving, mirroring ChunkText's
+// own clamping contract.
+func TestChunkTextForModel_ZeroAndNegativeInputsDefault(t *testing.T) {
+	text := "hello world, this is a short document"
+	chunks := ChunkTextForModel(context.Background(), text, "test-model", 0, -1, nil)
+	require.Len(t, chunks, 1)
+	assert.Equal(t, text, chunks[0].Text)
+}
+
+// TestChunkTextForModel_EmptyTextReturnsNil mirrors ChunkText's empty/
+// whitespace-only contract through the token-aware entry point.
+func TestChunkTextForModel_EmptyTextReturnsNil(t *testing.T) {
+	assert.Nil(t, ChunkTextForModel(context.Background(), "   \n\t  ", "test-model", 100, 10, nil))
+}
+
+// TestChunkTextForModel_NilCounterNeverExceedsConservativeEstimate proves
+// that even with no TokenCounter at all (an embedder that doesn't expose
+// TEI /tokenize), every chunk ChunkTextForModel produces still measures
+// under budget by the same conservative codeCharsPerToken estimate the
+// sizing pass used -- the guarantee that holds with zero live tokenizer
+// calls, as long as codeCharsPerToken is a true floor on real density.
+func TestChunkTextForModel_NilCounterNeverExceedsConservativeEstimate(t *testing.T) {
+	// No separators anywhere, forcing the hard-split fallback exactly like
+	// a long unbroken span of dense code (e.g. a minified line or a long
+	// identifier list).
+	text := strings.Repeat("x", 5000)
+	maxInputTokens := 100
+	budget := int(float64(maxInputTokens) * chunkSafetyMargin)
+
+	chunks := ChunkTextForModel(context.Background(), text, "test-model", maxInputTokens, 0, nil)
+	require.NotEmpty(t, chunks)
+	for _, c := range chunks {
+		estimate := int(math.Ceil(float64(utf8.RuneCountInString(c.Text)) / codeCharsPerToken))
+		assert.LessOrEqual(t, estimate, budget, "chunk %q exceeds the conservative token estimate", c.Text)
+	}
+}
+
+// TestChunkTextForModel_ReSplitsChunkThatMeasuresOverLimit is the
+// acceptance-bar test: a separator-less dense span that the initial
+// conservative rune sizing alone would let through over budget (because the
+// mocked served tokenizer is denser than codeCharsPerToken assumed) must be
+// caught and re-split by the real-count verification pass, so every final
+// chunk measures at or under the model's real token budget.
+func TestChunkTextForModel_ReSplitsChunkThatMeasuresOverLimit(t *testing.T) {
+	// tokensPerRune=0.5 (2 chars/token) is denser than codeCharsPerToken
+	// (2.5), so the initial size==budget*codeCharsPerToken pass alone would
+	// leave every chunk measuring ~1.25x over budget without the resplit.
+	counter := fixedDensityCounter{tokensPerRune: 0.5}
+	maxInputTokens := 100
+	budget := int(float64(maxInputTokens) * chunkSafetyMargin)
+
+	text := strings.Repeat("x", 3000) // no separators: forces hardSplit
+	chunks := ChunkTextForModel(context.Background(), text, "test-model", maxInputTokens, 0, counter)
+	require.NotEmpty(t, chunks)
+
+	for _, c := range chunks {
+		count, ok := counter.CountTokens(context.Background(), "test-model", c.Text)
+		require.True(t, ok)
+		assert.LessOrEqual(t, count, budget, "chunk %q still exceeds the real token budget after re-split", c.Text)
+	}
+
+	// Every chunk must still be an exact substring of the original text at
+	// its reported offset -- resplitting must not corrupt content.
+	runes := []rune(text)
+	for _, c := range chunks {
+		want := string(runes[c.Offset : c.Offset+utf8.RuneCountInString(c.Text)])
+		assert.Equal(t, want, c.Text)
+	}
+}
+
+// TestChunkTextForModel_PathologicalCounterTerminates proves resplitChunk's
+// depth/minResplitRunes safety valve bounds recursion even against a
+// TokenCounter that never agrees a chunk is small enough -- it must return
+// rather than recurse forever or blow up memory.
+func TestChunkTextForModel_PathologicalCounterTerminates(t *testing.T) {
+	text := strings.Repeat("y", 12)
+
+	done := make(chan []Chunk, 1)
+	go func() {
+		done <- ChunkTextForModel(context.Background(), text, "test-model", 100, 0, alwaysOverBudgetCounter{})
+	}()
+
+	select {
+	case chunks := <-done:
+		require.NotEmpty(t, chunks)
+		for _, c := range chunks {
+			assert.LessOrEqual(t, utf8.RuneCountInString(c.Text), minResplitRunes)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ChunkTextForModel did not terminate against a pathological TokenCounter")
+	}
+}
+
+// TestChunkTextForModel_CounterConsultedOnlyWhenProvided proves a nil
+// counter never panics (estimateTokens falls back to the conservative
+// ratio) and that a non-nil counter is actually consulted.
+func TestChunkTextForModel_CounterConsultedOnlyWhenProvided(t *testing.T) {
+	text := "short text well under any budget"
+
+	assert.NotPanics(t, func() {
+		ChunkTextForModel(context.Background(), text, "test-model", 512, 64, nil)
+	})
+
+	calls := 0
+	counter := countingCounter{fn: func(string) (int, bool) {
+		calls++
+		return 1, true
+	}}
+	chunks := ChunkTextForModel(context.Background(), text, "test-model", 512, 64, counter)
+	require.NotEmpty(t, chunks)
+	assert.Positive(t, calls, "a non-nil counter must be consulted for verification")
+}
+
+// countingCounter wraps a closure as a TokenCounter, for asserting a
+// counter was actually invoked.
+type countingCounter struct {
+	fn func(text string) (int, bool)
+}
+
+func (c countingCounter) CountTokens(_ context.Context, _, text string) (int, bool) {
+	return c.fn(text)
 }

--- a/spinifex/handlers/ochrevector/ingest.go
+++ b/spinifex/handlers/ochrevector/ingest.go
@@ -23,6 +23,16 @@ type Embedder interface {
 	Embed(ctx context.Context, modelID string, inputs []string) ([][]float32, error)
 }
 
+// TokenLimiter is the local seam for embedder token-budget introspection:
+// the same method set as gateway_bedrock.TokenLimiter's MaxInputLength,
+// restated here rather than imported so this package never depends on the
+// gateway. It is optional -- ingestObject type-asserts s.Embedder against
+// it rather than requiring it on Embedder, so a test double Embedder still
+// satisfies Embedder alone and falls back to DefaultMaxInputTokens.
+type TokenLimiter interface {
+	MaxInputLength(ctx context.Context, modelID string) int
+}
+
 const (
 	// ingestListPageSize bounds each ListObjectsV2 page; StartIngest's caller
 	// may point a job at a bucket/prefix far larger than fits in memory at
@@ -244,16 +254,29 @@ func (s *IngestService) ingestObject(ctx context.Context, accountID, indexID, ke
 		return &ingestDocError{err: fmt.Errorf("object exceeds max ingest size (%d bytes)", maxIngestObjectBytes)}
 	}
 
-	chunkSize := source.ChunkSize
-	if chunkSize <= 0 {
-		chunkSize = DefaultChunkSize
+	maxInputTokens := DefaultMaxInputTokens
+	if tl, ok := s.Embedder.(TokenLimiter); ok {
+		maxInputTokens = tl.MaxInputLength(ctx, source.EmbeddingModel)
 	}
-	chunkOverlap := source.ChunkOverlap
-	if chunkOverlap < 0 {
-		chunkOverlap = DefaultChunkOverlap
+	// source.ChunkSize (from Bedrock's FixedSizeChunkingConfiguration.MaxTokens,
+	// D3) is an operator token budget, not a rune count; honor it only when
+	// it asks for something tighter than the served embedder's real limit --
+	// a looser or unset value clamps down to what the embedder actually
+	// accepts, so operator config can never reopen the 413 this closes.
+	if source.ChunkSize > 0 && source.ChunkSize < maxInputTokens {
+		maxInputTokens = source.ChunkSize
+	}
+	overlapTokens := source.ChunkOverlap
+	if overlapTokens < 0 {
+		overlapTokens = DefaultChunkOverlapTokens
 	}
 
-	chunks := ChunkText(string(data), chunkSize, chunkOverlap)
+	var counter TokenCounter
+	if tc, ok := s.Embedder.(TokenCounter); ok {
+		counter = tc
+	}
+
+	chunks := ChunkTextForModel(ctx, string(data), source.EmbeddingModel, maxInputTokens, overlapTokens, counter)
 	if len(chunks) == 0 {
 		// An empty/whitespace-only document is not an error, but any
 		// previously-ingested rows for this key must still be cleared.

--- a/spinifex/handlers/ochrevector/ingest_test.go
+++ b/spinifex/handlers/ochrevector/ingest_test.go
@@ -8,10 +8,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -66,6 +68,70 @@ func (e *stubEmbedder) callCount() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.calls
+}
+
+// tokenLimiterStubEmbedder wraps stubEmbedder with a configurable
+// TokenLimiter.MaxInputLength, so ingestObject's optional-interface wiring
+// to the served embedder's real budget can be exercised without a live TEI
+// endpoint.
+type tokenLimiterStubEmbedder struct {
+	*stubEmbedder
+
+	maxInputLength int
+}
+
+var _ Embedder = (*tokenLimiterStubEmbedder)(nil)
+var _ TokenLimiter = (*tokenLimiterStubEmbedder)(nil)
+
+func (e *tokenLimiterStubEmbedder) MaxInputLength(_ context.Context, _ string) int {
+	return e.maxInputLength
+}
+
+// tokenCounterStubEmbedder additionally implements TokenCounter, counting
+// its own invocations so tests can prove ingestObject actually consults it
+// rather than relying solely on the conservative rune estimate.
+type tokenCounterStubEmbedder struct {
+	*tokenLimiterStubEmbedder
+
+	mu         sync.Mutex
+	countCalls int
+}
+
+var _ TokenCounter = (*tokenCounterStubEmbedder)(nil)
+
+func (e *tokenCounterStubEmbedder) CountTokens(_ context.Context, _, text string) (int, bool) {
+	e.mu.Lock()
+	e.countCalls++
+	e.mu.Unlock()
+	return int(math.Ceil(float64(utf8.RuneCountInString(text)) / codeCharsPerToken)), true
+}
+
+func (e *tokenCounterStubEmbedder) callCountTokens() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.countCalls
+}
+
+// newIngestTestSetupWithEmbedder mirrors newIngestTestSetup but takes a
+// caller-supplied Embedder, so tests can exercise the TokenLimiter/
+// TokenCounter optional-interface wiring without a live TEI endpoint.
+func newIngestTestSetupWithEmbedder(t *testing.T, embedder Embedder) (*IngestService, *Registry, *fakeBackend, *objectstore.MemoryObjectStore) {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+
+	registry := NewRegistry(js)
+	now := time.Now().UTC()
+	require.NoError(t, registry.Reserve(context.Background(), ingestAccountA, Record{
+		ID: "idx-one", Dimension: 2, EmbeddingModel: "stub-embed", State: StateCreating, CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, registry.SetState(context.Background(), ingestAccountA, "idx-one", StateReady))
+
+	backend := newFakeBackend()
+	store := objectstore.NewMemoryObjectStore()
+	jobs := NewJobStore(js)
+
+	svc := NewIngestService(jobs, registry, backend, store, embedder)
+	return svc, registry, backend, store
 }
 
 // newIngestTestSetup wires an IngestService over fresh in-memory stores, with
@@ -571,4 +637,70 @@ func TestIngestService_Sweep_LeavesFreshRunningAndTerminalJobsAlone(t *testing.T
 	assert.Equal(t, JobStateFailed, gotFailed.State)
 
 	assert.Equal(t, 0, backend.replaceDocumentCallCount(ingestAccountA, "idx-one", freshKey))
+}
+
+// TestRunJob_ClampsOperatorChunkSizeToEmbedderMaxInputLength proves an
+// operator-requested ChunkSize looser than the served embedder's real
+// max_input_length is clamped down to the embedder's limit rather than
+// passed through unclamped -- the fix for the as-if-runes bug where an
+// oversized chunk could 413 against the embedder regardless of what the
+// operator configured.
+func TestRunJob_ClampsOperatorChunkSizeToEmbedderMaxInputLength(t *testing.T) {
+	embedder := &tokenLimiterStubEmbedder{stubEmbedder: &stubEmbedder{}, maxInputLength: 20}
+	svc, _, backend, store := newIngestTestSetupWithEmbedder(t, embedder)
+	ctx := context.Background()
+
+	// Long enough that a 20-token budget forces multiple chunks, but well
+	// under a single chunk at the operator's much larger requested size.
+	doc := strings.Repeat("word ", 80)
+	putObject(t, store, ingestPrefix+"doc1.txt", doc)
+
+	source := testSource()
+	source.ChunkSize = 1000 // operator asks for a far larger budget than the embedder allows
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source, "")
+	require.NoError(t, err)
+	require.NoError(t, svc.RunJob(ctx, *job))
+
+	rows := backend.documentRows(ingestAccountA, "idx-one", ingestPrefix+"doc1.txt")
+	assert.Greater(t, len(rows), 1, "an oversized operator ChunkSize must clamp to the embedder's real max_input_length")
+}
+
+// TestRunJob_HonorsOperatorChunkSizeTighterThanEmbedderLimit proves an
+// operator-requested ChunkSize tighter than the embedder's own limit is
+// still honored -- clamping only ever tightens, never loosens, an operator's
+// request.
+func TestRunJob_HonorsOperatorChunkSizeTighterThanEmbedderLimit(t *testing.T) {
+	embedder := &tokenLimiterStubEmbedder{stubEmbedder: &stubEmbedder{}, maxInputLength: 512}
+	svc, _, backend, store := newIngestTestSetupWithEmbedder(t, embedder)
+	ctx := context.Background()
+
+	doc := strings.Repeat("word ", 80)
+	putObject(t, store, ingestPrefix+"doc1.txt", doc)
+
+	source := testSource()
+	source.ChunkSize = 10 // operator wants tighter chunks than the embedder's own limit
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", source, "")
+	require.NoError(t, err)
+	require.NoError(t, svc.RunJob(ctx, *job))
+
+	rows := backend.documentRows(ingestAccountA, "idx-one", ingestPrefix+"doc1.txt")
+	assert.Greater(t, len(rows), 1, "a tighter operator ChunkSize than the embedder limit must still be honored")
+}
+
+// TestRunJob_ConsultsTokenCounterWhenEmbedderProvidesOne proves ingestObject
+// type-asserts its Embedder for TokenCounter and actually calls it during
+// chunking verification, not just TokenLimiter.
+func TestRunJob_ConsultsTokenCounterWhenEmbedderProvidesOne(t *testing.T) {
+	embedder := &tokenCounterStubEmbedder{tokenLimiterStubEmbedder: &tokenLimiterStubEmbedder{stubEmbedder: &stubEmbedder{}, maxInputLength: 20}}
+	svc, _, _, store := newIngestTestSetupWithEmbedder(t, embedder)
+	ctx := context.Background()
+
+	doc := strings.Repeat("word ", 80)
+	putObject(t, store, ingestPrefix+"doc1.txt", doc)
+
+	job, err := svc.StartIngest(ctx, ingestAccountA, "idx-one", testSource(), "")
+	require.NoError(t, err)
+	require.NoError(t, svc.RunJob(ctx, *job))
+
+	assert.Positive(t, embedder.callCountTokens(), "ingestObject must consult the embedder's TokenCounter when it implements one")
 }

--- a/spinifex/handlers/ochrevector/rerank.go
+++ b/spinifex/handlers/ochrevector/rerank.go
@@ -1,0 +1,81 @@
+package handlers_ochrevector
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Reranker is the local seam for cross-encoder reranking: the same method
+// set as gateway_bedrock.Reranker, restated here so this package never
+// depends on the gateway (mirrors Embedder/TokenCounter).
+type Reranker interface {
+	Rerank(ctx context.Context, query string, docs []string) ([]int, error)
+}
+
+const (
+	// rerankOverFetchFactor and rerankMaxCandidates bound the extra
+	// candidates Query pulls from the backend before reranking, so a large
+	// requested k never turns into an unbounded fetch.
+	rerankOverFetchFactor = 4
+	rerankMaxCandidates   = 20
+
+	// rerankMaxDocRunes caps the candidate text sent to the reranker per
+	// document, bounding the /rerank request body regardless of chunk size.
+	rerankMaxDocRunes = 2000
+)
+
+// rerankFetchK scales k up by rerankOverFetchFactor for headroom, capped at
+// rerankMaxCandidates but never less than k itself.
+func rerankFetchK(k int) int {
+	return max(k, min(k*rerankOverFetchFactor, rerankMaxCandidates))
+}
+
+// rerankTopK reorders results against query and truncates to k. Any
+// failure (nil reranker, Rerank error, malformed index) falls back to
+// results' existing KNN order truncated to k.
+func rerankTopK(ctx context.Context, reranker Reranker, query string, results []QueryResult, k int) []QueryResult {
+	knnFallback := func() []QueryResult {
+		if len(results) > k {
+			return results[:k]
+		}
+		return results
+	}
+	if reranker == nil || len(results) == 0 {
+		return knnFallback()
+	}
+
+	docs := make([]string, len(results))
+	for i, r := range results {
+		docs[i] = truncateRunes(r.Chunk, rerankMaxDocRunes)
+	}
+
+	order, err := reranker.Rerank(ctx, query, docs)
+	if err != nil {
+		slog.DebugContext(ctx, "ochrevector: rerank failed, falling back to KNN order", "err", err)
+		return knnFallback()
+	}
+	if len(order) > k {
+		order = order[:k]
+	}
+
+	reranked := make([]QueryResult, 0, len(order))
+	for _, idx := range order {
+		if idx < 0 || idx >= len(results) {
+			slog.DebugContext(ctx, "ochrevector: rerank returned an out-of-range index, falling back to KNN order")
+			return knnFallback()
+		}
+		reranked = append(reranked, results[idx])
+	}
+	return reranked
+}
+
+// truncateRunes bounds s to at most n runes, without the truncation marker
+// truncateChunkForResponse appends -- that marker text has no business
+// being scored by a cross-encoder as part of the candidate's content.
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n])
+}

--- a/spinifex/handlers/ochrevector/rerank_test.go
+++ b/spinifex/handlers/ochrevector/rerank_test.go
@@ -1,0 +1,229 @@
+// Exercises unexported rerank orchestration internals with no exported
+// surface to drive them through.
+//
+//test:in-package
+package handlers_ochrevector
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubReranker is a controllable Reranker test double: it can fail every
+// call, or reorder docs by a caller-supplied score function (defaulting to
+// reversing the candidate order, so a rerank pass is visibly distinguishable
+// from the KNN order fakeBackend hands back).
+type stubReranker struct {
+	failAll   bool
+	failErr   error
+	order     func(docs []string) []int
+	lastQuery string
+	lastDocs  []string
+	calls     int
+}
+
+var _ Reranker = (*stubReranker)(nil)
+
+func (r *stubReranker) Rerank(_ context.Context, query string, docs []string) ([]int, error) {
+	r.calls++
+	r.lastQuery = query
+	r.lastDocs = docs
+	if r.failAll {
+		if r.failErr != nil {
+			return nil, r.failErr
+		}
+		return nil, errors.New("stub reranker: unavailable")
+	}
+	if r.order != nil {
+		return r.order(docs), nil
+	}
+	// Default: reverse order, so tests can tell a reranked result apart
+	// from the KNN order without needing a custom scoring function.
+	indices := make([]int, len(docs))
+	for i := range docs {
+		indices[i] = len(docs) - 1 - i
+	}
+	return indices, nil
+}
+
+// newAPITestSetupWithReranker mirrors newAPITestSetup but wires reranker
+// (non-nil, unlike the default setup) so these tests exercise Query's
+// over-fetch + rerank path.
+func newAPITestSetupWithReranker(t *testing.T, reranker Reranker) *apiTestSetup {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+
+	registry := NewRegistry(js)
+	backend := newFakeBackend()
+	indexSvc := NewService(registry, backend)
+
+	jobs := NewJobStore(js)
+	embedder := &stubEmbedder{}
+	ingestSvc := NewIngestService(jobs, registry, backend, nil, embedder)
+
+	return &apiTestSetup{
+		svc:      NewVectorService(indexSvc, ingestSvc, jobs, registry, backend, embedder, reranker),
+		registry: registry,
+		backend:  backend,
+		embedder: embedder,
+	}
+}
+
+func createRerankTestIndex(t *testing.T, s *apiTestSetup) {
+	t.Helper()
+	_, err := s.svc.CreateIndex(context.Background(), &CreateIndexRequest{
+		IndexID: "idx-one", Name: "kb1", Dimension: 2,
+	}, apiAccountA)
+	require.NoError(t, err)
+}
+
+// TestVectorService_Query_RerankReordersCandidates proves a configured
+// reranker's own order wins over the backend's KNN order, and the returned
+// results are truncated to the caller's requested k.
+func TestVectorService_Query_RerankReordersCandidates(t *testing.T) {
+	reranker := &stubReranker{}
+	s := newAPITestSetupWithReranker(t, reranker)
+	createRerankTestIndex(t, s)
+
+	s.backend.queryResults = []QueryResult{
+		{Chunk: "first", SourceKey: "docs/a.txt", Score: 0.9},
+		{Chunk: "second", SourceKey: "docs/b.txt", Score: 0.8},
+		{Chunk: "third", SourceKey: "docs/c.txt", Score: 0.7},
+	}
+
+	out, err := s.svc.Query(context.Background(), &QueryRequest{IndexID: "idx-one", Text: "hello", K: 2}, apiAccountA)
+	require.NoError(t, err)
+	require.Len(t, out.Results, 2)
+	// stubReranker's default order reverses the candidates: third, second,
+	// first -- truncated to k=2 gives third then second, the opposite of
+	// the KNN order fakeBackend handed back.
+	assert.Equal(t, "third", out.Results[0].Chunk)
+	assert.Equal(t, "second", out.Results[1].Chunk)
+	assert.Equal(t, "hello", reranker.lastQuery)
+}
+
+// TestVectorService_Query_RerankOverFetchesFromBackend proves Query asks
+// the backend for more than k candidates when a reranker is configured, so
+// the reranker has real headroom to improve on the KNN order.
+func TestVectorService_Query_RerankOverFetchesFromBackend(t *testing.T) {
+	reranker := &stubReranker{}
+	s := newAPITestSetupWithReranker(t, reranker)
+	createRerankTestIndex(t, s)
+
+	canned := make([]QueryResult, rerankMaxCandidates)
+	for i := range canned {
+		canned[i] = QueryResult{Chunk: "chunk", SourceKey: "docs/a.txt", Score: 1.0}
+	}
+	s.backend.queryResults = canned
+
+	_, err := s.svc.Query(context.Background(), &QueryRequest{IndexID: "idx-one", Text: "hello", K: 2}, apiAccountA)
+	require.NoError(t, err)
+	assert.Equal(t, rerankFetchK(2), s.backend.lastQueryK)
+	assert.Greater(t, s.backend.lastQueryK, 2, "over-fetch must request more than k from the backend")
+}
+
+// TestVectorService_Query_NoRerankerFallsBackToKNNOrder proves an unset
+// reranker (the default, matching every deployment that has not configured
+// a rerank endpoint) leaves Query at the backend's own KNN order, and asks
+// the backend for exactly k, not an over-fetched count.
+func TestVectorService_Query_NoRerankerFallsBackToKNNOrder(t *testing.T) {
+	s := newAPITestSetup(t) // reranker is nil in the default setup.
+	createRerankTestIndex(t, s)
+
+	s.backend.queryResults = []QueryResult{
+		{Chunk: "first", SourceKey: "docs/a.txt", Score: 0.9},
+		{Chunk: "second", SourceKey: "docs/b.txt", Score: 0.8},
+	}
+
+	out, err := s.svc.Query(context.Background(), &QueryRequest{IndexID: "idx-one", Text: "hello", K: 2}, apiAccountA)
+	require.NoError(t, err)
+	require.Len(t, out.Results, 2)
+	assert.Equal(t, "first", out.Results[0].Chunk)
+	assert.Equal(t, "second", out.Results[1].Chunk)
+	assert.Equal(t, 2, s.backend.lastQueryK, "no reranker configured must not over-fetch")
+}
+
+// TestVectorService_Query_RerankErrorFallsBackToKNNOrder proves a reranker
+// that errors never fails the request: Query falls back to the backend's
+// own KNN top-k rather than propagating the rerank failure.
+func TestVectorService_Query_RerankErrorFallsBackToKNNOrder(t *testing.T) {
+	reranker := &stubReranker{failAll: true}
+	s := newAPITestSetupWithReranker(t, reranker)
+	createRerankTestIndex(t, s)
+
+	s.backend.queryResults = []QueryResult{
+		{Chunk: "first", SourceKey: "docs/a.txt", Score: 0.9},
+		{Chunk: "second", SourceKey: "docs/b.txt", Score: 0.8},
+	}
+
+	out, err := s.svc.Query(context.Background(), &QueryRequest{IndexID: "idx-one", Text: "hello", K: 2}, apiAccountA)
+	require.NoError(t, err)
+	require.Len(t, out.Results, 2)
+	assert.Equal(t, "first", out.Results[0].Chunk)
+	assert.Equal(t, "second", out.Results[1].Chunk)
+	assert.Equal(t, 1, reranker.calls)
+}
+
+// TestVectorService_Query_RerankCapsCandidateDocLength proves a candidate
+// chunk larger than rerankMaxDocRunes is truncated before being sent to the
+// reranker, bounding the /rerank request body regardless of chunk size.
+func TestVectorService_Query_RerankCapsCandidateDocLength(t *testing.T) {
+	reranker := &stubReranker{}
+	s := newAPITestSetupWithReranker(t, reranker)
+	createRerankTestIndex(t, s)
+
+	longChunk := strings.Repeat("a", rerankMaxDocRunes+500)
+	s.backend.queryResults = []QueryResult{{Chunk: longChunk, SourceKey: "docs/a.txt", Score: 0.9}}
+
+	_, err := s.svc.Query(context.Background(), &QueryRequest{IndexID: "idx-one", Text: "hello", K: 1}, apiAccountA)
+	require.NoError(t, err)
+	require.Len(t, reranker.lastDocs, 1)
+	assert.Len(t, []rune(reranker.lastDocs[0]), rerankMaxDocRunes)
+}
+
+// TestRerankFetchK proves the over-fetch factor/cap arithmetic directly.
+func TestRerankFetchK(t *testing.T) {
+	tests := []struct {
+		name string
+		k    int
+		want int
+	}{
+		{"small k scales by factor", 2, 8},
+		{"scaled value clamped to max candidates", 10, rerankMaxCandidates},
+		{"k above max candidates passes through unover-fetched", 30, 30},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rerankFetchK(tt.k))
+		})
+	}
+}
+
+// TestRerankTopK_NilRerankerReturnsKNNOrderTruncated proves the helper's own
+// nil-reranker fallback directly, independent of vectorService.Query.
+func TestRerankTopK_NilRerankerReturnsKNNOrderTruncated(t *testing.T) {
+	results := []QueryResult{{Chunk: "a"}, {Chunk: "b"}, {Chunk: "c"}}
+	got := rerankTopK(context.Background(), nil, "query", results, 2)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a", got[0].Chunk)
+	assert.Equal(t, "b", got[1].Chunk)
+}
+
+// TestRerankTopK_OutOfRangeIndexFallsBackToKNNOrder proves a malformed
+// Reranker response (an index outside the candidate set) is treated the
+// same as a hard Rerank error: fall back rather than panic or silently drop
+// results.
+func TestRerankTopK_OutOfRangeIndexFallsBackToKNNOrder(t *testing.T) {
+	results := []QueryResult{{Chunk: "a"}, {Chunk: "b"}}
+	reranker := &stubReranker{order: func([]string) []int { return []int{5} }}
+	got := rerankTopK(context.Background(), reranker, "query", results, 2)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a", got[0].Chunk)
+	assert.Equal(t, "b", got[1].Chunk)
+}


### PR DESCRIPTION
## Commits
- size ingest chunks to the served embedder token limit (large docs no longer 422).
- rerank KB Retrieve candidates with a cross-encoder (bge-reranker).

## Notes
Independent of the co-serve PR at the git level (cut from `dev`); functionally uses a served reranker endpoint. Plan: `docs/development/improvements/ochre-coserve-vector-lifecycle.md`.