### PR TITLE
refactor(ui): validate route search params with zod schemas

### DIFF
--- a/spinifex/services/spinifexui/frontend/src/routes/_auth/ec2/(instances)/run-instances.tsx
+++ b/spinifex/services/spinifexui/frontend/src/routes/_auth/ec2/(instances)/run-instances.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import {
   ec2ImagesQueryOptions,
@@ -13,19 +14,15 @@ import {
 
 import { RunInstancesPage } from "./-components/run-instances-page"
 
+/* oxlint-disable promise/prefer-await-to-then, unicorn/no-useless-undefined -- zod's .catch() supplies a schema fallback, not a promise handler */
+const searchSchema = z.object({
+  launchTemplateId: z.string().optional().catch(undefined),
+  launchTemplateVersion: z.string().optional().catch(undefined),
+})
+/* oxlint-enable promise/prefer-await-to-then, unicorn/no-useless-undefined */
+
 export const Route = createFileRoute("/_auth/ec2/(instances)/run-instances")({
-  validateSearch: (
-    search: Record<string, unknown>,
-  ): { launchTemplateId?: string; launchTemplateVersion?: string } => ({
-    launchTemplateId:
-      typeof search.launchTemplateId === "string"
-        ? search.launchTemplateId
-        : undefined,
-    launchTemplateVersion:
-      typeof search.launchTemplateVersion === "string"
-        ? search.launchTemplateVersion
-        : undefined,
-  }),
+  validateSearch: searchSchema,
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(ec2ImagesQueryOptions),

--- a/spinifex/services/spinifexui/frontend/src/routes/_auth/ec2/(snapshots)/create-snapshot.tsx
+++ b/spinifex/services/spinifexui/frontend/src/routes/_auth/ec2/(snapshots)/create-snapshot.tsx
@@ -1,11 +1,8 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useSuspenseQuery } from "@tanstack/react-query"
-import {
-  createFileRoute,
-  type SearchSchemaInput,
-  useNavigate,
-} from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Controller, useForm, useWatch } from "react-hook-form"
+import { z } from "zod"
 
 import { BackLink } from "@/components/back-link"
 import {
@@ -28,10 +25,14 @@ import { useCreateSnapshot } from "@/mutations/ec2"
 import { ec2VolumesQueryOptions } from "@/queries/ec2"
 import { type CreateSnapshotFormData, createSnapshotSchema } from "@/types/ec2"
 
+/* oxlint-disable promise/prefer-await-to-then, unicorn/no-useless-undefined -- zod's .catch() supplies a schema fallback, not a promise handler */
+const searchSchema = z.object({
+  volumeId: z.string().optional().catch(undefined),
+})
+/* oxlint-enable promise/prefer-await-to-then, unicorn/no-useless-undefined */
+
 export const Route = createFileRoute("/_auth/ec2/(snapshots)/create-snapshot")({
-  validateSearch: (search: { volumeId?: string } & SearchSchemaInput) => ({
-    volumeId: typeof search.volumeId === "string" ? search.volumeId : undefined,
-  }),
+  validateSearch: searchSchema,
   loader: async ({ context }) => {
     await context.queryClient.ensureQueryData(ec2VolumesQueryOptions)
   },

--- a/spinifex/services/spinifexui/frontend/src/routes/_auth/ecs/(clusters)/create-service.tsx
+++ b/spinifex/services/spinifexui/frontend/src/routes/_auth/ecs/(clusters)/create-service.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, type SearchSchemaInput } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import {
   ec2SecurityGroupsQueryOptions,
@@ -9,14 +10,12 @@ import { elbv2TargetGroupsQueryOptions } from "@/queries/elbv2"
 
 import { CreateServicePage } from "./-components/create-service-page"
 
-interface CreateServiceSearch {
-  cluster: string
-}
+/* oxlint-disable promise/prefer-await-to-then -- zod's .catch() supplies a schema fallback, not a promise handler */
+const searchSchema = z.object({ cluster: z.string().catch("") })
+/* oxlint-enable promise/prefer-await-to-then */
 
 export const Route = createFileRoute("/_auth/ecs/(clusters)/create-service")({
-  validateSearch: (search: CreateServiceSearch & SearchSchemaInput) => ({
-    cluster: typeof search.cluster === "string" ? search.cluster : "",
-  }),
+  validateSearch: searchSchema,
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(ecsTaskDefinitionsQueryOptions),

--- a/spinifex/services/spinifexui/frontend/src/routes/_auth/ecs/(clusters)/register-task-definition.tsx
+++ b/spinifex/services/spinifexui/frontend/src/routes/_auth/ecs/(clusters)/register-task-definition.tsx
@@ -1,17 +1,16 @@
-import { createFileRoute, type SearchSchemaInput } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import { RegisterTaskDefinitionPage } from "./-components/register-task-definition-page"
 
-interface RegisterSearch {
-  cluster: string
-}
+/* oxlint-disable promise/prefer-await-to-then -- zod's .catch() supplies a schema fallback, not a promise handler */
+const searchSchema = z.object({ cluster: z.string().catch("") })
+/* oxlint-enable promise/prefer-await-to-then */
 
 export const Route = createFileRoute(
   "/_auth/ecs/(clusters)/register-task-definition",
 )({
-  validateSearch: (search: RegisterSearch & SearchSchemaInput) => ({
-    cluster: typeof search.cluster === "string" ? search.cluster : "",
-  }),
+  validateSearch: searchSchema,
   head: () => ({
     meta: [{ title: "Register Task Definition | ECS | Mulga" }],
   }),

--- a/spinifex/services/spinifexui/frontend/src/routes/_auth/ecs/(clusters)/run-task.tsx
+++ b/spinifex/services/spinifexui/frontend/src/routes/_auth/ecs/(clusters)/run-task.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, type SearchSchemaInput } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import {
   ec2SecurityGroupsQueryOptions,
@@ -8,14 +9,12 @@ import { ecsTaskDefinitionsQueryOptions } from "@/queries/ecs"
 
 import { RunTaskPage } from "./-components/run-task-page"
 
-interface RunTaskSearch {
-  cluster: string
-}
+/* oxlint-disable promise/prefer-await-to-then -- zod's .catch() supplies a schema fallback, not a promise handler */
+const searchSchema = z.object({ cluster: z.string().catch("") })
+/* oxlint-enable promise/prefer-await-to-then */
 
 export const Route = createFileRoute("/_auth/ecs/(clusters)/run-task")({
-  validateSearch: (search: RunTaskSearch & SearchSchemaInput) => ({
-    cluster: typeof search.cluster === "string" ? search.cluster : "",
-  }),
+  validateSearch: searchSchema,
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(ecsTaskDefinitionsQueryOptions),

--- a/spinifex/services/spinifexui/frontend/src/routes/login.tsx
+++ b/spinifex/services/spinifexui/frontend/src/routes/login.tsx
@@ -1,11 +1,8 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import {
-  createFileRoute,
-  redirect,
-  type SearchSchemaInput,
-} from "@tanstack/react-router"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
+import { z } from "zod"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -37,10 +34,16 @@ import { clearClients } from "@/lib/awsClient"
 import { isDirectHostAccess } from "@/lib/host-access"
 import { exchangeForSession } from "@/lib/sts"
 
+// Any reason other than the one the session-expiry redirect sends is dropped,
+// so a hand-typed value cannot put copy on the login page.
+/* oxlint-disable promise/prefer-await-to-then, unicorn/no-useless-undefined -- zod's .catch() supplies a schema fallback, not a promise handler */
+const searchSchema = z.object({
+  reason: z.literal("expired").optional().catch(undefined),
+})
+/* oxlint-enable promise/prefer-await-to-then, unicorn/no-useless-undefined */
+
 export const Route = createFileRoute("/login")({
-  validateSearch: (search: { reason?: string } & SearchSchemaInput) => ({
-    reason: search.reason === "expired" ? ("expired" as const) : undefined,
-  }),
+  validateSearch: searchSchema,
   beforeLoad: () => {
     if (getCredentials()) {
       throw redirect({ to: "/" })


### PR DESCRIPTION
## Summary

Replaces the six hand-written `validateSearch` functions with zod schemas, which is the form the [TanStack Router guide](https://tanstack.com/router/latest/docs/how-to/validate-search-params) recommends. Each schema now states the param shape once, instead of splitting it between a `SearchSchemaInput` annotation and a body of `typeof` checks that had to agree with it by hand.

## Behaviour

Unchanged. Fallbacks use zod v4's `.catch()`, so an unexpected value coerces to the same default it did before rather than raising and hitting an error boundary. The `fallback()` helper shown in parts of the router docs is the zod v3 path and needs `@tanstack/zod-adapter`; this repo is on zod 4.4.3, where `.catch()` is the documented equivalent.

## Files

- `src/routes/login.tsx`
- `src/routes/_auth/ec2/(instances)/run-instances.tsx`
- `src/routes/_auth/ec2/(snapshots)/create-snapshot.tsx`
- `src/routes/_auth/ecs/(clusters)/create-service.tsx`
- `src/routes/_auth/ecs/(clusters)/register-task-definition.tsx`
- `src/routes/_auth/ecs/(clusters)/run-task.tsx`

## Note for review

oxlint's promise plugin reads any `.catch(` member call as a promise handler, so each schema carries a scoped `oxlint-disable` naming that reason. If we would rather not have those, the alternative is a local `fallback(schema, value)` wrapper that confines the suppression to one helper.

## Testing

`tsc --noEmit` clean, `pnpm lint` clean.