### PR TITLE
fix: scope EKS policy checks to real resource ARNs

### DIFF
--- a/spinifex/arn/eks.go
+++ b/spinifex/arn/eks.go
@@ -1,0 +1,43 @@
+package arn
+
+import "fmt"
+
+// EKSResourceType is the resource-type segment of an arn:aws:eks ARN.
+type EKSResourceType string
+
+const (
+	EKSCluster     EKSResourceType = "cluster"
+	EKSNodegroup   EKSResourceType = "nodegroup"
+	EKSAddon       EKSResourceType = "addon"
+	EKSAccessEntry EKSResourceType = "access-entry"
+)
+
+// FormatEKSCluster builds arn:aws:eks:<region>:<account>:cluster/<name>.
+func FormatEKSCluster(region, accountID, name string) string {
+	return fmt.Sprintf("arn:aws:eks:%s:%s:%s/%s", region, accountID, EKSCluster, name)
+}
+
+// FormatEKSNodegroup builds the AWS nodegroup shape,
+// arn:aws:eks:<region>:<account>:nodegroup/<cluster>/<name>/<discriminator>.
+// The discriminator is the per-nodegroup UUID AWS appends.
+func FormatEKSNodegroup(region, accountID, cluster, name, discriminator string) string {
+	return fmt.Sprintf("arn:aws:eks:%s:%s:%s/%s/%s/%s", region, accountID, EKSNodegroup, cluster, name, discriminator)
+}
+
+// FormatEKSAddon builds arn:aws:eks:<region>:<account>:addon/<cluster>/<name>.
+func FormatEKSAddon(region, accountID, cluster, name string) string {
+	return fmt.Sprintf("arn:aws:eks:%s:%s:%s/%s/%s", region, accountID, EKSAddon, cluster, name)
+}
+
+// FormatEKSAccessEntry builds
+// arn:aws:eks:<region>:<account>:access-entry/<cluster>/<discriminator>.
+// The discriminator identifies the entry's principal; callers compute it.
+func FormatEKSAccessEntry(region, accountID, cluster, discriminator string) string {
+	return fmt.Sprintf("arn:aws:eks:%s:%s:%s/%s/%s", region, accountID, EKSAccessEntry, cluster, discriminator)
+}
+
+// FormatEKSResource builds an EKS ARN from an already-formed resource
+// component, such as one parsed off a caller-supplied ARN.
+func FormatEKSResource(region, accountID, resource string) string {
+	return fmt.Sprintf("arn:aws:eks:%s:%s:%s", region, accountID, resource)
+}

--- a/spinifex/arn/eks_test.go
+++ b/spinifex/arn/eks_test.go
@@ -1,0 +1,33 @@
+package arn_test
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/arn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatEKS(t *testing.T) {
+	const (
+		region  = "ap-southeast-2"
+		account = "123456789012"
+	)
+
+	assert.Equal(t, "arn:aws:eks:ap-southeast-2:123456789012:cluster/prod",
+		arn.FormatEKSCluster(region, account, "prod"))
+	assert.Equal(t, "arn:aws:eks:ap-southeast-2:123456789012:nodegroup/prod/workers/abc-123",
+		arn.FormatEKSNodegroup(region, account, "prod", "workers", "abc-123"))
+	assert.Equal(t, "arn:aws:eks:ap-southeast-2:123456789012:addon/prod/coredns",
+		arn.FormatEKSAddon(region, account, "prod", "coredns"))
+	assert.Equal(t, "arn:aws:eks:ap-southeast-2:123456789012:access-entry/prod/9f86d081",
+		arn.FormatEKSAccessEntry(region, account, "prod", "9f86d081"))
+	assert.Equal(t, "arn:aws:eks:ap-southeast-2:123456789012:cluster/prod",
+		arn.FormatEKSResource(region, account, "cluster/prod"))
+}
+
+// A name that needs percent-decoding in a URL path is placed in the ARN
+// decoded: the gate must name the object the handler acts on.
+func TestFormatEKSPreservesDecodedNames(t *testing.T) {
+	assert.Equal(t, "arn:aws:eks:us-east-1:123456789012:cluster/my cluster",
+		arn.FormatEKSCluster("us-east-1", "123456789012", "my cluster"))
+}

--- a/spinifex/gateway/eks.go
+++ b/spinifex/gateway/eks.go
@@ -255,18 +255,15 @@ func (gw *GatewayConfig) EKS_Request(w http.ResponseWriter, r *http.Request) err
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "eks", action); err != nil {
-		return err
-	}
-
-	if gw.NATSConn == nil {
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-
+	// Hoisted above the policy check because the resolver builds ARNs from it.
+	// gw.Region, never the caller-supplied credential-scope region, which would
+	// let a caller sign for another region and slide out from under a Deny.
 	accountID, _ := r.Context().Value(ctxAccountID).(string)
 	if accountID == "" {
 		slog.ErrorContext(r.Context(), "EKS_Request: no account ID in auth context")
-		return errors.New(awserrors.ErrorServerInternal)
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
 	}
 
 	body, err := io.ReadAll(r.Body)
@@ -287,6 +284,20 @@ func (gw *GatewayConfig) EKS_Request(w http.ResponseWriter, r *http.Request) err
 				body = qb
 			}
 		}
+	}
+
+	// After the body read: CreateCluster and the other create actions name their
+	// resource there rather than in the path.
+	resources, err := gateway_eks.ResourceARNs(action, gw.Region, accountID, params, body)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "eks", action, resources); err != nil {
+		return err
+	}
+
+	if gw.NATSConn == nil {
+		return errors.New(awserrors.ErrorServerInternal)
 	}
 
 	// Best-effort caller ARN; only CreateCluster consumes it, degrades to "".

--- a/spinifex/gateway/eks/authz.go
+++ b/spinifex/gateway/eks/authz.go
@@ -1,0 +1,305 @@
+package gateway_eks
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/mulgadc/spinifex/spinifex/arn"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+)
+
+// The resource a policy check evaluates against when the request names nothing
+// in particular, or when the identifier cannot be resolved at gate time.
+const anyResource = "*"
+
+// A nodegroup ARN ends in a UUID the gate cannot see without a describe round
+// trip, and (cluster, name) already identifies the nodegroup here. The literal
+// "*" is a value, so it matches the AWS-documented spelling without widening.
+const anyDiscriminator = "*"
+
+// Where an action's resource is named. Path parameters come from the route
+// regex; body sources are read from the same JSON the handler unmarshals.
+type resourceSource uint8
+
+const (
+	sourceAny resourceSource = iota
+	sourceCluster
+	sourceClusterFromBody
+	sourceInternalCluster
+	sourceNodegroup
+	sourceNodegroupFromBody
+	sourceAddon
+	sourceAddonFromBody
+	sourceAccessEntry
+	sourceAccessEntryFromBody
+	sourceTagARN
+)
+
+// Every action EKS_Request serves, with the resources AWS evaluates it against.
+// Exhaustive by contract: a completeness test compares this table with the
+// dispatch table in both directions.
+var eksScopes = map[string][]resourceSource{
+	// Cluster.
+	"CreateCluster":        {sourceClusterFromBody},
+	"DescribeCluster":      {sourceCluster},
+	"DeleteCluster":        {sourceCluster},
+	"UpdateClusterConfig":  {sourceCluster},
+	"UpdateClusterVersion": {sourceCluster},
+	"ListClusters":         {sourceAny},
+
+	// Internal control-plane routes. The cluster's owning account is a path
+	// segment on these two, and the ARN names that account rather than the
+	// system caller's, because that is the account the handler reads.
+	"ListInternalAddons":   {sourceInternalCluster},
+	"GetRecoveryDirective": {sourceInternalCluster},
+	// The owning account arrives in the body, which the handler parses.
+	"PublishInternal":    {sourceAny},
+	"WebhookTokenReview": {sourceAny},
+
+	// Nodegroups. Create evaluates the cluster and the nodegroup it is about
+	// to create, matching AWS.
+	"CreateNodegroup":        {sourceCluster, sourceNodegroupFromBody},
+	"DescribeNodegroup":      {sourceNodegroup},
+	"DeleteNodegroup":        {sourceNodegroup},
+	"UpdateNodegroupConfig":  {sourceNodegroup},
+	"UpdateNodegroupVersion": {sourceNodegroup},
+	"ListNodegroups":         {sourceCluster},
+
+	// Access entries and policies.
+	"CreateAccessEntry":            {sourceCluster, sourceAccessEntryFromBody},
+	"DescribeAccessEntry":          {sourceAccessEntry},
+	"UpdateAccessEntry":            {sourceAccessEntry},
+	"DeleteAccessEntry":            {sourceAccessEntry},
+	"ListAccessEntries":            {sourceCluster},
+	"AssociateAccessPolicy":        {sourceAccessEntry},
+	"DisassociateAccessPolicy":     {sourceAccessEntry},
+	"ListAssociatedAccessPolicies": {sourceAccessEntry},
+	// The AWS-managed policy catalogue is not an account resource.
+	"ListAccessPolicies": {sourceAny},
+
+	// Add-ons.
+	"CreateAddon":   {sourceCluster, sourceAddonFromBody},
+	"DescribeAddon": {sourceAddon},
+	"UpdateAddon":   {sourceAddon},
+	"DeleteAddon":   {sourceAddon},
+	"ListAddons":    {sourceCluster},
+	// The add-on version catalogue is not an account resource.
+	"DescribeAddonVersions": {sourceAny},
+
+	// Identity-provider configs. All four handlers are stubs and no
+	// identity-provider-config object exists here, so the cluster is the only
+	// resource these name.
+	"AssociateIdentityProviderConfig":    {sourceCluster},
+	"DescribeIdentityProviderConfig":     {sourceCluster},
+	"DisassociateIdentityProviderConfig": {sourceCluster},
+	"ListIdentityProviderConfigs":        {sourceCluster},
+
+	// Tags.
+	"TagResource":         {sourceTagARN},
+	"UntagResource":       {sourceTagARN},
+	"ListTagsForResource": {sourceTagARN},
+}
+
+// HasScope reports whether action has an explicit EKS scope-table entry.
+func HasScope(action string) bool {
+	_, ok := eksScopes[action]
+	return ok
+}
+
+// ScopedActions returns every action represented in the EKS scope table.
+func ScopedActions() []string {
+	actions := make([]string, 0, len(eksScopes))
+	for action := range eksScopes {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+	return actions
+}
+
+// ResourceARNs resolves the resources an EKS request authorizes against from
+// the path parameters and body the dispatcher already holds. params are the
+// route captures, already percent-decoded.
+func ResourceARNs(action, region, accountID string, params []string, body []byte) ([]string, error) {
+	sources, ok := eksScopes[action]
+	if !ok {
+		slog.Error("EKS authz: action is served but absent from the scope table", "action", action)
+		return nil, errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	resources := make([]string, 0, len(sources))
+	for _, source := range sources {
+		resource, err := resolve(source, action, region, accountID, params, body)
+		if err != nil {
+			return nil, err
+		}
+		// An unresolved member drops out rather than contributing "*", which no
+		// scoped Allow can match and which would deny a call AWS permits.
+		if resource == anyResource || slices.Contains(resources, resource) {
+			continue
+		}
+		resources = append(resources, resource)
+	}
+	if len(resources) == 0 {
+		return []string{anyResource}, nil
+	}
+	return resources, nil
+}
+
+func resolve(source resourceSource, action, region, accountID string, params []string, body []byte) (string, error) {
+	switch source {
+	case sourceAny:
+		return anyResource, nil
+
+	case sourceCluster:
+		return clusterARN(region, accountID, param(params, 0)), nil
+
+	case sourceClusterFromBody:
+		input := new(eks.CreateClusterInput)
+		if !unmarshalScope(action, body, input) {
+			return anyResource, nil
+		}
+		return clusterARN(region, accountID, aws.StringValue(input.Name)), nil
+
+	case sourceInternalCluster:
+		return clusterARN(region, param(params, 1), param(params, 0)), nil
+
+	case sourceNodegroup:
+		return nodegroupARN(region, accountID, param(params, 0), param(params, 1)), nil
+
+	case sourceNodegroupFromBody:
+		input := new(eks.CreateNodegroupInput)
+		if !unmarshalScope(action, body, input) {
+			return anyResource, nil
+		}
+		return nodegroupARN(region, accountID, param(params, 0), aws.StringValue(input.NodegroupName)), nil
+
+	case sourceAddon:
+		return addonARN(region, accountID, param(params, 0), param(params, 1)), nil
+
+	case sourceAddonFromBody:
+		input := new(eks.CreateAddonInput)
+		if !unmarshalScope(action, body, input) {
+			return anyResource, nil
+		}
+		return addonARN(region, accountID, param(params, 0), aws.StringValue(input.AddonName)), nil
+
+	case sourceAccessEntry:
+		return accessEntryARN(region, accountID, param(params, 0), param(params, 1)), nil
+
+	case sourceAccessEntryFromBody:
+		input := new(eks.CreateAccessEntryInput)
+		if !unmarshalScope(action, body, input) {
+			return anyResource, nil
+		}
+		return accessEntryARN(region, accountID, param(params, 0), aws.StringValue(input.PrincipalArn)), nil
+
+	case sourceTagARN:
+		return tagARN(region, accountID, param(params, 0)), nil
+
+	default:
+		slog.Error("EKS authz: unhandled resource source, failing closed", "action", action, "source", source)
+		return "", errors.New(awserrors.ErrorInternalError)
+	}
+}
+
+// An absent identifier authorizes account-wide, so a malformed request stays
+// the handler's validation fault rather than becoming an authorization failure.
+func clusterARN(region, accountID, cluster string) string {
+	if region == "" || accountID == "" || cluster == "" {
+		return anyResource
+	}
+	return arn.FormatEKSCluster(region, accountID, cluster)
+}
+
+func nodegroupARN(region, accountID, cluster, nodegroup string) string {
+	if region == "" || accountID == "" || cluster == "" || nodegroup == "" {
+		return anyResource
+	}
+	return arn.FormatEKSNodegroup(region, accountID, cluster, nodegroup, anyDiscriminator)
+}
+
+func addonARN(region, accountID, cluster, addon string) string {
+	if region == "" || accountID == "" || cluster == "" || addon == "" {
+		return anyResource
+	}
+	return arn.FormatEKSAddon(region, accountID, cluster, addon)
+}
+
+func accessEntryARN(region, accountID, cluster, principalARN string) string {
+	if region == "" || accountID == "" || cluster == "" || principalARN == "" {
+		return anyResource
+	}
+	return arn.FormatEKSAccessEntry(region, accountID, cluster, handlers_eks.PrincipalARNHash(principalARN))
+}
+
+// tagARN re-anchors the caller-supplied resource ARN on gw.Region and the
+// caller's account, because the tag handler ignores those segments and operates
+// in the caller's own account bucket. A nodegroup's UUID is dropped for the
+// same reason: the handler keys off (cluster, nodegroup) alone.
+func tagARN(region, accountID, resourceARN string) string {
+	kind, resource, ok := splitEKSARN(resourceARN)
+	if !ok || region == "" || accountID == "" {
+		return anyResource
+	}
+	switch kind {
+	case arn.EKSCluster:
+		return clusterARN(region, accountID, resource)
+	case arn.EKSNodegroup:
+		segments := strings.SplitN(resource, "/", 3)
+		if len(segments) < 2 {
+			return anyResource
+		}
+		return nodegroupARN(region, accountID, segments[0], segments[1])
+	default:
+		return arn.FormatEKSResource(region, accountID, string(kind)+"/"+resource)
+	}
+}
+
+// splitEKSARN reports the resource type and the component after it, using the
+// same shape rules the tag handler applies. An ARN it does not recognise
+// resolves to "*" so the NotImplemented response stays the handler's.
+func splitEKSARN(resourceARN string) (arn.EKSResourceType, string, bool) {
+	parts := strings.SplitN(resourceARN, ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[2] != "eks" {
+		return "", "", false
+	}
+	rawKind, resource, found := strings.Cut(parts[5], "/")
+	if !found || resource == "" {
+		return "", "", false
+	}
+	kind := arn.EKSResourceType(rawKind)
+	switch kind {
+	case arn.EKSCluster, arn.EKSNodegroup, arn.EKSAddon, arn.EKSAccessEntry:
+		return kind, resource, true
+	default:
+		return "", "", false
+	}
+}
+
+// unmarshalScope reads the identifier-bearing fields of a request body. A body
+// the gate cannot parse authorizes account-wide and leaves the rejection to the
+// handler, which unmarshals the same bytes.
+func unmarshalScope(action string, body []byte, input any) bool {
+	if len(body) == 0 {
+		return false
+	}
+	if err := json.Unmarshal(body, input); err != nil {
+		slog.Debug("EKS authz: body does not parse, authorizing account-wide", "action", action, "err", err)
+		return false
+	}
+	return true
+}
+
+func param(params []string, i int) string {
+	if i >= len(params) {
+		return ""
+	}
+	return params[i]
+}

--- a/spinifex/gateway/eks/authz_test.go
+++ b/spinifex/gateway/eks/authz_test.go
@@ -1,0 +1,202 @@
+package gateway_eks
+
+import (
+	"testing"
+
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	authzRegion    = "ap-southeast-2"
+	authzAccountID = "123456789012"
+)
+
+func resolveARNs(t *testing.T, action string, params []string, body string) []string {
+	t.Helper()
+	resources, err := ResourceARNs(action, authzRegion, authzAccountID, params, []byte(body))
+	require.NoError(t, err)
+	return resources
+}
+
+// One assertion per resource class: the ARN handed to the evaluator must name
+// the object the handler acts on, not a plausible-looking neighbour.
+func TestResourceARNsFidelity(t *testing.T) {
+	tests := []struct {
+		action string
+		params []string
+		body   string
+		want   []string
+	}{
+		{
+			action: "DescribeCluster",
+			params: []string{"prod"},
+			want:   []string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod"},
+		},
+		{
+			action: "CreateCluster",
+			body:   `{"name":"prod","version":"1.31"}`,
+			want:   []string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod"},
+		},
+		{
+			action: "DeleteNodegroup",
+			params: []string{"prod", "workers"},
+			want:   []string{"arn:aws:eks:ap-southeast-2:123456789012:nodegroup/prod/workers/*"},
+		},
+		{
+			action: "CreateNodegroup",
+			params: []string{"prod"},
+			body:   `{"nodegroupName":"workers"}`,
+			want: []string{
+				"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod",
+				"arn:aws:eks:ap-southeast-2:123456789012:nodegroup/prod/workers/*",
+			},
+		},
+		{
+			action: "DescribeAddon",
+			params: []string{"prod", "coredns"},
+			want:   []string{"arn:aws:eks:ap-southeast-2:123456789012:addon/prod/coredns"},
+		},
+		{
+			action: "CreateAddon",
+			params: []string{"prod"},
+			body:   `{"addonName":"coredns"}`,
+			want: []string{
+				"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod",
+				"arn:aws:eks:ap-southeast-2:123456789012:addon/prod/coredns",
+			},
+		},
+		{
+			action: "ListAddons",
+			params: []string{"prod"},
+			want:   []string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod"},
+		},
+		{
+			action: "ListClusters",
+			want:   []string{"*"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.action, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveARNs(t, tc.action, tc.params, tc.body))
+		})
+	}
+}
+
+// The access-entry discriminator must be the one the handler persists, or a
+// Deny naming the entry fences an ARN no object ever carries.
+func TestResourceARNsAccessEntryMatchesHandler(t *testing.T) {
+	const principal = "arn:aws:iam::123456789012:role/app/admin"
+	want := handlers_eks.PrincipalARNHash(principal)
+
+	resources := resolveARNs(t, "DeleteAccessEntry", []string{"prod", principal}, "")
+	assert.Equal(t,
+		[]string{"arn:aws:eks:ap-southeast-2:123456789012:access-entry/prod/" + want},
+		resources)
+
+	// CreateAccessEntry names the entry from the body and the cluster it lands in.
+	resources = resolveARNs(t, "CreateAccessEntry", []string{"prod"},
+		`{"principalArn":"`+principal+`"}`)
+	assert.Equal(t, []string{
+		"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod",
+		"arn:aws:eks:ap-southeast-2:123456789012:access-entry/prod/" + want,
+	}, resources)
+}
+
+// Route captures arrive percent-decoded, so the ARN carries the decoded name
+// the handler receives rather than the wire spelling.
+func TestResourceARNsUsesDecodedPathParams(t *testing.T) {
+	assert.Equal(t,
+		[]string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/my cluster"},
+		resolveARNs(t, "DescribeCluster", []string{"my cluster"}, ""))
+}
+
+// The tag handler ignores the ARN's own region and account and works in the
+// caller's bucket, so the gate must authorize the caller's account too.
+func TestResourceARNsTagARNIsReanchored(t *testing.T) {
+	tests := []struct {
+		name        string
+		resourceARN string
+		want        []string
+	}{
+		{
+			name:        "cluster",
+			resourceARN: "arn:aws:eks:ap-southeast-2:123456789012:cluster/prod",
+			want:        []string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod"},
+		},
+		{
+			name:        "foreign account is evaluated under the caller",
+			resourceARN: "arn:aws:eks:us-east-1:999999999999:cluster/prod",
+			want:        []string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod"},
+		},
+		{
+			name:        "nodegroup uuid is dropped, as the handler drops it",
+			resourceARN: "arn:aws:eks:ap-southeast-2:123456789012:nodegroup/prod/workers/8ac0f0b1",
+			want:        []string{"arn:aws:eks:ap-southeast-2:123456789012:nodegroup/prod/workers/*"},
+		},
+		{
+			name:        "addon",
+			resourceARN: "arn:aws:eks:ap-southeast-2:123456789012:addon/prod/coredns",
+			want:        []string{"arn:aws:eks:ap-southeast-2:123456789012:addon/prod/coredns"},
+		},
+		{
+			name:        "ARN the handler does not serve stays its own fault",
+			resourceARN: "arn:aws:ec2:ap-southeast-2:123456789012:instance/i-abc",
+			want:        []string{"*"},
+		},
+		{
+			name:        "malformed ARN",
+			resourceARN: "not-an-arn",
+			want:        []string{"*"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveARNs(t, "TagResource", []string{tc.resourceARN}, ""))
+		})
+	}
+}
+
+// The internal control-plane routes carry the cluster's owning account in the
+// path, and that is the account whose records the handler reads.
+func TestResourceARNsInternalRoutesUsePathAccount(t *testing.T) {
+	assert.Equal(t,
+		[]string{"arn:aws:eks:ap-southeast-2:999999999999:cluster/prod"},
+		resolveARNs(t, "ListInternalAddons", []string{"prod", "999999999999"}, ""))
+
+	assert.Equal(t,
+		[]string{"arn:aws:eks:ap-southeast-2:999999999999:cluster/prod"},
+		resolveARNs(t, "GetRecoveryDirective", []string{"prod", "999999999999", "i-abc"}, ""))
+}
+
+// An identifier the gate cannot read authorizes account-wide, leaving the
+// rejection to the handler that validates the request.
+func TestResourceARNsUnresolvedIdentifierIsAccountWide(t *testing.T) {
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "DescribeCluster", nil, ""))
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "CreateCluster", nil, ""))
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "CreateCluster", nil, "{not json"))
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "CreateCluster", nil, `{"version":"1.31"}`))
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "DescribeNodegroup", []string{"prod"}, ""))
+
+	// A create whose child is unnamed still evaluates the cluster: the absent
+	// member drops out instead of widening the whole check to "*".
+	assert.Equal(t,
+		[]string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/prod"},
+		resolveARNs(t, "CreateNodegroup", []string{"prod"}, `{}`))
+}
+
+// An id whose value is literally "*" builds an ARN ending in "*", which is a
+// value and not a pattern, so it cannot widen a grant.
+func TestResourceARNsIdentifierIsAValue(t *testing.T) {
+	assert.Equal(t,
+		[]string{"arn:aws:eks:ap-southeast-2:123456789012:cluster/*"},
+		resolveARNs(t, "DescribeCluster", []string{"*"}, ""))
+}
+
+func TestResourceARNsUnknownActionFailsClosed(t *testing.T) {
+	_, err := ResourceARNs("NotAnAction", authzRegion, authzAccountID, nil, nil)
+	require.Error(t, err)
+}

--- a/spinifex/gateway/eks_authz_completeness_test.go
+++ b/spinifex/gateway/eks_authz_completeness_test.go
@@ -1,0 +1,28 @@
+//test:in-package — eksRoutes is unexported here, and the completeness test
+// exists to compare it against the scope table.
+
+package gateway
+
+import (
+	"testing"
+
+	gateway_eks "github.com/mulgadc/spinifex/spinifex/gateway/eks"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEKSScopeTableIsExhaustive is what stops the next EKS route being added
+// with a silent account-wide grant. It asserts both directions, so a scope left
+// behind by a deleted or renamed action fails too.
+func TestEKSScopeTableIsExhaustive(t *testing.T) {
+	served := make(map[string]bool, len(eksRoutes))
+	for _, route := range eksRoutes {
+		served[route.action] = true
+		assert.True(t, gateway_eks.HasScope(route.action),
+			"eks action %q has no resource scope entry: add one to eksScopes in gateway/eks/authz.go", route.action)
+	}
+
+	for _, action := range gateway_eks.ScopedActions() {
+		assert.True(t, served[action],
+			"eksScopes has an entry for %q, which the dispatch table does not serve: remove it from gateway/eks/authz.go", action)
+	}
+}

--- a/spinifex/gateway/eks_authz_test.go
+++ b/spinifex/gateway/eks_authz_test.go
@@ -1,0 +1,151 @@
+//test:in-package — drives EKS_Request through the gateway's unexported test
+// helpers (withTestIdentity, policyMockIAMService) and auth context keys.
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/arn"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_eks "github.com/mulgadc/spinifex/spinifex/gateway/eks"
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dispatchEKS drives the gateway with no NATS connection. A permitted request
+// therefore reaches the NATS guard and fails there, which is what proves the
+// policy check ran ahead of the resource existing at all.
+func dispatchEKS(t *testing.T, gw *GatewayConfig, method, path, body string) error {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), ctxService, "eks")
+	ctx = context.WithValue(ctx, ctxAccountID, authzAccountID)
+	req = withTestIdentity(req.WithContext(ctx))
+	return gw.EKS_Request(httptest.NewRecorder(), req)
+}
+
+func eksARN(resource string) string {
+	return "arn:aws:eks:" + authzRegion + ":" + authzAccountID + ":" + resource
+}
+
+// TestEKSRequest_ScopedDenyFires is the bypass this work closes. An operator
+// fences a production cluster; before the resolver the fence was inert and
+// DeleteCluster against it was permitted with nothing logged.
+func TestEKSRequest_ScopedDenyFires(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "eks:*", "*"),
+		statement("Deny", "eks:DeleteCluster", "arn:aws:eks:*:*:cluster/prod"),
+	)
+
+	assertDenied(t, dispatchEKS(t, gw, http.MethodDelete, "/clusters/prod", ""))
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodDelete, "/clusters/dev", ""))
+}
+
+// TestEKSRequest_ScopedAllowGrants is the other half: a least-privilege policy
+// used to deny everything, so the only working policy shape was Resource "*".
+func TestEKSRequest_ScopedAllowGrants(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "eks:DeleteCluster", "arn:aws:eks:*:*:cluster/dev"),
+	)
+
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodDelete, "/clusters/dev", ""))
+	assertDenied(t, dispatchEKS(t, gw, http.MethodDelete, "/clusters/prod", ""))
+}
+
+// A nodegroup ARN carries a UUID the gate cannot see, so the resolver leaves it
+// wildcarded. The AWS-documented policy spelling must still match.
+func TestEKSRequest_NodegroupScopeMatchesWildcardUUID(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "eks:*", "*"),
+		statement("Deny", "eks:DeleteNodegroup", "arn:aws:eks:*:*:nodegroup/prod/workers/*"),
+	)
+
+	assertDenied(t, dispatchEKS(t, gw, http.MethodDelete, "/clusters/prod/node-groups/workers", ""))
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodDelete, "/clusters/prod/node-groups/batch", ""))
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodDelete, "/clusters/dev/node-groups/workers", ""))
+}
+
+// CreateCluster names its cluster in the body, so the body read has to happen
+// before the gate for a fence on a name prefix to fire at all.
+func TestEKSRequest_CreateClusterScopesFromBody(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "eks:*", "*"),
+		statement("Deny", "eks:CreateCluster", "arn:aws:eks:*:*:cluster/prod-*"),
+	)
+
+	assertDenied(t, dispatchEKS(t, gw, http.MethodPost, "/clusters", `{"name":"prod-1"}`))
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodPost, "/clusters", `{"name":"dev-1"}`))
+	// An unreadable body authorizes account-wide and stays the handler's fault.
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodPost, "/clusters", "{not json"))
+}
+
+// The access-entry principal arrives percent-encoded in the path; the ARN the
+// gate builds must be the one the handler's own builder produces.
+func TestEKSRequest_AccessEntryPathIsUnescaped(t *testing.T) {
+	const principal = "arn:aws:iam::123456789012:role/app/admin"
+	entry := arn.FormatEKSAccessEntry(authzRegion, authzAccountID, "prod", handlers_eks.PrincipalARNHash(principal))
+
+	gw := scopedPolicyGateway(
+		statement("Allow", "eks:*", "*"),
+		statement("Deny", "eks:DeleteAccessEntry", entry),
+	)
+
+	path := "/clusters/prod/access-entries/" + url.PathEscape(principal)
+	assertDenied(t, dispatchEKS(t, gw, http.MethodDelete, path, ""))
+
+	other := "/clusters/prod/access-entries/" + url.PathEscape("arn:aws:iam::123456789012:role/app/reader")
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodDelete, other, ""))
+}
+
+// A tag request names its resource by ARN. The handler ignores that ARN's
+// account and works in the caller's, so the gate must too.
+func TestEKSRequest_TagResourceScopesTheNamedResource(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "eks:*", "*"),
+		statement("Deny", "eks:TagResource", eksARN("cluster/prod")),
+	)
+
+	assertDenied(t, dispatchEKS(t, gw, http.MethodPost,
+		"/tags/"+url.PathEscape(eksARN("cluster/prod")), `{"tags":{"k":"v"}}`))
+	assertPermitted(t, dispatchEKS(t, gw, http.MethodPost,
+		"/tags/"+url.PathEscape(eksARN("cluster/dev")), `{"tags":{"k":"v"}}`))
+	// The same cluster spelled under another account is still the caller's.
+	assertDenied(t, dispatchEKS(t, gw, http.MethodPost,
+		"/tags/"+url.PathEscape("arn:aws:eks:us-east-1:999999999999:cluster/prod"), `{"tags":{"k":"v"}}`))
+}
+
+// The property the per-service rollout rests on: passing a real ARN where "*"
+// was passed before cannot withdraw access a working policy already grants.
+func TestEKSRequest_AccountWideGrantStillPermitsEveryAction(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "eks:*", "*"))
+	req := withTestIdentity(httptest.NewRequest(http.MethodGet, "/clusters", nil).
+		WithContext(context.WithValue(context.Background(), ctxAccountID, authzAccountID)))
+
+	for _, action := range gateway_eks.ScopedActions() {
+		t.Run(action, func(t *testing.T) {
+			resources, err := gateway_eks.ResourceARNs(action, authzRegion, authzAccountID,
+				[]string{"prod", "workers", "extra"}, []byte(`{"name":"prod","nodegroupName":"workers","addonName":"coredns","principalArn":"arn:aws:iam::123456789012:role/app"}`))
+			require.NoError(t, err)
+			assert.NoError(t, gw.checkPolicyResources(req, "eks", action, resources))
+		})
+	}
+}
+
+// The account-ID read moved above the gate, which used to reject a missing
+// account itself. InternalError is the code the caller has always seen.
+func TestEKSRequest_MissingAccountIDReturnsInternalError(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "eks:*", "*"))
+	req := withTestIdentity(httptest.NewRequest(http.MethodGet, "/clusters", nil).
+		WithContext(context.WithValue(context.Background(), ctxService, "eks")))
+
+	err := gw.EKS_Request(httptest.NewRecorder(), req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
+}

--- a/spinifex/handlers/eks/access_entry.go
+++ b/spinifex/handlers/eks/access_entry.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -36,14 +37,6 @@ var supportedAccessPolicies = map[string]string{
 // ErrAccessEntryNotFound is returned when no entry exists for the principal.
 // Callers translate it to ResourceNotFoundException at the service boundary.
 var ErrAccessEntryNotFound = errors.New("eks: access entry not found")
-
-// AccessEntryARN composes the access-entry ARN, keying the discriminator off
-// the principal-ARN hash for determinism. Clients address entries by
-// principalArn, not this ARN, so the divergence from AWS's UUID is informational.
-func AccessEntryARN(region, accountID, cluster, principalARN string) string {
-	return fmt.Sprintf("arn:aws:eks:%s:%s:access-entry/%s/%s",
-		region, accountID, cluster, PrincipalARNHash(principalARN))
-}
 
 // PutAccessEntryRecord writes the entry unconditionally.
 func PutAccessEntryRecord(ctx context.Context, kv jetstream.KeyValue, rec *AccessEntryRecord) error {
@@ -239,7 +232,7 @@ func newAccessEntryRecord(region, accountID, cluster, principalARN, username str
 		username = principalARN
 	}
 	return &AccessEntryRecord{
-		ARN:                AccessEntryARN(region, accountID, cluster, principalARN),
+		ARN:                arn.FormatEKSAccessEntry(region, accountID, cluster, PrincipalARNHash(principalARN)),
 		ClusterName:        cluster,
 		PrincipalARN:       principalARN,
 		KubernetesUsername: username,

--- a/spinifex/handlers/eks/addon_state.go
+++ b/spinifex/handlers/eks/addon_state.go
@@ -43,11 +43,6 @@ type AddonRecord struct {
 // Callers translate it to ResourceNotFoundException at the service boundary.
 var ErrAddonNotFound = errors.New("eks: addon not found")
 
-// AddonARN composes the deterministic ARN for a managed add-on.
-func AddonARN(region, accountID, cluster, addon string) string {
-	return fmt.Sprintf("arn:aws:eks:%s:%s:addon/%s/%s", region, accountID, cluster, addon)
-}
-
 // PutAddonRecord writes the record unconditionally.
 func PutAddonRecord(ctx context.Context, kv jetstream.KeyValue, cluster string, rec *AddonRecord) error {
 	if rec == nil {

--- a/spinifex/handlers/eks/addon_status_reconciler_test.go
+++ b/spinifex/handlers/eks/addon_status_reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
@@ -58,7 +59,7 @@ func TestApplyAddonStatusReport(t *testing.T) {
 		now := time.Now().UTC()
 		require.NoError(t, PutAddonRecord(t.Context(), acctKV, "c1", &AddonRecord{
 			AddonName: "coredns", AddonVersion: "1.11.1", Status: AddonStatusCreating,
-			Arn: AddonARN("us-east-1", testAccountID, "c1", "coredns"), CreatedAt: now, ModifiedAt: now,
+			Arn: arn.FormatEKSAddon("us-east-1", testAccountID, "c1", "coredns"), CreatedAt: now, ModifiedAt: now,
 		}))
 	}
 	get := func(t *testing.T) *AddonRecord {

--- a/spinifex/handlers/eks/addons.go
+++ b/spinifex/handlers/eks/addons.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -96,7 +97,7 @@ func (s *EKSServiceImpl) CreateAddon(ctx context.Context, input *eks.CreateAddon
 		Status:                AddonStatusCreating,
 		ServiceAccountRoleArn: aws.StringValue(input.ServiceAccountRoleArn),
 		ConfigurationValues:   aws.StringValue(input.ConfigurationValues),
-		Arn:                   AddonARN(s.deps.Region, accountID, cluster, addonName),
+		Arn:                   arn.FormatEKSAddon(s.deps.Region, accountID, cluster, addonName),
 		Tags:                  aws.StringValueMap(input.Tags),
 		CreatedAt:             now,
 		ModifiedAt:            now,

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/mulgadc/bluebottle/pkg/auth"
+	"github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/instancetypes"
@@ -78,13 +79,6 @@ const ngCASMaxRetries = 16
 // absent. Callers translate to the AWS shape (ResourceNotFoundException) at the
 // service boundary.
 var ErrNodegroupNotFound = errors.New("eks: nodegroup not found")
-
-// NodegroupARN composes a nodegroup ARN matching the AWS shape
-// (.../nodegroup/{cluster}/{ng}/{uuid}). The trailing UUID is the per-nodegroup
-// discriminator AWS appends; it is generated once at create time and persisted.
-func NodegroupARN(region, accountID, cluster, ng, id string) string {
-	return fmt.Sprintf("arn:aws:eks:%s:%s:nodegroup/%s/%s/%s", region, accountID, cluster, ng, id)
-}
 
 // PutNodegroupRecord writes the record unconditionally.
 func PutNodegroupRecord(ctx context.Context, kv jetstream.KeyValue, rec *NodegroupRecord) error {
@@ -281,7 +275,7 @@ func (s *EKSServiceImpl) createNodegroup(ctx context.Context, acctKV jetstream.K
 	rec := &NodegroupRecord{
 		ClusterName:    cluster,
 		Name:           ng,
-		Arn:            NodegroupARN(s.deps.Region, accountID, cluster, ng, uuid.NewV4().String()),
+		Arn:            arn.FormatEKSNodegroup(s.deps.Region, accountID, cluster, ng, uuid.NewV4().String()),
 		Status:         eks.NodegroupStatusCreating,
 		Subnets:        subnets,
 		InstanceTypes:  instanceTypes,

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/mulgadc/spinifex/spinifex/admin"
+	resourcearn "github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
@@ -564,14 +565,14 @@ func (s *EKSServiceImpl) CreateCluster(ctx context.Context, input *eks.CreateClu
 	}
 
 	region := s.deps.Region
-	arn := fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", region, accountID, name)
+	clusterARN := resourcearn.FormatEKSCluster(region, accountID, name)
 
 	publicAccess, privateAccess := endpointAccess(input.ResourcesVpcConfig)
 	publicCidrs := publicAccessCidrs(input.ResourcesVpcConfig, publicAccess)
 
 	meta := &ClusterMeta{
 		Name:    name,
-		Arn:     arn,
+		Arn:     clusterARN,
 		Status:  ClusterStatusCreating,
 		Version: deref(input.Version, defaultK8sVersion),
 		RoleArn: aws.StringValue(input.RoleArn),


### PR DESCRIPTION
## Problem

`EKS_Request` resolved the action and called `gw.checkPolicy(r, "eks", action)`, which evaluates against the literal resource `"*"`. The evaluator matches a statement's `Resource` as a pattern against the request's resource as a value, so a statement scoped to a cluster, nodegroup, add-on or access-entry ARN never participated: a scoped Deny failed open, a scoped Allow failed closed. All 38 EKS actions were enforceable only account-wide.

## Change

- **`gateway/eks/authz.go`** — new. Exhaustive 38-action scope table and resolver. 34 actions resolve a real ARN; four are explicitly account-wide (`ListClusters`, `ListAccessPolicies`, `DescribeAddonVersions`, and `PublishInternal`/`WebhookTokenReview`, whose owning account arrives in the body).
- **`gateway/eks.go`** — the account-ID read and the body read move above the gate; `checkPolicyResources` replaces `checkPolicy`.
- **`arn/eks.go`** — new. The four EKS ARN builders move to the shared leaf package, so the ARN the gate authorizes and the ARN persisted on the record cannot drift. The one-line `handlers/eks` wrappers are deleted and their callers build the ARN directly.

## Judgement calls

**The body read moves ahead of authorization.** `CreateCluster` is `POST /clusters` with the name in the body, so leaving it at `"*"` would make a fence on a name prefix inert for the one action that creates the object every other statement names. The dispatcher already read the whole body, so this is a reorder, not new machinery. The three creates evaluate the cluster plus the child they create; an unnamed child drops out rather than widening the call to `"*"`.

**A nodegroup resolves to `nodegroup/<cluster>/<name>/*`.** Recovering the trailing UUID would need a `DescribeNodegroup` round trip ahead of every nodegroup call. `(cluster, name)` already identifies the nodegroup here, and the final `*` is a value, not a pattern, so it matches the AWS-documented spelling without widening. An exact-ARN Deny still does not fire — `mulga-4j3ap`.

**Tag ARNs are re-anchored** on `gw.Region` and the caller's account, because the tag handler ignores those segments and operates in the caller's own bucket. A nodegroup's UUID is dropped for the same reason.

## Testing

- Six dispatcher regression tests verified failing against the unfixed gate and passing with it: scoped Deny, scoped Allow, the nodegroup wildcard, `CreateCluster` from the body, the percent-encoded access-entry path, and tag-ARN re-anchoring.
- Two-way completeness over `eksRoutes`, ARN fidelity per resource class, non-regression (`Allow eks:* on *` still permits all 38 once a real ARN is passed), and the `InternalError` ordering the hoist preserves.
- `make preflight` passes.