### PR TITLE
fix: recover a failed RDS instance whose agent is dead

### DIFF
--- a/spinifex/handlers/rds/commands.go
+++ b/spinifex/handlers/rds/commands.go
@@ -49,8 +49,10 @@ const (
 // which is bounded by the dirty set rather than by anything the caller knows.
 const (
 	setPasswordTimeout = 30 * time.Second
-	applyParamsTimeout = 120 * time.Second
-	stopEngineTimeout  = 120 * time.Second
+	// Overridable via Deps.ApplyParamsTimeout, so a test exercising an
+	// unreachable agent does not have to wait out the real budget.
+	defaultApplyParamsTimeout = 120 * time.Second
+	stopEngineTimeout         = 120 * time.Second
 	// growpart plus an online resize2fs/xfs_growfs. Both scale with the
 	// filesystem's metadata rather than with the volume, so this is generous
 	// rather than proportional to the grow.
@@ -93,7 +95,7 @@ func (s *Service) setMasterPassword(ctx context.Context, accountID, dbInstanceId
 // Returns the settings the engine accepted but will not apply until it
 // restarts, which is what RebootDBInstance then clears.
 func (s *Service) applyParameters(ctx context.Context, accountID, dbInstanceIdentifier string, params []Parameter) ([]string, error) {
-	reply, err := s.issueCommand(ctx, accountID, dbInstanceIdentifier, CommandApplyParams, applyParamsTimeout, params)
+	reply, err := s.issueCommand(ctx, accountID, dbInstanceIdentifier, CommandApplyParams, s.applyParamsTimeout(), params)
 	if err != nil {
 		return nil, err
 	}

--- a/spinifex/handlers/rds/lifecycle_test.go
+++ b/spinifex/handlers/rds/lifecycle_test.go
@@ -26,6 +26,10 @@ import (
 // milliseconds rather than in the minute a real one is given.
 const testVMStopTimeout = 40 * time.Millisecond
 
+// The wait for an apply-params reply, shrunk so an unreachable agent is
+// bounded in milliseconds rather than in the real command budget.
+const testApplyParamsTimeout = 40 * time.Millisecond
+
 // fakeInstanceCommander records the power commands the lifecycle ops issue, and
 // can refuse them the way a node that no longer holds the VM does.
 type fakeInstanceCommander struct {
@@ -178,6 +182,9 @@ type stubAgent struct {
 	// What a successful reply carries back. The apply-params reply reports the
 	// settings pending a restart here, since CommandReply has no payload.
 	message string
+	// Commands of this type are recorded but never answered, which is how an
+	// unreachable agent is modelled without waiting out its real budget.
+	silence string
 }
 
 // Set before any command is issued; guarded because the reply is built on the
@@ -186,6 +193,14 @@ func (a *stubAgent) replyWith(message string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.message = message
+}
+
+// Commands of this type get no reply at all, so the issuer's command budget
+// runs out rather than seeing a fast failure — the shape of a dead agent.
+func (a *stubAgent) silenceType(commandType string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.silence = commandType
 }
 
 func (a *stubAgent) received() []Command {
@@ -207,6 +222,10 @@ func newStubAgent(t *testing.T, nc *nats.Conn, accountID, dbID string, fail bool
 		}
 		agent.mu.Lock()
 		agent.issued = append(agent.issued, cmd)
+		if agent.silence != "" && cmd.Type == agent.silence {
+			agent.mu.Unlock()
+			return
+		}
 		reply := CommandReply{CommandID: cmd.CommandID, Status: CommandStatusSucceeded, Message: agent.message}
 		if agent.fail {
 			reply = CommandReply{CommandID: cmd.CommandID, Status: CommandStatusFailed, Message: "the engine did not stop"}

--- a/spinifex/handlers/rds/modify_test.go
+++ b/spinifex/handlers/rds/modify_test.go
@@ -70,6 +70,7 @@ func newModifyHarnessWithAgent(t *testing.T, agentFails bool) *modifyHarness {
 		InstanceState:      h.vmState,
 		VMStopTimeout:      testVMStopTimeout,
 		ServingCertKeyBits: testServingCertKeyBits,
+		ApplyParamsTimeout: testApplyParamsTimeout,
 	})
 	h.rec = NewReconciler(h.svc, "node-a")
 	return h

--- a/spinifex/handlers/rds/parametergroup.go
+++ b/spinifex/handlers/rds/parametergroup.go
@@ -217,7 +217,7 @@ func (s *Service) propagateParameterGroup(ctx context.Context, kv jetstream.KeyV
 		if !found || rec.DBParameterGroupName != name {
 			continue
 		}
-		if err := s.applyParameterGroup(ctx, kv, accountID, &rec, name, rec.DBInstanceClass); err != nil {
+		if err := s.applyParameterGroup(ctx, kv, accountID, &rec, name, rec.DBInstanceClass, false); err != nil {
 			failures = append(failures, err)
 		}
 	}

--- a/spinifex/handlers/rds/pending.go
+++ b/spinifex/handlers/rds/pending.go
@@ -54,7 +54,10 @@ func (s *Service) applyPendingModifications(ctx context.Context, kv jetstream.Ke
 		if class == "" {
 			class = rec.DBInstanceClass
 		}
-		if err := s.applyParameterGroup(ctx, kv, accountID, rec, group, class); err != nil {
+		// A class change replaces the VM next, and the fresh agent applies the
+		// resolved set itself on boot, so a dead old agent here is tolerated
+		// rather than blocking the one recovery lever a failed instance has.
+		if err := s.applyParameterGroup(ctx, kv, accountID, rec, group, class, pending.DBInstanceClass != ""); err != nil {
 			return err
 		}
 	}
@@ -143,7 +146,7 @@ func (s *Service) applyPendingModifications(ctx context.Context, kv jetstream.Ke
 // A re-resolve, never a merge: the whole set is recomputed from the catalog and
 // the new group's overrides, so a parameter the old group set and the new one
 // does not reverts to its default rather than lingering.
-func (s *Service) applyParameterGroup(ctx context.Context, kv jetstream.KeyValue, accountID string, rec *DBInstanceRecord, group, instanceClass string) error {
+func (s *Service) applyParameterGroup(ctx context.Context, kv jetstream.KeyValue, accountID string, rec *DBInstanceRecord, group, instanceClass string, tolerateUnreachableAgent bool) error {
 	engine, err := LookupEngine(rec.Engine)
 	if err != nil {
 		return err
@@ -157,6 +160,9 @@ func (s *Service) applyParameterGroup(ctx context.Context, kv jetstream.KeyValue
 	}
 	pendingReboot, err := s.applyParameters(ctx, accountID, rec.DBInstanceIdentifier, resolved)
 	if err != nil {
+		if tolerateUnreachableAgent && errors.Is(err, ErrCommandUnreachable) {
+			return s.deferParameterApplyToReplacement(ctx, kv, rec, resolved)
+		}
 		return s.recordParameterApplyFailure(ctx, kv, accountID, rec, group,
 			fmt.Errorf("apply the parameters of %s to %s: %w", group, rec.DBInstanceIdentifier, err))
 	}
@@ -172,6 +178,27 @@ func (s *Service) applyParameterGroup(ctx context.Context, kv jetstream.KeyValue
 	return s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
 		stored.Bootstrap.ResolvedParameters = resolved
 		stored.PendingRebootParameters = pendingReboot
+		stored.ParametersRolledBack = false
+		stored.ParameterApplyFailed = false
+	})
+}
+
+// The replacement's fresh agent applies resolved on boot, so it is persisted
+// here in place of the dead agent's reply, with nothing pending a reboot.
+// Persistence uses a detached ctx: the budget that just found the agent
+// unreachable must not also fail the write that unblocks recovery from it.
+func (s *Service) deferParameterApplyToReplacement(ctx context.Context, kv jetstream.KeyValue, rec *DBInstanceRecord, resolved []Parameter) error {
+	slog.WarnContext(ctx, "rds: the instance agent is unreachable; deferring the parameter apply to the replacement VM's fresh agent",
+		"dbInstance", rec.DBInstanceIdentifier)
+	rec.Bootstrap.ResolvedParameters = resolved
+	rec.PendingRebootParameters = nil
+	rec.ParametersRolledBack = false
+	rec.ParameterApplyFailed = false
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rollbackTimeout)
+	defer cancel()
+	return s.updateInstance(persistCtx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
+		stored.Bootstrap.ResolvedParameters = resolved
+		stored.PendingRebootParameters = nil
 		stored.ParametersRolledBack = false
 		stored.ParameterApplyFailed = false
 	})

--- a/spinifex/handlers/rds/pending_test.go
+++ b/spinifex/handlers/rds/pending_test.go
@@ -443,6 +443,61 @@ func TestApplyPendingModifications_AFailedParameterApplyIsRecordedOnTheInstance(
 	assert.Equal(t, 1, failures)
 }
 
+// A class change is the recovery lever for a failed/agentless instance, so an
+// unreachable old agent must not abort it: the class-correct set lands on the
+// record directly for the replacement's fresh agent to adopt on boot.
+func TestApplyPendingModifications_ClassChangeSurvivesAnUnreachableAgent(t *testing.T) {
+	h := newModifyHarness(t)
+	h.agent.silenceType(CommandApplyParams)
+	rec := modifyingRecord(&PendingModifiedValues{
+		DBInstanceClass: "db.m5.xlarge",
+		RequestedAt:     time.Now().UTC(),
+	})
+	seedReplaceable(t, h, rec)
+
+	require.NoError(t, h.svc.applyPendingModifications(t.Context(), h.kv(t), testAccountID, &rec))
+
+	issued := h.agent.received()
+	require.NotEmpty(t, issued)
+	assert.Equal(t, CommandApplyParams, issued[0].Type, "the apply was attempted against the old agent first")
+
+	stored := h.record(t)
+	assert.Equal(t, "db.m5.xlarge", stored.DBInstanceClass)
+	assert.Equal(t, testReplacementInstance, stored.InstanceID, "the replace ran despite the unreachable agent")
+	assert.False(t, stored.ParameterApplyFailed)
+	assert.Empty(t, stored.PendingRebootParameters)
+
+	memoryMiB, err := classMemoryMiB("db.m5.xlarge")
+	require.NoError(t, err)
+	assert.Equal(t, sharedBuffersFor(memoryMiB), parameterValue(stored.Bootstrap.ResolvedParameters, "shared_buffers"),
+		"the stored set was resolved against the class the instance is becoming, for the replacement to boot on")
+}
+
+// A parameter-group-only change has no replacement VM to defer onto, so an
+// unreachable agent still fails it exactly as before — the class-change
+// tolerance must not leak into the path a live-agent rollback owns.
+func TestApplyPendingModifications_ParameterGroupOnlyStillFailsOnAnUnreachableAgent(t *testing.T) {
+	h := newModifyHarness(t)
+	h.agent.silenceType(CommandApplyParams)
+	rec := modifyingRecord(&PendingModifiedValues{
+		DBParameterGroupName: testDefaultGroup,
+		RequestedAt:          time.Now().UTC(),
+	})
+	seedInstance(t, h.svc, rec)
+
+	err := h.svc.applyPendingModifications(t.Context(), h.kv(t), testAccountID, &rec)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCommandUnreachable)
+	assert.True(t, rec.ParameterApplyFailed, "the caller's copy reports what the store holds")
+
+	stored := h.record(t)
+	assert.True(t, stored.ParameterApplyFailed)
+	require.NotNil(t, stored.PendingModifiedValues, "the modify is still outstanding for the reconciler")
+	groups := projectParameterGroup(&stored)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "failed-to-apply", aws.StringValue(groups[0].ParameterApplyStatus))
+}
+
 func parameterValue(params []Parameter, name string) string {
 	for _, param := range params {
 		if param.Name == name {

--- a/spinifex/handlers/rds/service.go
+++ b/spinifex/handlers/rds/service.go
@@ -64,6 +64,9 @@ type Deps struct {
 	// Overrides how long a stop waits for the fleet to report the VM down.
 	// Zero takes defaultVMStopTimeout.
 	VMStopTimeout time.Duration
+	// Overrides how long an apply-params command waits for the agent to
+	// answer. Zero takes defaultApplyParamsTimeout.
+	ApplyParamsTimeout time.Duration
 	// Override the modify lease lifetime and renewal cadence in tests. A zero
 	// TTL takes the default; a refresh outside (0, TTL) derives as TTL/3.
 	ModifyLeaseTTL     time.Duration
@@ -114,6 +117,13 @@ func (s *Service) vmStopTimeout() time.Duration {
 		return s.deps.VMStopTimeout
 	}
 	return defaultVMStopTimeout
+}
+
+func (s *Service) applyParamsTimeout() time.Duration {
+	if s.deps.ApplyParamsTimeout > 0 {
+		return s.deps.ApplyParamsTimeout
+	}
+	return defaultApplyParamsTimeout
 }
 
 func (s *Service) failureGrace() time.Duration {


### PR DESCRIPTION
## Summary

A class-change `ModifyDBInstance` is the intended recovery path for a failed DB
instance, but `applyPendingModifications` applied the parameter group through
the live instance agent before the class-change replace ran. A dead agent
returned `ErrCommandUnreachable` and aborted the modify before
`replaceInstanceVM` could execute, so the one recovery lever the API offers
could not run for the case that needs it most.

This tolerates `ErrCommandUnreachable` for a class-change modify only: it
resolves the class-correct parameter set (a KV read, no agent involved),
persists it on the record, and defers the actual apply to the replacement
VM's fresh agent, which applies the resolved set itself on boot.
Parameter-group-only modifies (no replacement VM to defer onto) still fail on
a dead agent exactly as before.

Adds `Deps.ApplyParamsTimeout` so tests exercising an unreachable agent don't
have to wait out the real 120s command budget.

## Context

This was one of three sibling commits on `feat/rds-recover-agentless`. The
other two already landed on `dev` via #813; this one was left behind and had
no open PR. It is the missing third.

## Test plan

- [x] `go build ./spinifex/...`
- [x] `go test ./spinifex/handlers/rds/...` — passing, 85.4% package coverage
- [x] `golangci-lint run ./spinifex/handlers/rds/...` — 0 issues
- [x] Diff-coverage check (`scripts/diff-coverage.sh`) — diff under 100 changed lines, auto-skipped by the script's own threshold