### PR TITLE
feat: back up the ochre pgvector schema to object storage

### DIFF
--- a/cmd/spinifex/cmd/admin_ochre_vector.go
+++ b/cmd/spinifex/cmd/admin_ochre_vector.go
@@ -96,6 +96,26 @@ truncated in the default table; pass --json for the full response.`,
 	Run: runOchreVectorQuery,
 }
 
+var ochreVectorBackupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Back up an account's vector-store schema to predastore",
+	Long: `backup runs pg_dump against the platform appliance, scoped to --account's own
+kb_<account> schema, gzips the output, and uploads it to predastore under an
+account-scoped, timestamped object key. Backup is an explicit operator
+action -- it never runs automatically on appliance teardown.`,
+	Run: runOchreVectorBackup,
+}
+
+var ochreVectorRestoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore an account's vector-store schema from a predastore backup",
+	Long: `restore imports --from (an object key a prior backup wrote) back into
+--account's schema, replacing its existing tables cleanly, then repairs the
+account role's grants so query/ingest access resumes exactly as before the
+backup. Safe to run against an existing schema.`,
+	Run: runOchreVectorRestore,
+}
+
 func init() {
 	ochreCmd.AddCommand(ochreVectorCmd)
 	ochreVectorCmd.AddCommand(ochreVectorIndexCmd)
@@ -106,6 +126,8 @@ func init() {
 	ochreVectorCmd.AddCommand(ochreVectorJobCmd)
 	ochreVectorJobCmd.AddCommand(ochreVectorJobDescribeCmd)
 	ochreVectorCmd.AddCommand(ochreVectorQueryCmd)
+	ochreVectorCmd.AddCommand(ochreVectorBackupCmd)
+	ochreVectorCmd.AddCommand(ochreVectorRestoreCmd)
 
 	ochreVectorIndexCreateCmd.Flags().String("name", "", "Human-readable index name (required)")
 	ochreVectorIndexCreateCmd.Flags().Int("dimension", 0, "Embedding vector dimension (required)")
@@ -129,6 +151,14 @@ func init() {
 	ochreVectorQueryCmd.Flags().Bool("json", false, "Print full, untruncated results as JSON")
 	_ = ochreVectorQueryCmd.MarkFlagRequired("index")
 	_ = ochreVectorQueryCmd.MarkFlagRequired("text")
+
+	ochreVectorBackupCmd.Flags().String("account", "", "Account ID to back up (required)")
+	_ = ochreVectorBackupCmd.MarkFlagRequired("account")
+
+	ochreVectorRestoreCmd.Flags().String("account", "", "Account ID to restore into (required)")
+	ochreVectorRestoreCmd.Flags().String("from", "", "Backup object key to restore from, as printed by 'backup' (required)")
+	_ = ochreVectorRestoreCmd.MarkFlagRequired("account")
+	_ = ochreVectorRestoreCmd.MarkFlagRequired("from")
 }
 
 // vectorServiceFn indirects the NATS-backed client so the Run functions'
@@ -140,6 +170,59 @@ var vectorServiceFn = func() (handlers_ochrevector.VectorService, func(), error)
 		return nil, nil, err
 	}
 	return handlers_ochrevector.NewNATSVectorService(nc), nc.Close, nil
+}
+
+// vectorBackupRestoreTimeout bounds the backup/restore NATS round trip: it
+// covers the appliance's own pg_dump/psql run, not just a KV read/write, so
+// it is far more generous than the other vector subjects' timeouts.
+const vectorBackupRestoreTimeout = 10 * time.Minute
+
+// backupAccountFn indirects the NATS call so runBackupAccount is testable
+// without a live daemon, mirroring vectorServiceFn/applianceTeardownFn.
+// Backup/restore are operator-only (unlike VectorService's methods): the
+// target account is named in the request payload, not derived from the
+// caller's own header identity, since the operator CLI always connects as
+// the global account but must be able to target any tenant's schema.
+var backupAccountFn = func(ctx context.Context, accountID string) (*handlers_ochrevector.BackupAccountResponse, error) {
+	_, nc, err := loadConfigAndConnectFn()
+	if err != nil {
+		return nil, err
+	}
+	defer nc.Close()
+	return utils.NATSRequest[handlers_ochrevector.BackupAccountResponse](ctx, nc,
+		handlers_ochrevector.SubjectBackupAccount, &handlers_ochrevector.BackupAccountRequest{AccountID: accountID},
+		vectorBackupRestoreTimeout, utils.GlobalAccountID)
+}
+
+// restoreAccountFn indirects the NATS call so runRestoreAccount is testable
+// without a live daemon, mirroring backupAccountFn.
+var restoreAccountFn = func(ctx context.Context, accountID, objectKey string) error {
+	_, nc, err := loadConfigAndConnectFn()
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+	_, err = utils.NATSRequest[handlers_ochrevector.RestoreAccountResponse](ctx, nc,
+		handlers_ochrevector.SubjectRestoreAccount, &handlers_ochrevector.RestoreAccountRequest{AccountID: accountID, ObjectKey: objectKey},
+		vectorBackupRestoreTimeout, utils.GlobalAccountID)
+	return err
+}
+
+// runBackupAccount is the testable core of 'ochre vector backup'.
+func runBackupAccount(ctx context.Context, accountID string, backup func(context.Context, string) (*handlers_ochrevector.BackupAccountResponse, error)) (string, error) {
+	out, err := backup(ctx, accountID)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("✅ Backed up account %s to %s (%d bytes).", accountID, out.ObjectKey, out.SizeBytes), nil
+}
+
+// runRestoreAccount is the testable core of 'ochre vector restore'.
+func runRestoreAccount(ctx context.Context, accountID, objectKey string, restore func(context.Context, string, string) error) (string, error) {
+	if err := restore(ctx, accountID, objectKey); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("✅ Restored account %s from %s.", accountID, objectKey), nil
 }
 
 // formatIndexRecord renders one index record as aligned key/value lines.
@@ -447,4 +530,29 @@ func runOchreVectorQuery(cmd *cobra.Command, _ []string) {
 		return
 	}
 	fmt.Println(out)
+}
+
+func runOchreVectorBackup(cmd *cobra.Command, _ []string) {
+	accountID, _ := cmd.Flags().GetString("account")
+
+	msg, err := runBackupAccount(context.Background(), accountID, backupAccountFn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		ochreExit(1)
+		return
+	}
+	fmt.Println(msg)
+}
+
+func runOchreVectorRestore(cmd *cobra.Command, _ []string) {
+	accountID, _ := cmd.Flags().GetString("account")
+	objectKey, _ := cmd.Flags().GetString("from")
+
+	msg, err := runRestoreAccount(context.Background(), accountID, objectKey, restoreAccountFn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		ochreExit(1)
+		return
+	}
+	fmt.Println(msg)
 }

--- a/cmd/spinifex/cmd/admin_ochre_vector_test.go
+++ b/cmd/spinifex/cmd/admin_ochre_vector_test.go
@@ -382,3 +382,123 @@ func TestRunOchreVectorQuery_ConnectFailureExits1(t *testing.T) {
 	code := withOchreExitCapture(t, func() { runOchreVectorQuery(&cmd, nil) })
 	require.Equal(t, 1, code)
 }
+
+const testBackupAccountID = "123456789012"
+
+func TestRunBackupAccount_PrintsObjectKeyAndSize(t *testing.T) {
+	backup := func(_ context.Context, accountID string) (*handlers_ochrevector.BackupAccountResponse, error) {
+		require.Equal(t, testBackupAccountID, accountID)
+		return &handlers_ochrevector.BackupAccountResponse{ObjectKey: testBackupAccountID + "/backup.sql.gz", SizeBytes: 4096}, nil
+	}
+
+	msg, err := runBackupAccount(context.Background(), testBackupAccountID, backup)
+	require.NoError(t, err)
+	require.Contains(t, msg, testBackupAccountID+"/backup.sql.gz")
+	require.Contains(t, msg, "4096")
+}
+
+func TestRunBackupAccount_ErrorSurfaces(t *testing.T) {
+	backup := func(context.Context, string) (*handlers_ochrevector.BackupAccountResponse, error) {
+		return nil, errors.New("ochrevector: appliance not available")
+	}
+
+	_, err := runBackupAccount(context.Background(), testBackupAccountID, backup)
+	require.ErrorContains(t, err, "not available")
+}
+
+func TestRunRestoreAccount_ReportsSuccess(t *testing.T) {
+	var gotAccount, gotKey string
+	restore := func(_ context.Context, accountID, objectKey string) error {
+		gotAccount, gotKey = accountID, objectKey
+		return nil
+	}
+
+	msg, err := runRestoreAccount(context.Background(), testBackupAccountID, testBackupAccountID+"/backup.sql.gz", restore)
+	require.NoError(t, err)
+	require.Equal(t, testBackupAccountID, gotAccount)
+	require.Equal(t, testBackupAccountID+"/backup.sql.gz", gotKey)
+	require.Contains(t, msg, testBackupAccountID)
+}
+
+func TestRunRestoreAccount_ErrorSurfaces(t *testing.T) {
+	restore := func(context.Context, string, string) error {
+		return errors.New("ochrevector: object key does not belong to account")
+	}
+
+	_, err := runRestoreAccount(context.Background(), testBackupAccountID, "wrong/backup.sql.gz", restore)
+	require.ErrorContains(t, err, "does not belong to account")
+}
+
+// withBackupAccount swaps backupAccountFn for one that never dials NATS, so
+// the Run wrapper's flag/exit control flow is exercised without a live
+// daemon, mirroring withApplianceTeardown.
+func withBackupAccount(t *testing.T, fn func(context.Context, string) (*handlers_ochrevector.BackupAccountResponse, error)) {
+	t.Helper()
+	orig := backupAccountFn
+	t.Cleanup(func() { backupAccountFn = orig })
+	backupAccountFn = fn
+}
+
+// withRestoreAccount mirrors withBackupAccount for restoreAccountFn.
+func withRestoreAccount(t *testing.T, fn func(context.Context, string, string) error) {
+	t.Helper()
+	orig := restoreAccountFn
+	t.Cleanup(func() { restoreAccountFn = orig })
+	restoreAccountFn = fn
+}
+
+func TestRunOchreVectorBackup_PrintsSuccess(t *testing.T) {
+	withBackupAccount(t, func(context.Context, string) (*handlers_ochrevector.BackupAccountResponse, error) {
+		return &handlers_ochrevector.BackupAccountResponse{ObjectKey: testBackupAccountID + "/backup.sql.gz", SizeBytes: 1024}, nil
+	})
+
+	cmd := *ochreVectorBackupCmd
+	require.NoError(t, cmd.Flags().Set("account", testBackupAccountID))
+
+	var out string
+	code := withOchreExitCapture(t, func() {
+		out = captureStdout(t, func() { runOchreVectorBackup(&cmd, nil) })
+	})
+	require.Equal(t, -1, code)
+	require.Contains(t, out, testBackupAccountID+"/backup.sql.gz")
+}
+
+func TestRunOchreVectorBackup_ErrorExits1(t *testing.T) {
+	withBackupAccount(t, func(context.Context, string) (*handlers_ochrevector.BackupAccountResponse, error) {
+		return nil, errors.New("ochrevector: appliance not available")
+	})
+
+	cmd := *ochreVectorBackupCmd
+	require.NoError(t, cmd.Flags().Set("account", testBackupAccountID))
+
+	code := withOchreExitCapture(t, func() { runOchreVectorBackup(&cmd, nil) })
+	require.Equal(t, 1, code)
+}
+
+func TestRunOchreVectorRestore_PrintsSuccess(t *testing.T) {
+	withRestoreAccount(t, func(context.Context, string, string) error { return nil })
+
+	cmd := *ochreVectorRestoreCmd
+	require.NoError(t, cmd.Flags().Set("account", testBackupAccountID))
+	require.NoError(t, cmd.Flags().Set("from", testBackupAccountID+"/backup.sql.gz"))
+
+	var out string
+	code := withOchreExitCapture(t, func() {
+		out = captureStdout(t, func() { runOchreVectorRestore(&cmd, nil) })
+	})
+	require.Equal(t, -1, code)
+	require.Contains(t, out, testBackupAccountID)
+}
+
+func TestRunOchreVectorRestore_ErrorExits1(t *testing.T) {
+	withRestoreAccount(t, func(context.Context, string, string) error {
+		return errors.New("ochrevector: restore requires an object key")
+	})
+
+	cmd := *ochreVectorRestoreCmd
+	require.NoError(t, cmd.Flags().Set("account", testBackupAccountID))
+	require.NoError(t, cmd.Flags().Set("from", testBackupAccountID+"/backup.sql.gz"))
+
+	code := withOchreExitCapture(t, func() { runOchreVectorRestore(&cmd, nil) })
+	require.Equal(t, 1, code)
+}

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -163,6 +163,7 @@ type Daemon struct {
 	acmRenewalWorker      *handlers_acm.Worker
 	ochreVectorService    handlers_ochrevector.VectorService
 	ochreAppliance        *handlers_ochrevector.Appliance
+	ochreBackupService    *handlers_ochrevector.BackupService
 	ecrMetaService        *handlers_ecr.MetaServiceImpl
 	routeTableService     *handlers_ec2_routetable.RouteTableServiceImpl
 	natGatewayService     *handlers_ec2_natgw.NatGatewayServiceImpl

--- a/spinifex/daemon/ochre_deps.go
+++ b/spinifex/daemon/ochre_deps.go
@@ -138,7 +138,7 @@ func (d *Daemon) startOchreVector() {
 		return
 	}
 
-	// Registered here rather than in subscribeAll: these six subjects only
+	// Registered here rather than in subscribeAll: these subjects only
 	// exist once the appliance above is actually connected, which can be
 	// minutes after subscribeAll already ran. registerNatsSubs is the same
 	// table-driven mechanism subscribeAll itself uses, so a queue-group
@@ -152,6 +152,24 @@ func (d *Daemon) startOchreVector() {
 		{handlers_ochrevector.SubjectQuery, handleNATSRequest(vectorService.Query), "spinifex-workers"},
 		{handlers_ochrevector.SubjectListJobs, handleNATSRequest(vectorService.ListJobs), "spinifex-workers"},
 	}
+
+	// backup/restore need RegrantAccount alongside EnsureAccount, which is
+	// not part of VectorBackend itself; every real backend (pgxBackend)
+	// implements it, so this only ever skips registration for a future
+	// VectorBackend that does not.
+	if granter, ok := backend.(handlers_ochrevector.AccountGranter); ok {
+		backupSvc := handlers_ochrevector.NewBackupService(appliance, granter, store, handlers_ochrevector.ExecPgDumper{})
+		d.mu.Lock()
+		d.ochreBackupService = backupSvc
+		d.mu.Unlock()
+		subs = append(subs,
+			natsSub{handlers_ochrevector.SubjectBackupAccount, handleNATSRequest(backupSvc.Backup), "spinifex-workers"},
+			natsSub{handlers_ochrevector.SubjectRestoreAccount, handleNATSRequest(backupSvc.Restore), "spinifex-workers"},
+		)
+	} else {
+		slog.Warn("Ochre vector store: backend does not support account backup/restore; subjects not registered")
+	}
+
 	if err := d.registerNatsSubs(subs); err != nil {
 		slog.Error("Ochre vector store: failed to register NATS subjects", "err", err)
 		return
@@ -212,6 +230,7 @@ func (d *Daemon) handleOchreApplianceTeardown(ctx context.Context, _ *handlers_o
 	d.mu.Lock()
 	d.ochreAppliance = nil
 	d.ochreVectorService = nil
+	d.ochreBackupService = nil
 	d.mu.Unlock()
 
 	return &handlers_ochrevector.TeardownApplianceResponse{}, nil

--- a/spinifex/handlers/ochrevector/appliance.go
+++ b/spinifex/handlers/ochrevector/appliance.go
@@ -439,38 +439,10 @@ func (a *Appliance) resume(ctx context.Context, kv jetstream.KeyValue, rec Appli
 // the moment it takes to compose the DSN and open the pool. The password
 // never leaves this call.
 func (a *Appliance) Connect(ctx context.Context) (*pgxBackend, error) {
-	kv, err := a.bucket(ctx)
+	dsn, err := a.dsn(ctx)
 	if err != nil {
 		return nil, err
 	}
-	rec, _, err := a.getRecord(ctx, kv)
-	if err != nil {
-		return nil, err
-	}
-	if rec == nil {
-		return nil, errors.New("ochrevector: appliance not yet provisioned")
-	}
-	if rec.State != ApplianceStateAvailable {
-		return nil, fmt.Errorf("ochrevector: appliance not available (state %q)", rec.State)
-	}
-
-	dialIP, err := a.ensureHostPort(ctx, rec)
-	if err != nil {
-		return nil, err
-	}
-
-	password, err := a.decryptPassword(rec)
-	if err != nil {
-		return nil, err
-	}
-	// dialIP is only ever non-empty when the host-port path actually ran
-	// (WithHostPort configured); otherwise this is the unchanged pre-fix
-	// dial target.
-	dialHost := rec.Endpoint
-	if dialIP != "" {
-		dialHost = dialIP
-	}
-	dsn := buildDSN(dialHost, rec.Port, rec.MasterUsername, password)
 
 	backend, err := NewPgxBackend(ctx, dsn)
 	if err != nil {
@@ -481,6 +453,45 @@ func (a *Appliance) Connect(ctx context.Context) (*pgxBackend, error) {
 		return nil, err
 	}
 	return backend, nil
+}
+
+// dsn resolves the appliance's connection DSN: the same record lookup,
+// host-port routing and password decrypt Connect uses, without opening a
+// pgx pool. Backup/Restore shell out to pg_dump/psql instead of dialing
+// through pgx, but still need this exact dial host/port and password.
+func (a *Appliance) dsn(ctx context.Context) (string, error) {
+	kv, err := a.bucket(ctx)
+	if err != nil {
+		return "", err
+	}
+	rec, _, err := a.getRecord(ctx, kv)
+	if err != nil {
+		return "", err
+	}
+	if rec == nil {
+		return "", errors.New("ochrevector: appliance not yet provisioned")
+	}
+	if rec.State != ApplianceStateAvailable {
+		return "", fmt.Errorf("ochrevector: appliance not available (state %q)", rec.State)
+	}
+
+	dialIP, err := a.ensureHostPort(ctx, rec)
+	if err != nil {
+		return "", err
+	}
+
+	password, err := a.decryptPassword(rec)
+	if err != nil {
+		return "", err
+	}
+	// dialIP is only ever non-empty when the host-port path actually ran
+	// (WithHostPort configured); otherwise this is the unchanged pre-fix
+	// dial target.
+	dialHost := rec.Endpoint
+	if dialIP != "" {
+		dialHost = dialIP
+	}
+	return buildDSN(dialHost, rec.Port, rec.MasterUsername, password), nil
 }
 
 // getRecord reads and decodes the appliance record, returning (nil, nil, nil)

--- a/spinifex/handlers/ochrevector/backup.go
+++ b/spinifex/handlers/ochrevector/backup.go
@@ -1,0 +1,284 @@
+package handlers_ochrevector
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/mulgadc/spinifex/spinifex/objectstore"
+)
+
+// SubjectBackupAccount and SubjectRestoreAccount are the operator-only NATS
+// subjects for account-scoped pgvector schema backup/restore (D2-adjacent):
+// reached solely via `spx admin ochre vector backup`/`restore`, never
+// through the tenant-facing awsgw surface.
+const (
+	SubjectBackupAccount  = "ochre.appliance.backupAccount"
+	SubjectRestoreAccount = "ochre.appliance.restoreAccount"
+)
+
+// backupBucket holds every account's pgvector schema backup, one predastore
+// bucket with objects keyed per account and timestamp. Backup is an explicit
+// operator action (never automatic on teardown), so a stray or malicious
+// tenant request can never trigger a dump: only the operator CLI reaches
+// this subject.
+const backupBucket = "ochre-vector-backups"
+
+// backupObjectKeyLayout timestamps a backup object so successive backups of
+// the same account never collide and sort lexically newest-last.
+const backupObjectKeyLayout = "20060102T150405Z"
+
+// BackupAccountRequest names the account to back up. Carried in the payload
+// rather than derived from the caller's own NATS header identity: the
+// operator CLI always calls in as the global account, but must be able to
+// target any tenant account's schema, not just its own.
+type BackupAccountRequest struct {
+	AccountID string `json:"accountId"`
+}
+
+// BackupAccountResponse reports where the backup landed, so the operator can
+// hand ObjectKey straight to a later restore call.
+type BackupAccountResponse struct {
+	ObjectKey string `json:"objectKey"`
+	SizeBytes int64  `json:"sizeBytes"`
+}
+
+// RestoreAccountRequest names the account and the backup object to restore
+// into it. AccountID is payload-carried for the same reason as
+// BackupAccountRequest's.
+type RestoreAccountRequest struct {
+	AccountID string `json:"accountId"`
+	ObjectKey string `json:"objectKey"`
+}
+
+// RestoreAccountResponse has no fields: a successful restore has nothing
+// further to report beyond a nil error.
+type RestoreAccountResponse struct{}
+
+// PgDumper is the seam to the pg_dump/psql binaries this package shells out
+// to: the real implementation execs them against the appliance DSN, tests
+// substitute a fake so the object-key/gzip/streaming plumbing around it is
+// provable without a live Postgres or the binaries installed.
+type PgDumper interface {
+	// Dump streams a plain-SQL dump of schema at dsn to w. The dump is
+	// self-cleaning (DROP ... IF EXISTS before each CREATE) and carries no
+	// owner/privilege statements, so importing it never depends on which
+	// role happens to run the restore.
+	Dump(ctx context.Context, dsn, schema string, w io.Writer) error
+	// Restore runs the SQL read from r against the database at dsn.
+	Restore(ctx context.Context, dsn string, r io.Reader) error
+}
+
+// ExecPgDumper is the real PgDumper: it shells out to the pg_dump and psql
+// binaries, which must be present on the node's PATH.
+type ExecPgDumper struct{}
+
+var _ PgDumper = ExecPgDumper{}
+
+// Dump runs pg_dump scoped to schema, --clean/--if-exists so replaying the
+// output against an existing (or freshly EnsureAccount'd) schema is safe,
+// and --no-owner/--no-privileges so the output never references a role that
+// may not exist yet on the restore target.
+func (ExecPgDumper) Dump(ctx context.Context, dsn, schema string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, "pg_dump",
+		"--dbname="+dsn,
+		"--schema="+schema,
+		"--no-owner",
+		"--no-privileges",
+		"--clean",
+		"--if-exists",
+	)
+	cmd.Stdout = w
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("ochrevector: pg_dump schema %s: %w: %s", schema, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// Restore runs psql against dsn, reading the SQL script from r and stopping
+// on the first error rather than continuing past a partially-applied
+// restore.
+func (ExecPgDumper) Restore(ctx context.Context, dsn string, r io.Reader) error {
+	cmd := exec.CommandContext(ctx, "psql",
+		"--dbname="+dsn,
+		"--set=ON_ERROR_STOP=1",
+		"--quiet",
+	)
+	cmd.Stdin = r
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("ochrevector: psql restore: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// AccountGranter is the post-restore schema/privilege repair surface
+// BackupService needs: EnsureAccount recreates the schema-level grant a
+// dump's DROP/CREATE SCHEMA wipes, RegrantAccount then covers the tables and
+// sequences the dump itself recreated with no owner. *pgxBackend satisfies
+// it structurally; exported so daemon wiring can type-assert a VectorBackend
+// against it without this package's help.
+type AccountGranter interface {
+	EnsureAccount(ctx context.Context, accountID string) error
+	RegrantAccount(ctx context.Context, accountID string) error
+}
+
+var _ AccountGranter = (*pgxBackend)(nil)
+
+// applianceDSNResolver is the DSN-resolution surface BackupService needs
+// from *Appliance; narrowed to the one method so a fake appliance never has
+// to satisfy the whole singleton-orchestration type in tests.
+type applianceDSNResolver interface {
+	dsn(ctx context.Context) (string, error)
+}
+
+var _ applianceDSNResolver = (*Appliance)(nil)
+
+// BackupService performs account-scoped pg_dump/restore of the appliance's
+// per-account schema to/from predastore S3 (D3). Backup is an explicit
+// operator action, never automatic; Restore into an existing schema
+// overwrites it cleanly via the dump's own --clean/--if-exists statements,
+// then repairs the account role's grants that a schema-level DROP wipes.
+type BackupService struct {
+	Appliance applianceDSNResolver
+	Backend   AccountGranter
+	Store     objectstore.ObjectStore
+	Dumper    PgDumper
+	// Now stands in for time.Now in tests, so a backup's object key is
+	// deterministic.
+	Now func() time.Time
+}
+
+// NewBackupService constructs a BackupService over its dependencies.
+func NewBackupService(appliance applianceDSNResolver, backend AccountGranter, store objectstore.ObjectStore, dumper PgDumper) *BackupService {
+	return &BackupService{Appliance: appliance, Backend: backend, Store: store, Dumper: dumper, Now: time.Now}
+}
+
+// backupObjectKey scopes a backup object under accountID's own key prefix,
+// timestamped so successive backups never collide.
+func backupObjectKey(accountID string, at time.Time) string {
+	return fmt.Sprintf("%s/%s-%s.sql.gz", accountID, accountID, at.UTC().Format(backupObjectKeyLayout))
+}
+
+// Backup dumps accountID's schema, gzips it to a temp file (bounding memory
+// to the gzip buffer rather than the whole dump), then uploads it to
+// predastore under an account-scoped, timestamped key.
+func (s *BackupService) Backup(ctx context.Context, req *BackupAccountRequest, _ string) (*BackupAccountResponse, error) {
+	accountID := req.AccountID
+	if err := validateAccountID(accountID); err != nil {
+		return nil, err
+	}
+	dsn, err := s.Appliance.dsn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ochrevector: resolve appliance dsn for backup: %w", err)
+	}
+
+	tmp, err := os.CreateTemp("", "ochre-vector-backup-*.sql.gz")
+	if err != nil {
+		return nil, fmt.Errorf("ochrevector: create backup temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	defer tmp.Close()
+
+	gz := gzip.NewWriter(tmp)
+	if err := s.Dumper.Dump(ctx, dsn, schemaName(accountID), gz); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("ochrevector: flush backup gzip stream for account %s: %w", accountID, err)
+	}
+
+	info, err := tmp.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("ochrevector: stat backup temp file: %w", err)
+	}
+	size := info.Size()
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("ochrevector: rewind backup temp file: %w", err)
+	}
+
+	if err := s.Store.EnsureBucket(ctx, backupBucket); err != nil {
+		return nil, fmt.Errorf("ochrevector: ensure backup bucket: %w", err)
+	}
+
+	key := backupObjectKey(accountID, s.Now())
+	if _, err := s.Store.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(backupBucket),
+		Key:           aws.String(key),
+		Body:          tmp,
+		ContentLength: aws.Int64(size),
+		ContentType:   aws.String("application/gzip"),
+	}); err != nil {
+		return nil, fmt.Errorf("ochrevector: upload backup object %s: %w", key, err)
+	}
+
+	return &BackupAccountResponse{ObjectKey: key, SizeBytes: size}, nil
+}
+
+// Restore fetches objectKey from predastore, gunzips it straight into psql
+// against the appliance, then repairs the account role's grants (the dump
+// itself carries none) so query/ingest access resumes exactly as before the
+// backup. Idempotent: rerunning against the same or a fresh schema is safe.
+func (s *BackupService) Restore(ctx context.Context, req *RestoreAccountRequest, _ string) (*RestoreAccountResponse, error) {
+	accountID := req.AccountID
+	if err := validateAccountID(accountID); err != nil {
+		return nil, err
+	}
+	if req.ObjectKey == "" {
+		return nil, errors.New("ochrevector: restore requires an object key")
+	}
+	// Guards against restoring the wrong account's data into accountID by
+	// operator mistake: every backup key is minted under its own account
+	// prefix (backupObjectKey), so a mismatch here is always a typo, never
+	// a legitimate cross-account restore.
+	if !strings.HasPrefix(req.ObjectKey, accountID+"/") {
+		return nil, fmt.Errorf("ochrevector: object key %s does not belong to account %s", req.ObjectKey, accountID)
+	}
+
+	dsn, err := s.Appliance.dsn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ochrevector: resolve appliance dsn for restore: %w", err)
+	}
+
+	out, err := s.Store.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(backupBucket), Key: aws.String(req.ObjectKey)})
+	if err != nil {
+		return nil, fmt.Errorf("ochrevector: fetch backup object %s: %w", req.ObjectKey, err)
+	}
+	defer out.Body.Close()
+
+	gz, err := gzip.NewReader(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("ochrevector: open backup gzip stream %s: %w", req.ObjectKey, err)
+	}
+	defer gz.Close()
+
+	if err := s.Dumper.Restore(ctx, dsn, gz); err != nil {
+		return nil, err
+	}
+
+	// The dump's own DROP/CREATE SCHEMA wipes the schema-level USAGE/CREATE
+	// grant EnsureAccount made; repeating it here is idempotent and restores
+	// exactly that grant, then RegrantAccount covers the tables/sequences
+	// pg_dump recreated with no owner.
+	if err := s.Backend.EnsureAccount(ctx, accountID); err != nil {
+		return nil, fmt.Errorf("ochrevector: re-ensure account %s after restore: %w", accountID, err)
+	}
+	if err := s.Backend.RegrantAccount(ctx, accountID); err != nil {
+		return nil, fmt.Errorf("ochrevector: regrant account %s after restore: %w", accountID, err)
+	}
+
+	return &RestoreAccountResponse{}, nil
+}

--- a/spinifex/handlers/ochrevector/backup_test.go
+++ b/spinifex/handlers/ochrevector/backup_test.go
@@ -1,0 +1,263 @@
+// Exercises unexported ochrevector backup/restore internals with no
+// exported surface to drive them through.
+//
+//test:in-package
+package handlers_ochrevector
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/mulgadc/spinifex/spinifex/objectstore"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const backupTestAccount = "123456789012"
+
+// fakeDumper is the PgDumper test double: it records exactly what it was
+// asked to dump/restore and lets tests script content/errors, so the
+// object-key/gzip/streaming plumbing around it is provable without a live
+// Postgres or the pg_dump/psql binaries.
+type fakeDumper struct {
+	dumpContent []byte
+	dumpErr     error
+	dumpDSN     string
+	dumpSchema  string
+	dumpCalls   int
+
+	restoreErr     error
+	restoreDSN     string
+	restoreContent []byte
+	restoreCalls   int
+}
+
+func (f *fakeDumper) Dump(_ context.Context, dsn, schema string, w io.Writer) error {
+	f.dumpCalls++
+	f.dumpDSN = dsn
+	f.dumpSchema = schema
+	if f.dumpErr != nil {
+		return f.dumpErr
+	}
+	_, err := w.Write(f.dumpContent)
+	return err
+}
+
+func (f *fakeDumper) Restore(_ context.Context, dsn string, r io.Reader) error {
+	f.restoreCalls++
+	f.restoreDSN = dsn
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	f.restoreContent = data
+	return f.restoreErr
+}
+
+var _ PgDumper = (*fakeDumper)(nil)
+
+// fakeAccountGranter is the AccountGranter test double: it records every
+// EnsureAccount/RegrantAccount call so Restore's post-import repair sequence
+// is provable without a live pgxBackend.
+type fakeAccountGranter struct {
+	ensureCalls  []string
+	regrantCalls []string
+	ensureErr    error
+	regrantErr   error
+}
+
+func (f *fakeAccountGranter) EnsureAccount(_ context.Context, accountID string) error {
+	f.ensureCalls = append(f.ensureCalls, accountID)
+	return f.ensureErr
+}
+
+func (f *fakeAccountGranter) RegrantAccount(_ context.Context, accountID string) error {
+	f.regrantCalls = append(f.regrantCalls, accountID)
+	return f.regrantErr
+}
+
+var _ AccountGranter = (*fakeAccountGranter)(nil)
+
+// newBackupTestAppliance builds a real *Appliance (fakeLauncher, embedded
+// JetStream) seeded AVAILABLE at endpoint:port with no WithHostPort, so
+// dsn() resolves straight to that endpoint the way TestConnect_
+// NoHostPortDepsSkipsEnsure relies on for Connect.
+func newBackupTestAppliance(t *testing.T, endpoint string, port int) *Appliance {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	masterKey := testMasterKey(t)
+	appliance, err := NewAppliance(js, masterKey, &fakeLauncher{})
+	require.NoError(t, err)
+	seedAvailableAppliance(t, appliance, masterKey, endpoint, port)
+	return appliance
+}
+
+func gunzip(t *testing.T, data []byte) []byte {
+	t.Helper()
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return out
+}
+
+func TestBackupObjectKey_ScopedUnderAccountPrefixAndTimestamped(t *testing.T) {
+	at := time.Date(2026, 8, 18, 12, 30, 0, 0, time.UTC)
+	key := backupObjectKey(backupTestAccount, at)
+	assert.Equal(t, backupTestAccount+"/"+backupTestAccount+"-20260818T123000Z.sql.gz", key)
+}
+
+func TestBackupService_Backup_UploadsGzippedDumpUnderAccountKey(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	dumper := &fakeDumper{dumpContent: []byte("-- pg_dump output for kb_" + backupTestAccount)}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, store, dumper)
+
+	out, err := svc.Backup(context.Background(), &BackupAccountRequest{AccountID: backupTestAccount}, "")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, backupTestAccount+"/", out.ObjectKey[:len(backupTestAccount)+1])
+	assert.Equal(t, "kb_"+backupTestAccount, dumper.dumpSchema)
+	assert.Equal(t, 1, dumper.dumpCalls)
+	assert.NotZero(t, out.SizeBytes)
+
+	got, err := store.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String(backupBucket),
+		Key:    aws.String(out.ObjectKey),
+	})
+	require.NoError(t, err)
+	data, err := io.ReadAll(got.Body)
+	require.NoError(t, err)
+	assert.Equal(t, dumper.dumpContent, gunzip(t, data))
+}
+
+func TestBackupService_Backup_InvalidAccountIDRejected(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	dumper := &fakeDumper{}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, objectstore.NewMemoryObjectStore(), dumper)
+
+	_, err := svc.Backup(context.Background(), &BackupAccountRequest{AccountID: "not-an-account"}, "")
+	require.Error(t, err)
+	assert.Equal(t, 0, dumper.dumpCalls, "dumper must never run for a rejected account id")
+}
+
+func TestBackupService_Backup_DumperErrorLeavesNoObjectUploaded(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	dumper := &fakeDumper{dumpErr: errors.New("pg_dump: connection refused")}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, store, dumper)
+
+	_, err := svc.Backup(context.Background(), &BackupAccountRequest{AccountID: backupTestAccount}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "connection refused")
+	assert.Equal(t, 0, store.Count())
+}
+
+func TestBackupService_Backup_ApplianceNotAvailablePropagates(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	appliance, err := NewAppliance(js, testMasterKey(t), &fakeLauncher{})
+	require.NoError(t, err)
+	// Never seeded AVAILABLE: dsn() must refuse before the dumper ever runs.
+	dumper := &fakeDumper{}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, objectstore.NewMemoryObjectStore(), dumper)
+
+	_, err = svc.Backup(context.Background(), &BackupAccountRequest{AccountID: backupTestAccount}, "")
+	require.Error(t, err)
+	assert.Equal(t, 0, dumper.dumpCalls)
+}
+
+// seedBackupObject uploads a gzipped SQL script under accountID's own
+// object-key prefix, standing in for a prior Backup call.
+func seedBackupObject(t *testing.T, store *objectstore.MemoryObjectStore, accountID, sql string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(sql))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	key := backupObjectKey(accountID, time.Now())
+	require.NoError(t, store.EnsureBucket(context.Background(), backupBucket))
+	_, err = store.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String(backupBucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(buf.Bytes()),
+	})
+	require.NoError(t, err)
+	return key
+}
+
+func TestBackupService_Restore_RunsPsqlThenRegrantsAccount(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	key := seedBackupObject(t, store, backupTestAccount, "COPY kb_"+backupTestAccount+".idx_x FROM stdin;\n")
+	dumper := &fakeDumper{}
+	granter := &fakeAccountGranter{}
+	svc := NewBackupService(appliance, granter, store, dumper)
+
+	out, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: key}, "")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	assert.Equal(t, 1, dumper.restoreCalls)
+	assert.Contains(t, string(dumper.restoreContent), "COPY kb_"+backupTestAccount)
+	assert.Equal(t, []string{backupTestAccount}, granter.ensureCalls)
+	assert.Equal(t, []string{backupTestAccount}, granter.regrantCalls)
+}
+
+func TestBackupService_Restore_RejectsMismatchedAccountPrefix(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	otherAccount := "000000000099"
+	key := seedBackupObject(t, store, otherAccount, "-- not this account's dump")
+	dumper := &fakeDumper{}
+	granter := &fakeAccountGranter{}
+	svc := NewBackupService(appliance, granter, store, dumper)
+
+	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: key}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "does not belong to account")
+	assert.Equal(t, 0, dumper.restoreCalls)
+	assert.Empty(t, granter.ensureCalls, "must not touch the account's schema on a rejected key")
+}
+
+func TestBackupService_Restore_MissingObjectKeyRejected(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, objectstore.NewMemoryObjectStore(), &fakeDumper{})
+
+	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "requires an object key")
+}
+
+func TestBackupService_Restore_ObjectNotFoundPropagates(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, objectstore.NewMemoryObjectStore(), &fakeDumper{})
+
+	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{
+		AccountID: backupTestAccount,
+		ObjectKey: backupTestAccount + "/missing.sql.gz",
+	}, "")
+	require.Error(t, err)
+}
+
+func TestBackupService_Restore_PsqlErrorSkipsRegrant(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	key := seedBackupObject(t, store, backupTestAccount, "-- broken sql")
+	dumper := &fakeDumper{restoreErr: errors.New("psql: syntax error")}
+	granter := &fakeAccountGranter{}
+	svc := NewBackupService(appliance, granter, store, dumper)
+
+	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: key}, "")
+	require.Error(t, err)
+	assert.Empty(t, granter.ensureCalls, "a failed import must not be followed by a grant repair")
+}

--- a/spinifex/handlers/ochrevector/backup_test.go
+++ b/spinifex/handlers/ochrevector/backup_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,6 +64,31 @@ func (f *fakeDumper) Restore(_ context.Context, dsn string, r io.Reader) error {
 }
 
 var _ PgDumper = (*fakeDumper)(nil)
+
+// TestExecPgDumper_Dump_MissingBinaryPropagatesError points PATH at an empty
+// directory so pg_dump can never be found, proving Dump builds the command
+// and wraps exec's failure without needing a live Postgres or binary.
+func TestExecPgDumper_Dump_MissingBinaryPropagatesError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	var buf bytes.Buffer
+	schema := schemaName(backupTestAccount)
+
+	err := ExecPgDumper{}.Dump(context.Background(), "postgres://ignored", schema, &buf)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "pg_dump schema "+schema)
+	assert.Zero(t, buf.Len())
+}
+
+// TestExecPgDumper_Restore_MissingBinaryPropagatesError is Dump's
+// counterpart for Restore: psql is unreachable via PATH, so Restore must
+// wrap exec's failure rather than hang on stdin.
+func TestExecPgDumper_Restore_MissingBinaryPropagatesError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	err := ExecPgDumper{}.Restore(context.Background(), "postgres://ignored", strings.NewReader("select 1;"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "psql restore")
+}
 
 // fakeAccountGranter is the AccountGranter test double: it records every
 // EnsureAccount/RegrantAccount call so Restore's post-import repair sequence
@@ -159,6 +185,60 @@ func TestBackupService_Backup_DumperErrorLeavesNoObjectUploaded(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "connection refused")
 	assert.Equal(t, 0, store.Count())
+}
+
+// failingStore wraps MemoryObjectStore so tests can script EnsureBucket/
+// PutObject failures the way a predastore outage would, without a live
+// backend.
+type failingStore struct {
+	*objectstore.MemoryObjectStore
+
+	ensureBucketErr error
+	putObjectErr    error
+}
+
+func (f *failingStore) EnsureBucket(ctx context.Context, bucket string) error {
+	if f.ensureBucketErr != nil {
+		return f.ensureBucketErr
+	}
+	return f.MemoryObjectStore.EnsureBucket(ctx, bucket)
+}
+
+func (f *failingStore) PutObject(ctx context.Context, input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	if f.putObjectErr != nil {
+		return nil, f.putObjectErr
+	}
+	return f.MemoryObjectStore.PutObject(ctx, input)
+}
+
+var _ objectstore.ObjectStore = (*failingStore)(nil)
+
+func TestBackupService_Backup_EnsureBucketErrorPropagates(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := &failingStore{
+		MemoryObjectStore: objectstore.NewMemoryObjectStore(),
+		ensureBucketErr:   errors.New("predastore: bucket quota exceeded"),
+	}
+	dumper := &fakeDumper{dumpContent: []byte("-- pg_dump output")}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, store, dumper)
+
+	_, err := svc.Backup(context.Background(), &BackupAccountRequest{AccountID: backupTestAccount}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "bucket quota exceeded")
+}
+
+func TestBackupService_Backup_PutObjectErrorPropagates(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := &failingStore{
+		MemoryObjectStore: objectstore.NewMemoryObjectStore(),
+		putObjectErr:      errors.New("predastore: connection reset"),
+	}
+	dumper := &fakeDumper{dumpContent: []byte("-- pg_dump output")}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, store, dumper)
+
+	_, err := svc.Backup(context.Background(), &BackupAccountRequest{AccountID: backupTestAccount}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "connection reset")
 }
 
 func TestBackupService_Backup_ApplianceNotAvailablePropagates(t *testing.T) {
@@ -260,4 +340,75 @@ func TestBackupService_Restore_PsqlErrorSkipsRegrant(t *testing.T) {
 	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: key}, "")
 	require.Error(t, err)
 	assert.Empty(t, granter.ensureCalls, "a failed import must not be followed by a grant repair")
+}
+
+func TestBackupService_Restore_InvalidAccountIDRejected(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	dumper := &fakeDumper{}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, objectstore.NewMemoryObjectStore(), dumper)
+
+	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: "not-an-account", ObjectKey: "x/y.sql.gz"}, "")
+	require.Error(t, err)
+	assert.Equal(t, 0, dumper.restoreCalls, "dumper must never run for a rejected account id")
+}
+
+func TestBackupService_Restore_ApplianceNotAvailablePropagates(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	appliance, err := NewAppliance(js, testMasterKey(t), &fakeLauncher{})
+	require.NoError(t, err)
+	// Never seeded AVAILABLE: dsn() must refuse before the dumper ever runs.
+	dumper := &fakeDumper{}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, objectstore.NewMemoryObjectStore(), dumper)
+
+	_, err = svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: backupTestAccount + "/x.sql.gz"}, "")
+	require.Error(t, err)
+	assert.Equal(t, 0, dumper.restoreCalls)
+}
+
+func TestBackupService_Restore_CorruptGzipObjectRejected(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	require.NoError(t, store.EnsureBucket(context.Background(), backupBucket))
+	key := backupTestAccount + "/not-gzip.sql.gz"
+	_, err := store.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String(backupBucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader([]byte("this is not a gzip stream")),
+	})
+	require.NoError(t, err)
+	dumper := &fakeDumper{}
+	svc := NewBackupService(appliance, &fakeAccountGranter{}, store, dumper)
+
+	_, err = svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: key}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "open backup gzip stream")
+	assert.Equal(t, 0, dumper.restoreCalls)
+}
+
+func TestBackupService_Restore_EnsureAccountErrorPropagates(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	key := seedBackupObject(t, store, backupTestAccount, "-- sql")
+	dumper := &fakeDumper{}
+	granter := &fakeAccountGranter{ensureErr: errors.New("grant: schema locked")}
+	svc := NewBackupService(appliance, granter, store, dumper)
+
+	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: key}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "schema locked")
+	assert.Empty(t, granter.regrantCalls, "must not attempt regrant when the ensure-account repair fails")
+}
+
+func TestBackupService_Restore_RegrantAccountErrorPropagates(t *testing.T) {
+	appliance := newBackupTestAppliance(t, "127.0.0.1", 5432)
+	store := objectstore.NewMemoryObjectStore()
+	key := seedBackupObject(t, store, backupTestAccount, "-- sql")
+	dumper := &fakeDumper{}
+	granter := &fakeAccountGranter{regrantErr: errors.New("grant: role missing")}
+	svc := NewBackupService(appliance, granter, store, dumper)
+
+	_, err := svc.Restore(context.Background(), &RestoreAccountRequest{AccountID: backupTestAccount, ObjectKey: key}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "role missing")
+	assert.Equal(t, []string{backupTestAccount}, granter.ensureCalls, "ensure-account must still run before the failing regrant")
 }

--- a/spinifex/handlers/ochrevector/pgx_backend.go
+++ b/spinifex/handlers/ochrevector/pgx_backend.go
@@ -119,6 +119,30 @@ func (b *pgxBackend) EnsureAccount(ctx context.Context, accountID string) error 
 	return nil
 }
 
+// RegrantAccount grants the account role full privileges on every table and
+// sequence currently in its schema. A restore imports a dump taken with
+// --no-owner/--no-privileges as the master role, which recreates each object
+// owned by the master role rather than the account role; this closes that
+// gap so query/ingest access is unaffected by which role ran the restore.
+func (b *pgxBackend) RegrantAccount(ctx context.Context, accountID string) error {
+	if err := validateAccountID(accountID); err != nil {
+		return err
+	}
+	schema := sanitizeIdent(schemaName(accountID))
+	role := sanitizeIdent(roleName(accountID))
+
+	// #nosec G201 -- schema/role are sanitized, validated identifiers; GRANT
+	// does not accept bound parameters.
+	if _, err := b.pool.Exec(ctx, fmt.Sprintf(`GRANT ALL ON ALL TABLES IN SCHEMA %s TO %s`, schema, role)); err != nil {
+		return fmt.Errorf("ochrevector: regrant tables for account %s: %w", accountID, err)
+	}
+	// #nosec G201 -- schema/role are sanitized, validated identifiers.
+	if _, err := b.pool.Exec(ctx, fmt.Sprintf(`GRANT ALL ON ALL SEQUENCES IN SCHEMA %s TO %s`, schema, role)); err != nil {
+		return fmt.Errorf("ochrevector: regrant sequences for account %s: %w", accountID, err)
+	}
+	return nil
+}
+
 // withAccountTx runs fn inside a transaction scoped to accountID: SET LOCAL
 // ROLE to the account's role and SET LOCAL search_path to its schema, so
 // every statement fn issues is enforced by Postgres' own grants — even a


### PR DESCRIPTION
## Commit
- back up the ochre pgvector schema to object storage.

## Notes
Independent feature off `dev`.