### PR TITLE
fix: scope ELBv2 policy checks to the resources a request names

### DIFF
--- a/spinifex/arn/elbv2.go
+++ b/spinifex/arn/elbv2.go
@@ -1,0 +1,88 @@
+package arn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ELBv2ResourceType is the resource-type segment of an
+// arn:aws:elasticloadbalancing ARN.
+type ELBv2ResourceType string
+
+const (
+	ELBv2LoadBalancer ELBv2ResourceType = "loadbalancer"
+	ELBv2TargetGroup  ELBv2ResourceType = "targetgroup"
+	ELBv2Listener     ELBv2ResourceType = "listener"
+	ELBv2ListenerRule ELBv2ResourceType = "listener-rule"
+)
+
+// elbv2NetworkType is the load balancer type ELBv2 spells "network". This
+// package is a leaf, so the value is repeated here rather than imported.
+const elbv2NetworkType = "network"
+
+// ELBv2LBPathSegment returns the path segment a load balancer type takes inside
+// an ARN: "net" for a network load balancer, "app" for everything else.
+func ELBv2LBPathSegment(lbType string) string {
+	if lbType == elbv2NetworkType {
+		return "net"
+	}
+	return "app"
+}
+
+// FormatELBv2LoadBalancer builds
+// arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<app|net>/<name>/<id>.
+func FormatELBv2LoadBalancer(region, accountID, name, lbID, lbType string) string {
+	return fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:%s/%s/%s/%s",
+		region, accountID, ELBv2LoadBalancer, ELBv2LBPathSegment(lbType), name, lbID)
+}
+
+// FormatELBv2TargetGroup builds
+// arn:aws:elasticloadbalancing:<region>:<account>:targetgroup/<name>/<id>.
+func FormatELBv2TargetGroup(region, accountID, name, tgID string) string {
+	return fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:%s/%s/%s",
+		region, accountID, ELBv2TargetGroup, name, tgID)
+}
+
+// FormatELBv2Listener builds
+// arn:aws:elasticloadbalancing:<region>:<account>:listener/<app|net>/<lb>/<lbID>/<id>.
+func FormatELBv2Listener(region, accountID, lbName, lbID, listenerID, lbType string) string {
+	return fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:%s/%s/%s/%s/%s",
+		region, accountID, ELBv2Listener, ELBv2LBPathSegment(lbType), lbName, lbID, listenerID)
+}
+
+// FormatELBv2Resource builds an ELBv2 ARN from an already-formed resource
+// component, such as one derived from a caller-supplied parent ARN.
+func FormatELBv2Resource(region, accountID string, kind ELBv2ResourceType, resource string) string {
+	return fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:%s/%s", region, accountID, kind, resource)
+}
+
+// ParsedELBv2 is an arn:aws:elasticloadbalancing ARN split into its parts.
+// Resource is the path following the resource-type segment, which for every
+// ELBv2 type but the target group carries the load balancer's own path.
+type ParsedELBv2 struct {
+	Region    string
+	AccountID string
+	Kind      ELBv2ResourceType
+	Resource  string
+}
+
+// ParseELBv2 splits an ELBv2 ARN. ok is false for anything that is not an
+// arn:aws:elasticloadbalancing ARN naming one of the four resource types: an
+// ARN this stack never builds has no resource it can correctly stand for.
+func ParseELBv2(value string) (ParsedELBv2, bool) {
+	parts := strings.SplitN(value, ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[1] != "aws" || parts[2] != "elasticloadbalancing" {
+		return ParsedELBv2{}, false
+	}
+	rawKind, resource, found := strings.Cut(parts[5], "/")
+	if !found || rawKind == "" {
+		return ParsedELBv2{}, false
+	}
+	kind := ELBv2ResourceType(rawKind)
+	switch kind {
+	case ELBv2LoadBalancer, ELBv2TargetGroup, ELBv2Listener, ELBv2ListenerRule:
+		return ParsedELBv2{Region: parts[3], AccountID: parts[4], Kind: kind, Resource: resource}, true
+	default:
+		return ParsedELBv2{}, false
+	}
+}

--- a/spinifex/arn/elbv2_test.go
+++ b/spinifex/arn/elbv2_test.go
@@ -1,0 +1,93 @@
+package arn_test
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/arn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatELBv2LoadBalancer(t *testing.T) {
+	assert.Equal(t,
+		"arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/50dc6c495c0c9188",
+		arn.FormatELBv2LoadBalancer("us-east-1", "123456789012", "my-alb", "50dc6c495c0c9188", "application"))
+	assert.Equal(t,
+		"arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/my-nlb/50dc6c495c0c9188",
+		arn.FormatELBv2LoadBalancer("us-east-1", "123456789012", "my-nlb", "50dc6c495c0c9188", "network"))
+}
+
+// An unrecognised type takes the application segment, which is what the handler
+// does: only "network" is spelled "net".
+func TestELBv2LBPathSegment(t *testing.T) {
+	assert.Equal(t, "net", arn.ELBv2LBPathSegment("network"))
+	assert.Equal(t, "app", arn.ELBv2LBPathSegment("application"))
+	assert.Equal(t, "app", arn.ELBv2LBPathSegment(""))
+}
+
+func TestFormatELBv2TargetGroup(t *testing.T) {
+	assert.Equal(t,
+		"arn:aws:elasticloadbalancing:us-west-2:111222333444:targetgroup/my-tg/deadbeef",
+		arn.FormatELBv2TargetGroup("us-west-2", "111222333444", "my-tg", "deadbeef"))
+}
+
+func TestFormatELBv2Listener(t *testing.T) {
+	assert.Equal(t,
+		"arn:aws:elasticloadbalancing:eu-west-1:999888777666:listener/app/my-alb/lbid123/listener456",
+		arn.FormatELBv2Listener("eu-west-1", "999888777666", "my-alb", "lbid123", "listener456", "application"))
+	assert.Equal(t,
+		"arn:aws:elasticloadbalancing:eu-west-1:999888777666:listener/net/my-nlb/lbid123/listener456",
+		arn.FormatELBv2Listener("eu-west-1", "999888777666", "my-nlb", "lbid123", "listener456", "network"))
+}
+
+func TestFormatELBv2Resource(t *testing.T) {
+	assert.Equal(t,
+		"arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:listener-rule/app/alb/lb1/l1/r1",
+		arn.FormatELBv2Resource("ap-southeast-2", "123456789012", arn.ELBv2ListenerRule, "app/alb/lb1/l1/r1"))
+}
+
+func TestParseELBv2(t *testing.T) {
+	parsed, ok := arn.ParseELBv2("arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer/app/prod/abc123")
+	assert.True(t, ok)
+	assert.Equal(t, "ap-southeast-2", parsed.Region)
+	assert.Equal(t, "123456789012", parsed.AccountID)
+	assert.Equal(t, arn.ELBv2LoadBalancer, parsed.Kind)
+	assert.Equal(t, "app/prod/abc123", parsed.Resource)
+}
+
+// Round-tripping every builder through the parser is what stops the gate and
+// the handler drifting onto different ARN formats.
+func TestParseELBv2_RoundTripsEveryBuilder(t *testing.T) {
+	region, account := "ap-southeast-2", "123456789012"
+	cases := []struct {
+		value string
+		kind  arn.ELBv2ResourceType
+	}{
+		{arn.FormatELBv2LoadBalancer(region, account, "prod", "abc123", "application"), arn.ELBv2LoadBalancer},
+		{arn.FormatELBv2TargetGroup(region, account, "web", "def456"), arn.ELBv2TargetGroup},
+		{arn.FormatELBv2Listener(region, account, "prod", "abc123", "l1", "network"), arn.ELBv2Listener},
+		{arn.FormatELBv2Resource(region, account, arn.ELBv2ListenerRule, "app/prod/abc123/l1/r1"), arn.ELBv2ListenerRule},
+	}
+	for _, tc := range cases {
+		parsed, ok := arn.ParseELBv2(tc.value)
+		assert.True(t, ok, tc.value)
+		assert.Equal(t, tc.kind, parsed.Kind, tc.value)
+		assert.Equal(t, region, parsed.Region, tc.value)
+		assert.Equal(t, account, parsed.AccountID, tc.value)
+	}
+}
+
+func TestParseELBv2_Rejects(t *testing.T) {
+	rejected := []string{
+		"",
+		"not-an-arn",
+		"arn:aws:ec2:ap-southeast-2:123456789012:instance/i-abc",
+		"arn:aws-cn:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer/app/prod/abc",
+		"arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:widget/app/prod/abc",
+		"arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer",
+		"arn:aws:elasticloadbalancing:ap-southeast-2:123456789012",
+	}
+	for _, value := range rejected {
+		_, ok := arn.ParseELBv2(value)
+		assert.False(t, ok, value)
+	}
+}

--- a/spinifex/awsec2query/parser.go
+++ b/spinifex/awsec2query/parser.go
@@ -283,3 +283,39 @@ func setSliceField(field reflect.Value, params map[string]string, prefix, listNa
 	field.Set(slice)
 	return nil
 }
+
+// StringValuesAt reads every string at a dotted field path in a parsed query
+// input, flattening slices along the way. Authorization resolvers use it to
+// pull a request's identifiers out of the same struct the handler receives.
+func StringValuesAt(input any, path string) []string {
+	return stringValuesAt(reflect.ValueOf(input), strings.Split(path, "."))
+}
+
+func stringValuesAt(value reflect.Value, path []string) []string {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() {
+		return nil
+	}
+	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
+		var values []string
+		for i := 0; i < value.Len(); i++ {
+			values = append(values, stringValuesAt(value.Index(i), path)...)
+		}
+		return values
+	}
+	if len(path) == 0 {
+		if value.Kind() == reflect.String {
+			return []string{value.String()}
+		}
+		return nil
+	}
+	if value.Kind() != reflect.Struct {
+		return nil
+	}
+	return stringValuesAt(value.FieldByName(path[0]), path[1:])
+}

--- a/spinifex/gateway/ec2/authz.go
+++ b/spinifex/gateway/ec2/authz.go
@@ -5,9 +5,7 @@ package gateway_ec2
 
 import (
 	"errors"
-	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/awsec2query"
@@ -380,7 +378,7 @@ func (s *resourceScope) resolve(region, accountID string, input any) ([]string, 
 // precedence. Values are deduplicated before policy evaluation.
 func (s *resourceScope) identifiers(input any) []string {
 	for _, path := range s.paths {
-		values := stringValuesAt(reflect.ValueOf(input), strings.Split(path, "."))
+		values := awsec2query.StringValuesAt(input, path)
 		seen := make(map[string]struct{}, len(values))
 		ids := make([]string, 0, len(values))
 		for _, value := range values {
@@ -398,33 +396,4 @@ func (s *resourceScope) identifiers(input any) []string {
 		}
 	}
 	return nil
-}
-
-func stringValuesAt(value reflect.Value, path []string) []string {
-	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
-		if value.IsNil() {
-			return nil
-		}
-		value = value.Elem()
-	}
-	if !value.IsValid() {
-		return nil
-	}
-	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
-		var values []string
-		for i := 0; i < value.Len(); i++ {
-			values = append(values, stringValuesAt(value.Index(i), path)...)
-		}
-		return values
-	}
-	if len(path) == 0 {
-		if value.Kind() == reflect.String {
-			return []string{value.String()}
-		}
-		return nil
-	}
-	if value.Kind() != reflect.Struct {
-		return nil
-	}
-	return stringValuesAt(value.FieldByName(path[0]), path[1:])
 }

--- a/spinifex/gateway/elbv2.go
+++ b/spinifex/gateway/elbv2.go
@@ -14,35 +14,44 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
-// ELBv2Handler processes parsed query args and returns XML response bytes.
-type ELBv2Handler func(ctx context.Context, action string, q map[string]string, gw *GatewayConfig, accountID string) ([]byte, error)
+// elbv2Action parses once so authorization and dispatch share one typed input.
+type elbv2Action struct {
+	parse    func(map[string]string) (any, error)
+	dispatch func(ctx context.Context, action string, parsed any, gw *GatewayConfig, accountID string) ([]byte, error)
+}
 
-// elbv2Handler creates a type-safe ELBv2Handler that allocates the typed input struct,
-// parses query params into it, calls the handler, and marshals the output to XML.
+// elbv2Handler creates a type-safe elbv2Action. Parsing is separate from
+// dispatch so the resolver authorizes the exact input the handler executes.
 // ELBv2 uses the IAM-style XML envelope: <ActionResponse><ActionResult>...</ActionResult></ActionResponse>.
-func elbv2Handler[In any](handler func(context.Context, *In, *GatewayConfig, string) (any, error)) ELBv2Handler {
-	return func(ctx context.Context, action string, q map[string]string, gw *GatewayConfig, accountID string) ([]byte, error) {
-		input := new(In)
-		if err := awsec2query.QueryParamsToStruct(q, input); err != nil {
-			if errors.Is(err, awsec2query.ErrSliceTooLarge) {
-				return nil, errors.New(awserrors.ErrorMalformedQueryString)
+func elbv2Handler[In any](handler func(context.Context, *In, *GatewayConfig, string) (any, error)) elbv2Action {
+	return elbv2Action{
+		parse: func(q map[string]string) (any, error) {
+			input := new(In)
+			if err := awsec2query.QueryParamsToStruct(q, input); err != nil {
+				return nil, err
 			}
-			return nil, err
-		}
-		output, err := handler(ctx, input, gw, accountID)
-		if err != nil {
-			return nil, err
-		}
-		payload := utils.GenerateIAMXMLPayload(action, output)
-		xmlOutput, err := utils.MarshalToXML(payload)
-		if err != nil {
-			return nil, errors.New("failed to marshal response to XML")
-		}
-		return xmlOutput, nil
+			return input, nil
+		},
+		dispatch: func(ctx context.Context, action string, parsed any, gw *GatewayConfig, accountID string) ([]byte, error) {
+			input, ok := parsed.(*In)
+			if !ok {
+				return nil, errors.New(awserrors.ErrorInternalError)
+			}
+			output, err := handler(ctx, input, gw, accountID)
+			if err != nil {
+				return nil, err
+			}
+			payload := utils.GenerateIAMXMLPayload(action, output)
+			xmlOutput, err := utils.MarshalToXML(payload)
+			if err != nil {
+				return nil, errors.New("failed to marshal response to XML")
+			}
+			return xmlOutput, nil
+		},
 	}
 }
 
-var elbv2Actions = map[string]ELBv2Handler{
+var elbv2Actions = map[string]elbv2Action{
 	"CreateLoadBalancer": elbv2Handler(func(ctx context.Context, input *elbv2.CreateLoadBalancerInput, gw *GatewayConfig, accountID string) (any, error) {
 		if err := gw.Quota.EnforceLoadBalancers(ctx, gw.NATSConn, accountID, 1); err != nil {
 			return nil, err
@@ -175,7 +184,30 @@ func (gw *GatewayConfig) ELBv2_Request(w http.ResponseWriter, r *http.Request) e
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "elasticloadbalancing", action); err != nil {
+	// Hoisted above the policy check because the resolver builds ARNs from it.
+	// gw.Region, never the caller-supplied credential-scope region, which would
+	// let a caller sign for another region and slide out from under a Deny.
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.ErrorContext(r.Context(), "ELBv2_Request: no account ID in auth context")
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
+	}
+
+	input, err := handler.parse(queryArgs)
+	if err != nil {
+		if errors.Is(err, awsec2query.ErrSliceTooLarge) {
+			return errors.New(awserrors.ErrorMalformedQueryString)
+		}
+		return err
+	}
+
+	resources, err := gateway_elbv2.ResourceARNs(action, gw.Region, accountID, input)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "elasticloadbalancing", action, resources); err != nil {
 		return err
 	}
 
@@ -183,13 +215,7 @@ func (gw *GatewayConfig) ELBv2_Request(w http.ResponseWriter, r *http.Request) e
 		return errors.New(awserrors.ErrorServerInternal)
 	}
 
-	accountID, _ := r.Context().Value(ctxAccountID).(string)
-	if accountID == "" {
-		slog.ErrorContext(r.Context(), "ELBv2_Request: no account ID in auth context")
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-
-	xmlOutput, err := handler(r.Context(), action, queryArgs, gw, accountID)
+	xmlOutput, err := handler.dispatch(r.Context(), action, input, gw, accountID)
 	if err != nil {
 		return err
 	}

--- a/spinifex/gateway/elbv2/authz.go
+++ b/spinifex/gateway/elbv2/authz.go
@@ -1,0 +1,285 @@
+package gateway_elbv2
+
+import (
+	"errors"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/arn"
+	"github.com/mulgadc/spinifex/spinifex/awsec2query"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// The resource a policy check evaluates against when the request names nothing
+// in particular, or when the identifier cannot be resolved at gate time.
+const anyResource = "*"
+
+// Stands in for the short id of a resource the request is about to create. It
+// is a value, so a policy scoped to the parent path matches it where "*" would
+// not; a Deny naming the stored id cannot fire, because it does not exist yet.
+const anyID = "*"
+
+// Where an action's resource is named, and how it becomes an ARN. The caller
+// supplies a full ARN for everything but the four creates, which derive one
+// from a parent ARN or from the name the request asks for.
+type resourceSource uint8
+
+const (
+	sourceAny resourceSource = iota
+	sourceLoadBalancerARN
+	sourceTargetGroupARN
+	sourceListenerARN
+	sourceRuleARN
+	sourceRulePriorityARNs
+	sourceResourceARNs
+	sourceNewLoadBalancer
+	sourceNewTargetGroup
+	sourceNewListener
+	sourceNewRule
+	sourceDefaultActionTargetGroups
+	sourceActionTargetGroups
+)
+
+// Every action ELBv2_Request serves, with the resources AWS evaluates it
+// against. Exhaustive by contract: a completeness test compares this table with
+// the dispatch table in both directions, so an action cannot be added with a
+// silent account-wide grant.
+var elbv2Scopes = map[string][]resourceSource{
+	// Load balancers.
+	"CreateLoadBalancer":             {sourceNewLoadBalancer},
+	"DeleteLoadBalancer":             {sourceLoadBalancerARN},
+	"ModifyLoadBalancerAttributes":   {sourceLoadBalancerARN},
+	"DescribeLoadBalancerAttributes": {sourceLoadBalancerARN},
+	"SetSecurityGroups":              {sourceLoadBalancerARN},
+	"SetSubnets":                     {sourceLoadBalancerARN},
+	"SetIpAddressType":               {sourceLoadBalancerARN},
+
+	// Target groups.
+	"CreateTargetGroup":             {sourceNewTargetGroup},
+	"DeleteTargetGroup":             {sourceTargetGroupARN},
+	"ModifyTargetGroup":             {sourceTargetGroupARN},
+	"ModifyTargetGroupAttributes":   {sourceTargetGroupARN},
+	"DescribeTargetGroupAttributes": {sourceTargetGroupARN},
+	"RegisterTargets":               {sourceTargetGroupARN},
+	"DeregisterTargets":             {sourceTargetGroupARN},
+	"DescribeTargetHealth":          {sourceTargetGroupARN},
+
+	// Listeners. A create evaluates the load balancer, the listener it is about
+	// to create and every target group its default actions forward to, matching
+	// AWS; a redirect-only action names no target group and drops out.
+	"CreateListener":               {sourceLoadBalancerARN, sourceNewListener, sourceDefaultActionTargetGroups},
+	"ModifyListener":               {sourceListenerARN, sourceDefaultActionTargetGroups},
+	"DeleteListener":               {sourceListenerARN},
+	"AddListenerCertificates":      {sourceListenerARN},
+	"RemoveListenerCertificates":   {sourceListenerARN},
+	"DescribeListenerCertificates": {sourceListenerARN},
+	"DescribeListenerAttributes":   {sourceListenerARN},
+	"ModifyListenerAttributes":     {sourceListenerARN},
+
+	// Rules.
+	"CreateRule":        {sourceListenerARN, sourceNewRule, sourceActionTargetGroups},
+	"ModifyRule":        {sourceRuleARN, sourceActionTargetGroups},
+	"DeleteRule":        {sourceRuleARN},
+	"SetRulePriorities": {sourceRulePriorityARNs},
+
+	// Tags, which name their resources by ARN whatever type they are.
+	"AddTags":      {sourceResourceARNs},
+	"RemoveTags":   {sourceResourceARNs},
+	"DescribeTags": {sourceResourceARNs},
+
+	// Describes. "*" is fidelity, not a stub: AWS documents no resource type for
+	// these five either, so a pasted AWS policy behaves the same way here.
+	"DescribeLoadBalancers": {sourceAny},
+	"DescribeTargetGroups":  {sourceAny},
+	"DescribeListeners":     {sourceAny},
+	"DescribeRules":         {sourceAny},
+	"DescribeSSLPolicies":   {sourceAny},
+
+	// The lb-agent routes carry only the load balancer's short id. Recovering
+	// its name and type to build an ARN needs a NATS round trip on every
+	// heartbeat, so both authorize account-wide.
+	"LBAgentHeartbeat": {sourceAny},
+	"GetLBConfig":      {sourceAny},
+}
+
+// HasScope reports whether action has an explicit ELBv2 scope-table entry.
+func HasScope(action string) bool {
+	_, ok := elbv2Scopes[action]
+	return ok
+}
+
+// ScopedActions returns every action represented in the ELBv2 scope table, so a
+// scope left behind by a deleted or renamed action fails completeness too.
+func ScopedActions() []string {
+	actions := make([]string, 0, len(elbv2Scopes))
+	for action := range elbv2Scopes {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+	return actions
+}
+
+// ResourceARNs resolves the resources an ELBv2 request authorizes against from
+// the same parsed SDK input the handler receives. A caller-supplied ARN naming
+// another partition, region or account is rejected here rather than authorized
+// verbatim, because that is how the gate and the handler come to disagree about
+// which object is being addressed.
+func ResourceARNs(action, region, accountID string, input any) ([]string, error) {
+	sources, ok := elbv2Scopes[action]
+	if !ok {
+		slog.Error("ELBv2 authz: action is served but absent from the scope table", "action", action)
+		return nil, errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	resources := make([]string, 0, len(sources))
+	for _, source := range sources {
+		resolved, err := resolve(source, action, region, accountID, input)
+		if err != nil {
+			return nil, err
+		}
+		for _, resource := range resolved {
+			// An unresolved member drops out rather than contributing "*", which no
+			// scoped Allow can match and which would deny a call AWS permits.
+			if resource == anyResource || slices.Contains(resources, resource) {
+				continue
+			}
+			resources = append(resources, resource)
+		}
+	}
+	if len(resources) == 0 {
+		return []string{anyResource}, nil
+	}
+	return resources, nil
+}
+
+func resolve(source resourceSource, action, region, accountID string, input any) ([]string, error) {
+	switch source {
+	case sourceAny:
+		return []string{anyResource}, nil
+
+	case sourceLoadBalancerARN:
+		return suppliedARNs(region, accountID, input, "LoadBalancerArn")
+
+	case sourceTargetGroupARN:
+		return suppliedARNs(region, accountID, input, "TargetGroupArn")
+
+	case sourceListenerARN:
+		return suppliedARNs(region, accountID, input, "ListenerArn")
+
+	case sourceRuleARN:
+		return suppliedARNs(region, accountID, input, "RuleArn")
+
+	case sourceRulePriorityARNs:
+		return suppliedARNs(region, accountID, input, "RulePriorities.RuleArn")
+
+	case sourceResourceARNs:
+		return suppliedARNs(region, accountID, input, "ResourceArns")
+
+	case sourceNewLoadBalancer:
+		name := firstValue(input, "Name")
+		if name == "" {
+			return []string{anyResource}, nil
+		}
+		return []string{arn.FormatELBv2LoadBalancer(region, accountID, name, anyID, firstValue(input, "Type"))}, nil
+
+	case sourceNewTargetGroup:
+		name := firstValue(input, "Name")
+		if name == "" {
+			return []string{anyResource}, nil
+		}
+		return []string{arn.FormatELBv2TargetGroup(region, accountID, name, anyID)}, nil
+
+	case sourceNewListener:
+		return derivedChild(region, accountID, input, "LoadBalancerArn", arn.ELBv2LoadBalancer, arn.ELBv2Listener)
+
+	case sourceNewRule:
+		return derivedChild(region, accountID, input, "ListenerArn", arn.ELBv2Listener, arn.ELBv2ListenerRule)
+
+	case sourceDefaultActionTargetGroups:
+		return suppliedARNs(region, accountID, input,
+			"DefaultActions.TargetGroupArn", "DefaultActions.ForwardConfig.TargetGroups.TargetGroupArn")
+
+	case sourceActionTargetGroups:
+		return suppliedARNs(region, accountID, input,
+			"Actions.TargetGroupArn", "Actions.ForwardConfig.TargetGroups.TargetGroupArn")
+
+	default:
+		slog.Error("ELBv2 authz: unhandled resource source, failing closed", "action", action, "source", source)
+		return nil, errors.New(awserrors.ErrorInternalError)
+	}
+}
+
+// suppliedARNs validates every ARN the request names at the given field paths.
+// An absent identifier authorizes account-wide, so a malformed request stays
+// the handler's validation fault rather than becoming an authorization failure.
+func suppliedARNs(region, accountID string, input any, paths ...string) ([]string, error) {
+	var resources []string
+	for _, path := range paths {
+		for _, value := range awsec2query.StringValuesAt(input, path) {
+			if value == "" {
+				continue
+			}
+			if err := checkARN(value, region, accountID); err != nil {
+				return nil, err
+			}
+			resources = append(resources, value)
+		}
+	}
+	if len(resources) == 0 {
+		return []string{anyResource}, nil
+	}
+	return resources, nil
+}
+
+// derivedChild builds the ARN of a resource the request is about to create
+// under the parent it names. The parent already carries the load balancer's
+// name, type and id in the spelling the handler will reuse, so the child is
+// retyped from it rather than rebuilt from components the gate cannot see.
+func derivedChild(region, accountID string, input any, path string, parent, child arn.ELBv2ResourceType) ([]string, error) {
+	value := firstValue(input, path)
+	if value == "" {
+		return []string{anyResource}, nil
+	}
+	if err := checkARN(value, region, accountID); err != nil {
+		return nil, err
+	}
+	parsed, _ := arn.ParseELBv2(value)
+	if parsed.Kind != parent || parsed.Resource == "" {
+		return nil, arnError(value, "expected an ELBv2 "+string(parent)+" ARN")
+	}
+	return []string{arn.FormatELBv2Resource(region, accountID, child, parsed.Resource+"/"+anyID)}, nil
+}
+
+// checkARN requires a caller-supplied ARN to be an ELBv2 ARN in this endpoint's
+// region and the caller's own account.
+func checkARN(value, region, accountID string) error {
+	parsed, ok := arn.ParseELBv2(value)
+	if !ok {
+		return arnError(value, "expected the form arn:aws:elasticloadbalancing:{region}:{account}:{type}/{path}")
+	}
+	if parsed.Region != region {
+		return arnError(value, "region "+parsed.Region+" does not match this endpoint's region "+region)
+	}
+	if parsed.AccountID != accountID {
+		return arnError(value, "the resource belongs to another account")
+	}
+	if strings.TrimSpace(parsed.Resource) == "" {
+		return arnError(value, "the resource path is empty")
+	}
+	return nil
+}
+
+func arnError(value, why string) error {
+	return awserrors.Errorf(awserrors.ErrorInvalidParameterValue, "%q is not a valid ELBv2 ARN: %s", value, why)
+}
+
+func firstValue(input any, path string) string {
+	for _, value := range awsec2query.StringValuesAt(input, path) {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/spinifex/gateway/elbv2/authz.go
+++ b/spinifex/gateway/elbv2/authz.go
@@ -3,7 +3,6 @@ package gateway_elbv2
 import (
 	"errors"
 	"log/slog"
-	"slices"
 	"sort"
 	"strings"
 
@@ -134,6 +133,7 @@ func ResourceARNs(action, region, accountID string, input any) ([]string, error)
 	}
 
 	resources := make([]string, 0, len(sources))
+	seen := make(map[string]struct{}, len(sources))
 	for _, source := range sources {
 		resolved, err := resolve(source, action, region, accountID, input)
 		if err != nil {
@@ -142,9 +142,16 @@ func ResourceARNs(action, region, accountID string, input any) ([]string, error)
 		for _, resource := range resolved {
 			// An unresolved member drops out rather than contributing "*", which no
 			// scoped Allow can match and which would deny a call AWS permits.
-			if resource == anyResource || slices.Contains(resources, resource) {
+			if resource == anyResource {
 				continue
 			}
+			if _, duplicate := seen[resource]; duplicate {
+				continue
+			}
+			if len(resources) >= awsec2query.MaxSliceLen {
+				return nil, errors.New(awserrors.ErrorMalformedQueryString)
+			}
+			seen[resource] = struct{}{}
 			resources = append(resources, resource)
 		}
 	}
@@ -220,6 +227,11 @@ func suppliedARNs(region, accountID string, input any, paths ...string) ([]strin
 		for _, value := range awsec2query.StringValuesAt(input, path) {
 			if value == "" {
 				continue
+			}
+			// A nested list can fan out past what any single list may hold, so the
+			// bound is asserted here rather than inherited from the parser.
+			if len(resources) >= awsec2query.MaxSliceLen {
+				return nil, errors.New(awserrors.ErrorMalformedQueryString)
 			}
 			if err := checkARN(value, region, accountID); err != nil {
 				return nil, err

--- a/spinifex/gateway/elbv2/authz_test.go
+++ b/spinifex/gateway/elbv2/authz_test.go
@@ -1,0 +1,223 @@
+package gateway_elbv2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/mulgadc/spinifex/spinifex/arn"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	authzRegion  = "ap-southeast-2"
+	authzAccount = "123456789012"
+)
+
+func lbARN(name, id string) string {
+	return arn.FormatELBv2LoadBalancer(authzRegion, authzAccount, name, id, "application")
+}
+
+func tgARN(name, id string) string {
+	return arn.FormatELBv2TargetGroup(authzRegion, authzAccount, name, id)
+}
+
+func listenerARN(lbName, lbID, id string) string {
+	return arn.FormatELBv2Listener(authzRegion, authzAccount, lbName, lbID, id, "application")
+}
+
+func resolveARNs(t *testing.T, action string, input any) []string {
+	t.Helper()
+	resources, err := ResourceARNs(action, authzRegion, authzAccount, input)
+	require.NoError(t, err)
+	return resources
+}
+
+func TestResourceARNs_UnknownAction(t *testing.T) {
+	_, err := ResourceARNs("NotAnAction", authzRegion, authzAccount, &elbv2.DeleteLoadBalancerInput{})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidAction, err.Error())
+}
+
+// Each resource class is asserted against the exact ARN, so a gate that
+// authorizes a differently-spelled ARN than the handler stores fails here.
+func TestResourceARNs_PerResourceClass(t *testing.T) {
+	assert.Equal(t, []string{lbARN("prod", "abc123")},
+		resolveARNs(t, "DeleteLoadBalancer", &elbv2.DeleteLoadBalancerInput{
+			LoadBalancerArn: aws.String(lbARN("prod", "abc123")),
+		}))
+
+	assert.Equal(t, []string{tgARN("web", "def456")},
+		resolveARNs(t, "RegisterTargets", &elbv2.RegisterTargetsInput{
+			TargetGroupArn: aws.String(tgARN("web", "def456")),
+		}))
+
+	assert.Equal(t, []string{listenerARN("prod", "abc123", "l1")},
+		resolveARNs(t, "DeleteListener", &elbv2.DeleteListenerInput{
+			ListenerArn: aws.String(listenerARN("prod", "abc123", "l1")),
+		}))
+
+	ruleARN := arn.FormatELBv2Resource(authzRegion, authzAccount, arn.ELBv2ListenerRule, "app/prod/abc123/l1/r1")
+	assert.Equal(t, []string{ruleARN},
+		resolveARNs(t, "DeleteRule", &elbv2.DeleteRuleInput{RuleArn: aws.String(ruleARN)}))
+}
+
+// The four creates name a resource that does not exist, so the short id is a
+// wildcard under a path the parent or the requested name already fixes.
+func TestResourceARNs_Creates(t *testing.T) {
+	assert.Equal(t,
+		[]string{"arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer/app/prod/*"},
+		resolveARNs(t, "CreateLoadBalancer", &elbv2.CreateLoadBalancerInput{Name: aws.String("prod")}))
+
+	assert.Equal(t,
+		[]string{"arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer/net/edge/*"},
+		resolveARNs(t, "CreateLoadBalancer", &elbv2.CreateLoadBalancerInput{
+			Name: aws.String("edge"), Type: aws.String("network"),
+		}))
+
+	assert.Equal(t,
+		[]string{"arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:targetgroup/web/*"},
+		resolveARNs(t, "CreateTargetGroup", &elbv2.CreateTargetGroupInput{Name: aws.String("web")}))
+
+	assert.Equal(t,
+		[]string{lbARN("prod", "abc123"), "arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:listener/app/prod/abc123/*"},
+		resolveARNs(t, "CreateListener", &elbv2.CreateListenerInput{
+			LoadBalancerArn: aws.String(lbARN("prod", "abc123")),
+		}))
+
+	assert.Equal(t,
+		[]string{listenerARN("prod", "abc123", "l1"), "arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:listener-rule/app/prod/abc123/l1/*"},
+		resolveARNs(t, "CreateRule", &elbv2.CreateRuleInput{
+			ListenerArn: aws.String(listenerARN("prod", "abc123", "l1")),
+		}))
+}
+
+// The derived listener ARN is the shared builder's output with the short id
+// replaced by "*", which is what makes a create-time name-prefix fence work.
+func TestResourceARNs_DerivedListenerMatchesBuilder(t *testing.T) {
+	stored := arn.FormatELBv2Listener(authzRegion, authzAccount, "prod", "abc123", "l7", "application")
+	resources := resolveARNs(t, "CreateListener", &elbv2.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN("prod", "abc123")),
+	})
+	require.Len(t, resources, 2)
+	assert.Equal(t, arn.FormatELBv2Listener(authzRegion, authzAccount, "prod", "abc123", "*", "application"), resources[1])
+	assert.NotEqual(t, stored, resources[1])
+}
+
+// A listener's target groups are authorized alongside it, and a redirect-only
+// action names none, which leaves the call scoped rather than widening it.
+func TestResourceARNs_ListenerTargetGroups(t *testing.T) {
+	withTG := resolveARNs(t, "CreateListener", &elbv2.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN("prod", "abc123")),
+		DefaultActions: []*elbv2.Action{
+			{Type: aws.String("forward"), TargetGroupArn: aws.String(tgARN("web", "def456"))},
+		},
+	})
+	assert.Contains(t, withTG, tgARN("web", "def456"))
+
+	redirect := resolveARNs(t, "CreateListener", &elbv2.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN("prod", "abc123")),
+		DefaultActions:  []*elbv2.Action{{Type: aws.String("redirect")}},
+	})
+	assert.NotContains(t, redirect, "*")
+	assert.Len(t, redirect, 2)
+}
+
+// A weighted forward names its target groups inside ForwardConfig, which AWS
+// evaluates the same way as the flat TargetGroupArn.
+func TestResourceARNs_ForwardConfigTargetGroups(t *testing.T) {
+	resources := resolveARNs(t, "ModifyRule", &elbv2.ModifyRuleInput{
+		RuleArn: aws.String(arn.FormatELBv2Resource(authzRegion, authzAccount, arn.ELBv2ListenerRule, "app/prod/abc123/l1/r1")),
+		Actions: []*elbv2.Action{{
+			Type: aws.String("forward"),
+			ForwardConfig: &elbv2.ForwardActionConfig{
+				TargetGroups: []*elbv2.TargetGroupTuple{
+					{TargetGroupArn: aws.String(tgARN("blue", "1"))},
+					{TargetGroupArn: aws.String(tgARN("green", "2"))},
+				},
+			},
+		}},
+	})
+	assert.Contains(t, resources, tgARN("blue", "1"))
+	assert.Contains(t, resources, tgARN("green", "2"))
+}
+
+func TestResourceARNs_ListsEveryMember(t *testing.T) {
+	assert.Equal(t, []string{tgARN("a", "1"), tgARN("b", "2")},
+		resolveARNs(t, "AddTags", &elbv2.AddTagsInput{
+			ResourceArns: []*string{aws.String(tgARN("a", "1")), aws.String(tgARN("b", "2"))},
+		}))
+
+	assert.Equal(t, []string{lbARN("one", "1"), lbARN("two", "2")},
+		resolveARNs(t, "DescribeTags", &elbv2.DescribeTagsInput{
+			ResourceArns: []*string{aws.String(lbARN("one", "1")), aws.String(lbARN("two", "2"))},
+		}))
+
+	rule := func(id string) string {
+		return arn.FormatELBv2Resource(authzRegion, authzAccount, arn.ELBv2ListenerRule, "app/prod/abc123/l1/"+id)
+	}
+	assert.Equal(t, []string{rule("r1"), rule("r2")},
+		resolveARNs(t, "SetRulePriorities", &elbv2.SetRulePrioritiesInput{
+			RulePriorities: []*elbv2.RulePriorityPair{
+				{RuleArn: aws.String(rule("r1")), Priority: aws.Int64(1)},
+				{RuleArn: aws.String(rule("r2")), Priority: aws.Int64(2)},
+			},
+		}))
+}
+
+// An identifier the request omits leaves the call account-wide, so the
+// resulting MissingParameter stays the handler's to report.
+func TestResourceARNs_AbsentIdentifier(t *testing.T) {
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "DeleteLoadBalancer", &elbv2.DeleteLoadBalancerInput{}))
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "CreateTargetGroup", &elbv2.CreateTargetGroupInput{}))
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "AddTags", &elbv2.AddTagsInput{}))
+	assert.Equal(t, []string{"*"}, resolveARNs(t, "SetRulePriorities", &elbv2.SetRulePrioritiesInput{}))
+}
+
+// The seven account-wide actions are explicit entries, not omissions.
+func TestResourceARNs_AccountWideActions(t *testing.T) {
+	for _, action := range []string{
+		"DescribeLoadBalancers", "DescribeTargetGroups", "DescribeListeners",
+		"DescribeRules", "DescribeSSLPolicies", "LBAgentHeartbeat", "GetLBConfig",
+	} {
+		assert.True(t, HasScope(action), action)
+		assert.Equal(t, []string{"*"}, resolveARNs(t, action, &elbv2.DescribeLoadBalancersInput{}), action)
+	}
+}
+
+// A caller's spelling is parsed, not passed through: authorizing an ARN that
+// names another account lets the gate and the handler address different objects.
+func TestResourceARNs_RejectsForeignARNs(t *testing.T) {
+	rejected := map[string]string{
+		"another account":    arn.FormatELBv2LoadBalancer(authzRegion, "999999999999", "prod", "abc", "application"),
+		"another region":     arn.FormatELBv2LoadBalancer("us-east-1", authzAccount, "prod", "abc", "application"),
+		"another partition":  "arn:aws-cn:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer/app/prod/abc",
+		"another service":    "arn:aws:ec2:ap-southeast-2:123456789012:instance/i-abc",
+		"unknown type":       "arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:widget/prod/abc",
+		"not an arn at all":  "prod",
+		"no resource at all": "arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer/",
+	}
+	for name, value := range rejected {
+		_, err := ResourceARNs("DeleteLoadBalancer", authzRegion, authzAccount, &elbv2.DeleteLoadBalancerInput{
+			LoadBalancerArn: aws.String(value),
+		})
+		require.Error(t, err, name)
+		code, ok := awserrors.ResolveErrorCode(err)
+		require.True(t, ok, name)
+		assert.Equal(t, awserrors.ErrorInvalidParameterValue, code, name)
+	}
+}
+
+// A parent of the wrong type cannot derive a child, and must not silently
+// produce an ARN naming a resource nobody asked for.
+func TestResourceARNs_DerivedChildRejectsWrongParent(t *testing.T) {
+	_, err := ResourceARNs("CreateListener", authzRegion, authzAccount, &elbv2.CreateListenerInput{
+		LoadBalancerArn: aws.String(tgARN("web", "def456")),
+	})
+	require.Error(t, err)
+	code, ok := awserrors.ResolveErrorCode(err)
+	require.True(t, ok)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, code)
+}

--- a/spinifex/gateway/elbv2/authz_test.go
+++ b/spinifex/gateway/elbv2/authz_test.go
@@ -1,6 +1,7 @@
 package gateway_elbv2
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -142,6 +143,34 @@ func TestResourceARNs_ForwardConfigTargetGroups(t *testing.T) {
 	})
 	assert.Contains(t, resources, tgARN("blue", "1"))
 	assert.Contains(t, resources, tgARN("green", "2"))
+}
+
+// A rule's actions nest a target-group list inside each action, so the fan-out
+// can exceed what any one list holds. Resolving it is quadratic in the member
+// count, and it runs before the policy check, so the bound is load-bearing.
+func TestResourceARNs_BoundsNestedFanOut(t *testing.T) {
+	actions := make([]*elbv2.Action, 0, 64)
+	for a := 0; a < 64; a++ {
+		tgs := make([]*elbv2.TargetGroupTuple, 0, 64)
+		for m := 0; m < 64; m++ {
+			tgs = append(tgs, &elbv2.TargetGroupTuple{
+				TargetGroupArn: aws.String(tgARN(fmt.Sprintf("tg%d-%d", a, m), "1")),
+			})
+		}
+		actions = append(actions, &elbv2.Action{
+			Type:          aws.String("forward"),
+			ForwardConfig: &elbv2.ForwardActionConfig{TargetGroups: tgs},
+		})
+	}
+
+	_, err := ResourceARNs("CreateRule", authzRegion, authzAccount, &elbv2.CreateRuleInput{
+		ListenerArn: aws.String(listenerARN("prod", "abc123", "l1")),
+		Actions:     actions,
+	})
+	require.Error(t, err)
+	code, ok := awserrors.ResolveErrorCode(err)
+	require.True(t, ok)
+	assert.Equal(t, awserrors.ErrorMalformedQueryString, code)
 }
 
 func TestResourceARNs_ListsEveryMember(t *testing.T) {

--- a/spinifex/gateway/elbv2_authz_completeness_test.go
+++ b/spinifex/gateway/elbv2_authz_completeness_test.go
@@ -1,0 +1,27 @@
+//test:in-package — elbv2Actions is unexported here, and the completeness test
+// exists to compare it against the scope table.
+
+package gateway
+
+import (
+	"testing"
+
+	gateway_elbv2 "github.com/mulgadc/spinifex/spinifex/gateway/elbv2"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestELBv2ScopeTableIsExhaustive is what stops the next ELBv2 action being
+// added with a silent account-wide grant. It asserts both directions, so a
+// scope left behind by a deleted or renamed action fails too.
+func TestELBv2ScopeTableIsExhaustive(t *testing.T) {
+	for action := range elbv2Actions {
+		assert.True(t, gateway_elbv2.HasScope(action),
+			"elbv2 action %q has no resource scope entry: add one to elbv2Scopes in gateway/elbv2/authz.go", action)
+	}
+
+	for _, action := range gateway_elbv2.ScopedActions() {
+		_, ok := elbv2Actions[action]
+		assert.True(t, ok,
+			"elbv2Scopes has an entry for %q, which the dispatch table does not serve: remove it from gateway/elbv2/authz.go", action)
+	}
+}

--- a/spinifex/gateway/elbv2_authz_test.go
+++ b/spinifex/gateway/elbv2_authz_test.go
@@ -1,0 +1,238 @@
+//test:in-package — drives ELBv2_Request through the gateway's unexported test
+// helpers (scopedPolicyGateway, withTestIdentity) and auth context keys.
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/arn"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func elbv2LB(name, id string) string {
+	return arn.FormatELBv2LoadBalancer(authzRegion, authzAccountID, name, id, "application")
+}
+
+func elbv2TG(name, id string) string {
+	return arn.FormatELBv2TargetGroup(authzRegion, authzAccountID, name, id)
+}
+
+func elbv2Listener(lbName, lbID, id string) string {
+	return arn.FormatELBv2Listener(authzRegion, authzAccountID, lbName, lbID, id, "application")
+}
+
+// dispatchELBv2 drives the gateway with no NATS connection. A permitted request
+// therefore reaches the NATS guard and fails there, which is what proves the
+// policy check ran ahead of the resource having to exist.
+func dispatchELBv2(t *testing.T, gw *GatewayConfig, body string) error {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), ctxService, "elasticloadbalancing")
+	ctx = context.WithValue(ctx, ctxAccountID, authzAccountID)
+	return gw.ELBv2_Request(httptest.NewRecorder(), withTestIdentity(req.WithContext(ctx)))
+}
+
+// TestELBv2Request_ScopedDenyFires is the bypass this work closes. An operator
+// fences a production load balancer; before the resolver the fence was inert
+// and DeleteLoadBalancer against it was permitted with nothing logged.
+func TestELBv2Request_ScopedDenyFires(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "elasticloadbalancing:*", "*"),
+		statement("Deny", "elasticloadbalancing:DeleteLoadBalancer", elbv2LB("prod", "abc123")),
+	)
+
+	assertDenied(t, dispatchELBv2(t, gw, "Action=DeleteLoadBalancer&LoadBalancerArn="+elbv2LB("prod", "abc123")))
+	assertPermitted(t, dispatchELBv2(t, gw, "Action=DeleteLoadBalancer&LoadBalancerArn="+elbv2LB("dev", "def456")))
+}
+
+// TestELBv2Request_ScopedAllowGrants is the other half: a least-privilege
+// policy used to deny everything, so the only working shape was Resource "*".
+// The sibling is denied rather than not-found, because the gate runs first.
+func TestELBv2Request_ScopedAllowGrants(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "elasticloadbalancing:RegisterTargets", elbv2TG("web", "def456")),
+	)
+
+	assertPermitted(t, dispatchELBv2(t, gw, "Action=RegisterTargets&TargetGroupArn="+elbv2TG("web", "def456")))
+	assertDenied(t, dispatchELBv2(t, gw, "Action=RegisterTargets&TargetGroupArn="+elbv2TG("other", "def456")))
+}
+
+// A create-time fence is what a name-prefix convention depends on, and it can
+// only fire because the create resolves to the name it asks for.
+func TestELBv2Request_CreateScopedByName(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "elasticloadbalancing:*", "*"),
+		statement("Deny", "elasticloadbalancing:CreateLoadBalancer",
+			"arn:aws:elasticloadbalancing:*:*:loadbalancer/app/prod-*"),
+	)
+
+	assertDenied(t, dispatchELBv2(t, gw, "Action=CreateLoadBalancer&Name=prod-web"))
+	assertPermitted(t, dispatchELBv2(t, gw, "Action=CreateLoadBalancer&Name=dev-web"))
+}
+
+// A listener is denied on its target group even though its load balancer is
+// permitted: every resource AWS evaluates is evaluated here too.
+func TestELBv2Request_MultiResourceParity(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "elasticloadbalancing:*", "*"),
+		statement("Deny", "elasticloadbalancing:CreateListener", elbv2TG("restricted", "1")),
+	)
+
+	assertDenied(t, dispatchELBv2(t, gw,
+		"Action=CreateListener&LoadBalancerArn="+elbv2LB("prod", "abc123")+
+			"&DefaultActions.member.1.Type=forward&DefaultActions.member.1.TargetGroupArn="+elbv2TG("restricted", "1")))
+	assertPermitted(t, dispatchELBv2(t, gw,
+		"Action=CreateListener&LoadBalancerArn="+elbv2LB("prod", "abc123")+
+			"&DefaultActions.member.1.Type=forward&DefaultActions.member.1.TargetGroupArn="+elbv2TG("allowed", "2")))
+}
+
+// A redirect-only default action names no target group, so the call stays
+// scoped to the load balancer rather than widening to "*".
+func TestELBv2Request_RedirectActionDoesNotWiden(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "elasticloadbalancing:CreateListener", elbv2LB("prod", "abc123")),
+		statement("Allow", "elasticloadbalancing:CreateListener",
+			"arn:aws:elasticloadbalancing:*:*:listener/app/prod/abc123/*"),
+	)
+
+	assertPermitted(t, dispatchELBv2(t, gw,
+		"Action=CreateListener&LoadBalancerArn="+elbv2LB("prod", "abc123")+
+			"&DefaultActions.member.1.Type=redirect"))
+}
+
+// One fenced member fails the batch whole, which is AWS's combining rule.
+func TestELBv2Request_DenyOneTagMemberFailsTheBatch(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "elasticloadbalancing:*", "*"),
+		statement("Deny", "elasticloadbalancing:AddTags", elbv2LB("prod", "abc123")),
+	)
+
+	assertDenied(t, dispatchELBv2(t, gw,
+		"Action=AddTags&ResourceArns.member.1="+elbv2TG("web", "1")+
+			"&ResourceArns.member.2="+elbv2LB("prod", "abc123")+
+			"&Tags.member.1.Key=env&Tags.member.1.Value=prod"))
+	assertPermitted(t, dispatchELBv2(t, gw,
+		"Action=AddTags&ResourceArns.member.1="+elbv2TG("web", "1")+
+			"&Tags.member.1.Key=env&Tags.member.1.Value=prod"))
+}
+
+// An ARN naming another account is rejected at the gate rather than authorized
+// verbatim and left for the handler to fail as a not-found.
+func TestELBv2Request_ForeignAccountARNRejected(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "elasticloadbalancing:*", "*"))
+
+	err := dispatchELBv2(t, gw, "Action=DeleteLoadBalancer&LoadBalancerArn="+
+		arn.FormatELBv2LoadBalancer(authzRegion, "999999999999", "prod", "abc123", "application"))
+	require.Error(t, err)
+	code, ok := awserrors.ResolveErrorCode(err)
+	require.True(t, ok)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, code)
+
+	err = dispatchELBv2(t, gw, "Action=DeleteLoadBalancer&LoadBalancerArn="+
+		arn.FormatELBv2LoadBalancer("us-east-1", authzAccountID, "prod", "abc123", "application"))
+	require.Error(t, err)
+	code, ok = awserrors.ResolveErrorCode(err)
+	require.True(t, ok)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, code)
+}
+
+// An absent identifier authorizes account-wide, leaving the validation fault
+// where it belongs: with the handler.
+func TestELBv2Request_AbsentIdentifierStaysHandlerFault(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "elasticloadbalancing:*", "*"))
+
+	assertPermitted(t, dispatchELBv2(t, gw, "Action=DeleteLoadBalancer"))
+	assertDenied(t, dispatchELBv2(t,
+		scopedPolicyGateway(statement("Allow", "elasticloadbalancing:*", elbv2LB("prod", "abc123"))),
+		"Action=DeleteLoadBalancer"))
+}
+
+// A missing account ID returns InternalError, which is the code the policy gate
+// returned before the read was hoisted above it.
+func TestELBv2Request_MissingAccountIDIsInternalError(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "elasticloadbalancing:*", "*"))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("Action=DescribeLoadBalancers"))
+	ctx := context.WithValue(req.Context(), ctxService, "elasticloadbalancing")
+	err := gw.ELBv2_Request(httptest.NewRecorder(), withTestIdentity(req.WithContext(ctx)))
+
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
+}
+
+// Non-regression: an account-wide Allow still permits every scoped action once
+// a real ARN is passed, so scoping did not quietly deny working policies.
+func TestELBv2Request_AccountWideAllowStillPermitsEveryScopedAction(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "elasticloadbalancing:*", "*"))
+
+	lb := elbv2LB("prod", "abc123")
+	tg := elbv2TG("web", "def456")
+	listener := elbv2Listener("prod", "abc123", "l1")
+	rule := arn.FormatELBv2Resource(authzRegion, authzAccountID, arn.ELBv2ListenerRule, "app/prod/abc123/l1/r1")
+
+	bodies := map[string]string{
+		"CreateLoadBalancer":             "Action=CreateLoadBalancer&Name=prod",
+		"DeleteLoadBalancer":             "Action=DeleteLoadBalancer&LoadBalancerArn=" + lb,
+		"ModifyLoadBalancerAttributes":   "Action=ModifyLoadBalancerAttributes&LoadBalancerArn=" + lb,
+		"DescribeLoadBalancerAttributes": "Action=DescribeLoadBalancerAttributes&LoadBalancerArn=" + lb,
+		"SetSecurityGroups":              "Action=SetSecurityGroups&LoadBalancerArn=" + lb,
+		"SetSubnets":                     "Action=SetSubnets&LoadBalancerArn=" + lb,
+		"SetIpAddressType":               "Action=SetIpAddressType&LoadBalancerArn=" + lb,
+		"CreateTargetGroup":              "Action=CreateTargetGroup&Name=web",
+		"DeleteTargetGroup":              "Action=DeleteTargetGroup&TargetGroupArn=" + tg,
+		"ModifyTargetGroup":              "Action=ModifyTargetGroup&TargetGroupArn=" + tg,
+		"ModifyTargetGroupAttributes":    "Action=ModifyTargetGroupAttributes&TargetGroupArn=" + tg,
+		"DescribeTargetGroupAttributes":  "Action=DescribeTargetGroupAttributes&TargetGroupArn=" + tg,
+		"RegisterTargets":                "Action=RegisterTargets&TargetGroupArn=" + tg,
+		"DeregisterTargets":              "Action=DeregisterTargets&TargetGroupArn=" + tg,
+		"DescribeTargetHealth":           "Action=DescribeTargetHealth&TargetGroupArn=" + tg,
+		"CreateListener":                 "Action=CreateListener&LoadBalancerArn=" + lb,
+		"ModifyListener":                 "Action=ModifyListener&ListenerArn=" + listener,
+		"DeleteListener":                 "Action=DeleteListener&ListenerArn=" + listener,
+		"AddListenerCertificates":        "Action=AddListenerCertificates&ListenerArn=" + listener,
+		"RemoveListenerCertificates":     "Action=RemoveListenerCertificates&ListenerArn=" + listener,
+		"DescribeListenerCertificates":   "Action=DescribeListenerCertificates&ListenerArn=" + listener,
+		"DescribeListenerAttributes":     "Action=DescribeListenerAttributes&ListenerArn=" + listener,
+		"ModifyListenerAttributes":       "Action=ModifyListenerAttributes&ListenerArn=" + listener,
+		"CreateRule":                     "Action=CreateRule&ListenerArn=" + listener,
+		"ModifyRule":                     "Action=ModifyRule&RuleArn=" + rule,
+		"DeleteRule":                     "Action=DeleteRule&RuleArn=" + rule,
+		"SetRulePriorities":              "Action=SetRulePriorities&RulePriorities.member.1.RuleArn=" + rule,
+		"AddTags":                        "Action=AddTags&ResourceArns.member.1=" + lb,
+		"RemoveTags":                     "Action=RemoveTags&ResourceArns.member.1=" + lb,
+		"DescribeTags":                   "Action=DescribeTags&ResourceArns.member.1=" + lb,
+	}
+
+	// Every scoped action is covered, so a new one cannot land here untested.
+	for action := range elbv2Actions {
+		if _, unscoped := elbv2UnscopedActions[action]; unscoped {
+			continue
+		}
+		require.Contains(t, bodies, action, "add %q to the non-regression table", action)
+	}
+
+	for action, body := range bodies {
+		t.Run(action, func(t *testing.T) {
+			assertPermitted(t, dispatchELBv2(t, gw, body))
+		})
+	}
+}
+
+// The seven actions AWS documents no resource type for, listed here so the
+// non-regression table above can assert it covers everything else.
+var elbv2UnscopedActions = map[string]struct{}{
+	"DescribeLoadBalancers": {},
+	"DescribeTargetGroups":  {},
+	"DescribeListeners":     {},
+	"DescribeRules":         {},
+	"DescribeSSLPolicies":   {},
+	"LBAgentHeartbeat":      {},
+	"GetLBConfig":           {},
+}

--- a/spinifex/handlers/elbv2/arn_test.go
+++ b/spinifex/handlers/elbv2/arn_test.go
@@ -16,31 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildLBArn(t *testing.T) {
-	arn := buildLBArn("us-east-1", "123456789012", "my-alb", "50dc6c495c0c9188", LoadBalancerTypeApplication)
-	assert.Equal(t, "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/50dc6c495c0c9188", arn)
-}
-
-func TestBuildLBArn_Network(t *testing.T) {
-	arn := buildLBArn("us-east-1", "123456789012", "my-nlb", "50dc6c495c0c9188", LoadBalancerTypeNetwork)
-	assert.Equal(t, "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/my-nlb/50dc6c495c0c9188", arn)
-}
-
-func TestBuildTGArn(t *testing.T) {
-	arn := buildTGArn("us-west-2", "111222333444", "my-tg", "deadbeef")
-	assert.Equal(t, "arn:aws:elasticloadbalancing:us-west-2:111222333444:targetgroup/my-tg/deadbeef", arn)
-}
-
-func TestBuildListenerArn(t *testing.T) {
-	arn := buildListenerArn("eu-west-1", "999888777666", "my-alb", "lbid123", "listener456", LoadBalancerTypeApplication)
-	assert.Equal(t, "arn:aws:elasticloadbalancing:eu-west-1:999888777666:listener/app/my-alb/lbid123/listener456", arn)
-}
-
-func TestBuildListenerArn_NLB(t *testing.T) {
-	arn := buildListenerArn("eu-west-1", "999888777666", "my-nlb", "lbid123", "listener456", LoadBalancerTypeNetwork)
-	assert.Equal(t, "arn:aws:elasticloadbalancing:eu-west-1:999888777666:listener/net/my-nlb/lbid123/listener456", arn)
-}
-
 // TestBuildLBAgentEnv verifies that buildLBAgentEnv produces a KEY=value blob
 // containing all five env vars with the correct values.
 func TestBuildLBAgentEnv(t *testing.T) {

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	resourcearn "github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	handlers_acm "github.com/mulgadc/spinifex/spinifex/handlers/acm"
@@ -1139,20 +1140,6 @@ func certFilesToSDK(certFiles map[string]string) []*CertFile {
 	return out
 }
 
-// lbArnPathSegment returns the ARN path segment for the given LB type:
-// "app" for application LBs, "net" for network LBs.
-func lbArnPathSegment(lbType string) string {
-	if lbType == LoadBalancerTypeNetwork {
-		return "net"
-	}
-	return "app"
-}
-
-// buildLBArn constructs a load balancer ARN from components.
-func buildLBArn(region, accountID, name, lbID, lbType string) string {
-	return fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:loadbalancer/%s/%s/%s", region, accountID, lbArnPathSegment(lbType), name, lbID)
-}
-
 // resolveTargetIP looks up the private IP for an instance by finding its primary ENI.
 // Returns empty string if VPC service is unavailable or no ENI found.
 func (s *ELBv2ServiceImpl) resolveTargetIP(ctx context.Context, instanceID, accountID string) string {
@@ -1197,43 +1184,15 @@ func (s *ELBv2ServiceImpl) resolveRegisteredTargetIP(ctx context.Context, target
 	}
 }
 
-// buildTGArn constructs a target group ARN from components.
-func buildTGArn(region, accountID, name, tgID string) string {
-	return fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:targetgroup/%s/%s", region, accountID, name, tgID)
-}
-
-// buildListenerArn constructs a listener ARN from components.
-func buildListenerArn(region, accountID, lbName, lbID, listenerID, lbType string) string {
-	return fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:listener/%s/%s/%s/%s", region, accountID, lbArnPathSegment(lbType), lbName, lbID, listenerID)
-}
-
-// ELBv2 resource types as they appear in the resource segment of an ARN.
-const (
-	elbv2ResourceLoadBalancer = "loadbalancer"
-	elbv2ResourceTargetGroup  = "targetgroup"
-	elbv2ResourceListener     = "listener"
-	elbv2ResourceListenerRule = "listener-rule"
-)
-
-// elbv2ResourceTypeFromArn extracts the resource type from an ELBv2 ARN,
-// returning one of "loadbalancer", "targetgroup", "listener", "listener-rule".
-func elbv2ResourceTypeFromArn(arn string) (string, error) {
-	parts := strings.SplitN(arn, ":", 6)
-	if len(parts) < 6 || parts[0] != "arn" || parts[2] != "elasticloadbalancing" {
+// elbv2ResourceTypeFromArn extracts the resource type from an ELBv2 ARN. The
+// gateway's policy resolver parses the same ARNs with the same rules, so the
+// two cannot disagree about which object a request addresses.
+func elbv2ResourceTypeFromArn(arn string) (resourcearn.ELBv2ResourceType, error) {
+	parsed, ok := resourcearn.ParseELBv2(arn)
+	if !ok {
 		return "", errors.New(awserrors.ErrorInvalidParameterValue)
 	}
-	resourceSegment := parts[5]
-	slash := strings.Index(resourceSegment, "/")
-	if slash <= 0 {
-		return "", errors.New(awserrors.ErrorInvalidParameterValue)
-	}
-	resourceType := resourceSegment[:slash]
-	switch resourceType {
-	case elbv2ResourceLoadBalancer, elbv2ResourceTargetGroup, elbv2ResourceListener, elbv2ResourceListenerRule:
-		return resourceType, nil
-	default:
-		return "", errors.New(awserrors.ErrorInvalidParameterValue)
-	}
+	return parsed.Kind, nil
 }
 
 // isCompatibleProtocol reports whether a listener protocol is compatible with a target group protocol.
@@ -1329,8 +1288,8 @@ func (s *ELBv2ServiceImpl) createLoadBalancer(ctx context.Context, input *elbv2.
 	}
 
 	lbID := utils.GenerateResourceID("lb")
-	lbArn := buildLBArn(s.region, accountID, name, lbID, lbType)
-	arnPathSegment := lbArnPathSegment(lbType)
+	lbArn := resourcearn.FormatELBv2LoadBalancer(s.region, accountID, name, lbID, lbType)
+	arnPathSegment := resourcearn.ELBv2LBPathSegment(lbType)
 	dnsPrefix := ""
 	if scheme == SchemeInternal {
 		dnsPrefix = "internal-"
@@ -2022,7 +1981,7 @@ func (s *ELBv2ServiceImpl) CreateTargetGroup(ctx context.Context, input *elbv2.C
 	}
 
 	tgID := utils.GenerateResourceID("tg")
-	tgArn := buildTGArn(s.region, accountID, name, tgID)
+	tgArn := resourcearn.FormatELBv2TargetGroup(s.region, accountID, name, tgID)
 
 	tags := tagsFromSDK(input.Tags)
 
@@ -2654,7 +2613,7 @@ func (s *ELBv2ServiceImpl) CreateListener(ctx context.Context, input *elbv2.Crea
 	}
 
 	listenerID := utils.GenerateResourceID("lst")
-	listenerArn := buildListenerArn(s.region, accountID, lb.Name, lb.LoadBalancerID, listenerID, lb.Type)
+	listenerArn := resourcearn.FormatELBv2Listener(s.region, accountID, lb.Name, lb.LoadBalancerID, listenerID, lb.Type)
 
 	var actions []ListenerAction
 	for _, a := range input.DefaultActions {
@@ -3045,7 +3004,7 @@ func (s *ELBv2ServiceImpl) DescribeTags(ctx context.Context, input *elbv2.Descri
 			found         bool
 		)
 		switch resourceType {
-		case elbv2ResourceLoadBalancer:
+		case resourcearn.ELBv2LoadBalancer:
 			notFoundError = awserrors.ErrorELBv2LoadBalancerNotFound
 			lb, lbErr := s.store.GetLoadBalancerByArn(ctx, arn)
 			if lbErr != nil {
@@ -3057,7 +3016,7 @@ func (s *ELBv2ServiceImpl) DescribeTags(ctx context.Context, input *elbv2.Descri
 				tags = lb.Tags
 				ownerAccount = lb.AccountID
 			}
-		case elbv2ResourceTargetGroup:
+		case resourcearn.ELBv2TargetGroup:
 			notFoundError = awserrors.ErrorELBv2TargetGroupNotFound
 			tg, tgErr := s.store.GetTargetGroupByArn(ctx, arn)
 			if tgErr != nil {
@@ -3069,7 +3028,7 @@ func (s *ELBv2ServiceImpl) DescribeTags(ctx context.Context, input *elbv2.Descri
 				tags = tg.Tags
 				ownerAccount = tg.AccountID
 			}
-		case elbv2ResourceListener:
+		case resourcearn.ELBv2Listener:
 			notFoundError = awserrors.ErrorELBv2ListenerNotFound
 			l, lErr := s.store.GetListenerByArn(ctx, arn)
 			if lErr != nil {
@@ -3081,7 +3040,7 @@ func (s *ELBv2ServiceImpl) DescribeTags(ctx context.Context, input *elbv2.Descri
 				tags = l.Tags
 				ownerAccount = l.AccountID
 			}
-		case elbv2ResourceListenerRule:
+		case resourcearn.ELBv2ListenerRule:
 			notFoundError = awserrors.ErrorELBv2RuleNotFound
 			r, rErr := s.store.GetRuleByArn(ctx, arn)
 			if rErr != nil {

--- a/spinifex/handlers/elbv2/service_impl_tags.go
+++ b/spinifex/handlers/elbv2/service_impl_tags.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	resourcearn "github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
@@ -28,7 +29,7 @@ func (s *ELBv2ServiceImpl) resolveTaggable(ctx context.Context, arn string) (h t
 	}
 
 	switch resourceType {
-	case elbv2ResourceLoadBalancer:
+	case resourcearn.ELBv2LoadBalancer:
 		notFoundError = awserrors.ErrorELBv2LoadBalancerNotFound
 		lb, e := s.store.GetLoadBalancerByArn(ctx, arn)
 		if e != nil {
@@ -42,7 +43,7 @@ func (s *ELBv2ServiceImpl) resolveTaggable(ctx context.Context, arn string) (h t
 				return s.store.PutLoadBalancer(ctx, lb)
 			}}
 		}
-	case elbv2ResourceTargetGroup:
+	case resourcearn.ELBv2TargetGroup:
 		notFoundError = awserrors.ErrorELBv2TargetGroupNotFound
 		tg, e := s.store.GetTargetGroupByArn(ctx, arn)
 		if e != nil {
@@ -56,7 +57,7 @@ func (s *ELBv2ServiceImpl) resolveTaggable(ctx context.Context, arn string) (h t
 				return s.store.PutTargetGroup(ctx, tg)
 			}}
 		}
-	case elbv2ResourceListener:
+	case resourcearn.ELBv2Listener:
 		notFoundError = awserrors.ErrorELBv2ListenerNotFound
 		l, e := s.store.GetListenerByArn(ctx, arn)
 		if e != nil {
@@ -70,7 +71,7 @@ func (s *ELBv2ServiceImpl) resolveTaggable(ctx context.Context, arn string) (h t
 				return s.store.PutListener(ctx, l)
 			}}
 		}
-	case elbv2ResourceListenerRule:
+	case resourcearn.ELBv2ListenerRule:
 		notFoundError = awserrors.ErrorELBv2RuleNotFound
 		r, e := s.store.GetRuleByArn(ctx, arn)
 		if e != nil {


### PR DESCRIPTION
## Problem

`ELBv2_Request` resolved the action and then called `gw.checkPolicy`, which evaluates against the literal resource `"*"`. The evaluator matches a statement's `Resource` as a *pattern* against the request's resource as a *value*, so a statement scoped to a load balancer, target group, listener or rule ARN never matched: a scoped Deny failed open and a scoped Allow failed closed. All 37 ELBv2 actions were enforceable only account-wide.

## Changes

**`spinifex/arn/elbv2.go` (new)** — ELBv2 resource types, the load balancer path segment, the three ARN builders and `ParseELBv2`. The handler's four private builders and `elbv2ResourceTypeFromArn` move here, so the ARN the gate authorizes and the ARN persisted on the record cannot drift onto different formats. Wire output is byte-for-byte unchanged.

**`spinifex/gateway/elbv2/authz.go` (new)** — the exhaustive 37-action scope table, the resolver, `HasScope` and `ScopedActions`. 30 actions resolve a real ELBv2 resource; 7 are account-wide with the reason named in the table rather than omitted.

**`spinifex/gateway/elbv2.go`** — split into parse and dispatch so authorization and execution share one typed input, the account-ID read hoisted above the gate, and `checkPolicyResources` called with the resolved ARNs.

### Caller-supplied ARNs are parsed, not passed through

Every non-create scope reads an ARN the caller wrote. The resolver requires `arn:aws:elasticloadbalancing`, a known resource type, this endpoint's region and the caller's own account; anything else is `InvalidParameterValue` before the evaluator sees it. This is the RDS `taggedResourceScope` rule, and it exists because authorizing a caller's spelling verbatim lets the gate and the handler disagree about which account's object is being addressed.

Two behaviour changes follow, both on requests that fail today anyway: an ARN naming another account or region now returns `InvalidParameterValue` at the gate instead of the handler's not-found, and the partition is checked. The store already refuses to serve a record whose ARN does not match byte-for-byte, so no request that succeeds today changes.

### The created resource is derived from its parent

The four creates resolve to a `*` short id under a path the parent ARN or the requested name already fixes — `loadbalancer/app/<Name>/*`, `targetgroup/<Name>/*`, and for listeners and rules the parent's resource part retyped. That makes `Deny elasticloadbalancing:CreateLoadBalancer on arn:aws:elasticloadbalancing:*:*:loadbalancer/app/prod-*` fire, which is the create-time fence a name-prefix convention depends on.

## One deviation from the plan

The dotted field-path reader EC2's resolver held privately (`stringValuesAt`) is now `awsec2query.StringValuesAt`, shared by both resolvers rather than duplicated into the ELBv2 one. `gateway/ec2/authz.go` is a pure call-site swap; its tests are unchanged and green.

## Out of scope

- `LBAgentHeartbeat` and `GetLBConfig` carry only `LBID`, the load balancer's short id, and recovering its name and type to build an ARN needs a NATS round trip on every agent heartbeat. Both authorize account-wide. Building `loadbalancer/*/*/<id>` was rejected: those `*` are values, so the ARN still would not match a Deny naming the real load balancer while looking as though it does. Recorded as `mulga-19z1o`.
- Naming a created resource's short id in a Deny, which cannot exist at create time.

## Testing

- **Scoped Deny** fires on the named load balancer and permits a sibling; **scoped Allow** grants the named target group and denies a sibling with `AccessDenied`, not a not-found.
- **Completeness**, both directions, against `elbv2Actions`.
- **ARN fidelity** per resource class and for the four creates, with the derived listener ARN asserted to be the shared builder's output with the short id replaced by `*`.
- **Multi-resource parity**: `CreateListener` denied on its target group even though the load balancer is permitted; a redirect-only default action leaves the call scoped to the load balancer rather than widening it.
- **Foreign account, region and partition**, **absent identifier**, and **error ordering** (a missing account ID returns `InternalError`, the code the policy gate returned before the hoist).
- **Non-regression**: `Allow elasticloadbalancing:* on *` still permits all 30 scoped actions, and the table is asserted to cover every scoped action so a new one cannot land untested.
- `make preflight` passes.