### PR TITLE
fix: give LB microVM initramfs headroom by bumping sys.micro to 256 MiB

### DIFF
--- a/scripts/build-microvm-image.sh
+++ b/scripts/build-microvm-image.sh
@@ -334,5 +334,22 @@ if [ "$total_bytes" -gt "$max_bytes" ]; then
     exit 1
 fi
 echo "[build-microvm-image] artifact size gate: PASS (${total_mib} MiB / ${ARTIFACT_MAX_MiB} MiB)"
+
+# --- Guest-RAM initramfs gate (uncompressed) ---
+# The kernel unpacks the whole initramfs into RAM before init, so the
+# UNCOMPRESSED size — not the gzip artifact — sets the sys.micro memory floor.
+# Over budget => "Initramfs unpacking failed" panic before userspace.
+UNCOMPRESSED_MAX_MiB="${MICROVM_INITRAMFS_UNCOMPRESSED_MAX_MiB:-96}"
+uncompressed_bytes=$(zcat "$INITRAMFS_OUT" | wc -c)
+uncompressed_mib=$(( (uncompressed_bytes + 1048575) / 1048576 ))
+umax_bytes=$(( UNCOMPRESSED_MAX_MiB * 1024 * 1024 ))
+if [ "$uncompressed_bytes" -gt "$umax_bytes" ]; then
+    echo "ERROR: uncompressed initramfs ${uncompressed_mib} MiB exceeds ${UNCOMPRESSED_MAX_MiB} MiB guest-RAM gate" >&2
+    echo "       The LB microVM unpacks this into its 256 MiB guest RAM; a larger" >&2
+    echo "       footprint panics the kernel before init. Slim the initramfs, or raise" >&2
+    echo "       sys.micro memory AND MICROVM_INITRAMFS_UNCOMPRESSED_MAX_MiB together." >&2
+    exit 1
+fi
+echo "[build-microvm-image] initramfs guest-RAM gate: PASS (${uncompressed_mib} MiB / ${UNCOMPRESSED_MAX_MiB} MiB uncompressed)"
 echo ""
 echo "[build-microvm-image] done."

--- a/spinifex/instancetypes/definitions.go
+++ b/spinifex/instancetypes/definitions.go
@@ -310,8 +310,8 @@ var p5eSizes = []instanceSize{
 // systemSizes defines internal-only instance types for system VMs (LB, NAT GW, etc.).
 // These are registered in the type map for allocation but excluded from DescribeInstanceTypes.
 var systemSizes = []instanceSize{
-	{"micro", 1, 0.125}, // 1 vCPU, 128 MB — ELBv2 LB microVMs
-	{"medium", 2, 4},    // 2 vCPU, 4 GB — EKS k3s control-plane VMs
+	{"micro", 1, 0.25}, // 1 vCPU, 256 MB — ELBv2 LB microVMs (initramfs unpack headroom)
+	{"medium", 2, 4},   // 2 vCPU, 4 GB — EKS k3s control-plane VMs
 }
 
 // instanceFamilyDefs lists all supported instance families. Excluded families require

--- a/spinifex/instancetypes/generate_test.go
+++ b/spinifex/instancetypes/generate_test.go
@@ -82,7 +82,7 @@ func TestGenerateSystemTypes(t *testing.T) {
 	sysMicro, ok := types["sys.micro"]
 	require.True(t, ok, "sys.micro must exist")
 	assert.Equal(t, int64(1), *sysMicro.VCpuInfo.DefaultVCpus, "sys.micro should have 1 vCPU")
-	assert.Equal(t, int64(128), *sysMicro.MemoryInfo.SizeInMiB, "sys.micro should have 128 MiB")
+	assert.Equal(t, int64(256), *sysMicro.MemoryInfo.SizeInMiB, "sys.micro should have 256 MiB")
 	assert.False(t, *sysMicro.BurstablePerformanceSupported, "sys.micro should not be burstable")
 
 	sysMedium, ok := types["sys.medium"]


### PR DESCRIPTION
## Problem

Every ELBv2 load-balancer microVM kernel-panics before userspace. `sys.micro` boots with `-m 128`; after kernel reservations ~75 MiB is usable, but the initramfs unpacks to 37.7 MiB with the Go 1.27 `lb-agent` (16.9 MiB, 45% of the archive) leaving <512 KiB of headroom. Go 1.27 grew the static `lb-agent` by +348 KiB, which crossed the line. The guest dies with `Initramfs unpacking failed: write error` / `Kernel panic - not syncing: No working init found`, so `lb-agent` never heartbeats and every target stays stuck in `initial`.

The build gate only measured the **compressed** artifact (~15 MiB, always PASS) — blind to the **uncompressed** footprint the kernel must hold in RAM while unpacking the cpio, which is the real constraint.

## Fix

- Bump `sys.micro` to 256 MiB (`{"micro", 1, 0.25}`). LB memory derives from the instance type via `buildDirectBootConfig`, so the 37.7 MiB initramfs now unpacks with ample margin.
- Add an **uncompressed** initramfs gate to `build-microvm-image.sh` (`MICROVM_INITRAMFS_UNCOMPRESSED_MAX_MiB`, default 96) that fails the build loudly when the uncompressed footprint would outgrow the guest-RAM budget — so a future binary bump breaks the build, not production.
- Update `TestGenerateSystemTypes` to assert 256 MiB.

## Testing

- `make preflight` passes.
- `go test ./spinifex/instancetypes/...` green.
- Live: redeploy wattle and confirm the ALB appliance boots (no initramfs panic), the target leaves `initial`, and the demo chat routes.

Closes mulga-hkymb.