### PR TITLE
fix: scope policy checks for the JSON-body services

### DIFF
--- a/spinifex/gateway/bedrock.go
+++ b/spinifex/gateway/bedrock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -196,24 +195,19 @@ func (gw *GatewayConfig) Bedrock_Request(w http.ResponseWriter, r *http.Request)
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "bedrock", action); err != nil {
-		return err
-	}
-
-	if gw.NATSConn == nil {
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-
+	// Hoisted above the policy check because the resolver builds ARNs from it.
 	accountID, _ := r.Context().Value(ctxAccountID).(string)
 	if accountID == "" {
 		slog.ErrorContext(r.Context(), "Bedrock_Request: no account ID in auth context")
-		return errors.New(awserrors.ErrorServerInternal)
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
 	}
 
-	body, err := io.ReadAll(r.Body)
+	body, err := readBoundedBody(r)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "Bedrock_Request: failed to read body", "err", err)
-		return errors.New(awserrors.ErrorInvalidParameterValue)
+		return err
 	}
 
 	// Some REST-JSON actions carry their non-path inputs as singular query
@@ -233,6 +227,20 @@ func (gw *GatewayConfig) Bedrock_Request(w http.ResponseWriter, r *http.Request)
 				body = qb
 			}
 		}
+	}
+
+	// After the body read and the query fold: CreateProvisionedModelThroughput
+	// names the foundation model it commits there rather than in the path.
+	resources, err := gateway_bedrock.ResourceARNs("bedrock", action, gw.Region, accountID, params, body)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "bedrock", action, resources); err != nil {
+		return err
+	}
+
+	if gw.NATSConn == nil {
+		return errors.New(awserrors.ErrorServerInternal)
 	}
 
 	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockLoggingConfigStore(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), gw.bedrockGuardrailStore())

--- a/spinifex/gateway/bedrock/arn.go
+++ b/spinifex/gateway/bedrock/arn.go
@@ -87,6 +87,17 @@ func looksLikeProvisionedModelARN(modelID string) bool {
 	return strings.HasPrefix(modelID, "arn:") && strings.Contains(modelID, ":"+provisionedModelResourceType+"/")
 }
 
+// knowledgeBaseResourceType is the ARN resource-type segment a knowledge base
+// renders under. DataSource carries no ARN field in AWS's own shape (only
+// KnowledgeBase does), so there is no data-source counterpart.
+const knowledgeBaseResourceType = "knowledge-base"
+
+// FormatKnowledgeBaseARN builds the ARN a CreateKnowledgeBase call returns,
+// mirroring FormatGuardrailARN's shape.
+func FormatKnowledgeBaseARN(region, accountID, id string) string {
+	return fmt.Sprintf("arn:aws:bedrock:%s:%s:%s/%s", region, accountID, knowledgeBaseResourceType, id)
+}
+
 // guardrailResourceType is the ARN resource-type segment for a guardrail.
 const guardrailResourceType = "guardrail"
 

--- a/spinifex/gateway/bedrock/authz.go
+++ b/spinifex/gateway/bedrock/authz.go
@@ -1,0 +1,266 @@
+package gateway_bedrock
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sort"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
+)
+
+// The resource a policy check evaluates against when the request names nothing
+// in particular, or when the identifier cannot be resolved at gate time.
+const anyResource = "*"
+
+// Stands in for the id of a resource the request is about to create. It is a
+// value, so a policy scoped to the resource type matches it where "*" would
+// not; a Deny naming the stored id cannot fire, because it does not exist yet.
+const anyID = "*"
+
+// foundationModelResourceType is the ARN resource-type segment for a foundation
+// model. AWS spells these ARNs with an empty account segment, because the model
+// catalogue is not an account resource, and a policy written against AWS must
+// match here.
+const foundationModelResourceType = "foundation-model"
+
+// Where an action's resource is named. Path parameters come from the route
+// regex; body sources are read from the same JSON the handler unmarshals.
+type resourceSource uint8
+
+const (
+	sourceAny resourceSource = iota
+	sourceFoundationModelPath
+	sourceInferenceTargetPath
+	sourceGuardrailPath
+	sourceNewGuardrail
+	sourceProvisionedModelPath
+	sourceNewProvisionedModel
+	sourceProvisionedModelSourceBody
+	sourceKnowledgeBasePath
+	sourceNewKnowledgeBase
+	sourceKnowledgeBaseBody
+)
+
+// bedrockScopes holds one table per service the Bedrock family serves. They
+// share a package because they share the ARN builders and the id-or-ARN
+// spelling every Bedrock surface accepts. Exhaustive by contract: a
+// completeness test compares each table with its dispatch table in both
+// directions, so an action cannot be added with a silent account-wide grant.
+var bedrockScopes = map[string]map[string][]resourceSource{
+	"bedrock": {
+		// The model catalogue is not an account resource; the list is
+		// account-level and the get names one model.
+		"ListFoundationModels": {sourceAny},
+		"GetFoundationModel":   {sourceFoundationModelPath},
+
+		// The model-invocation logging configuration is account-level.
+		"PutModelInvocationLoggingConfiguration":    {sourceAny},
+		"GetModelInvocationLoggingConfiguration":    {sourceAny},
+		"DeleteModelInvocationLoggingConfiguration": {sourceAny},
+
+		// Provisioned throughput. A create evaluates the commitment it is about
+		// to create and the foundation model it commits, matching AWS.
+		"CreateProvisionedModelThroughput": {sourceNewProvisionedModel, sourceProvisionedModelSourceBody},
+		"GetProvisionedModelThroughput":    {sourceProvisionedModelPath},
+		"UpdateProvisionedModelThroughput": {sourceProvisionedModelPath},
+		"DeleteProvisionedModelThroughput": {sourceProvisionedModelPath},
+		"ListProvisionedModelThroughputs":  {sourceAny},
+
+		// Guardrails.
+		"CreateGuardrail":        {sourceNewGuardrail},
+		"GetGuardrail":           {sourceGuardrailPath},
+		"UpdateGuardrail":        {sourceGuardrailPath},
+		"DeleteGuardrail":        {sourceGuardrailPath},
+		"CreateGuardrailVersion": {sourceGuardrailPath},
+		"ListGuardrails":         {sourceAny},
+	},
+
+	"bedrock-runtime": {
+		// The path segment is a model id or a provisioned-throughput ARN, the
+		// same translation resolveInferenceTarget performs downstream.
+		"Converse":                      {sourceInferenceTargetPath},
+		"ConverseStream":                {sourceInferenceTargetPath},
+		"InvokeModel":                   {sourceInferenceTargetPath},
+		"InvokeModelWithResponseStream": {sourceInferenceTargetPath},
+		"ApplyGuardrail":                {sourceGuardrailPath},
+	},
+
+	// AWS's own DataSource shape carries no ARN, and the data-source and
+	// ingestion-job actions are evaluated against the knowledge base, so both
+	// path ids collapse to one resource.
+	"bedrock-agent": {
+		"CreateKnowledgeBase": {sourceNewKnowledgeBase},
+		"ListKnowledgeBases":  {sourceAny},
+		"GetKnowledgeBase":    {sourceKnowledgeBasePath},
+		"DeleteKnowledgeBase": {sourceKnowledgeBasePath},
+		"CreateDataSource":    {sourceKnowledgeBasePath},
+		"ListDataSources":     {sourceKnowledgeBasePath},
+		"GetDataSource":       {sourceKnowledgeBasePath},
+		"DeleteDataSource":    {sourceKnowledgeBasePath},
+		"StartIngestionJob":   {sourceKnowledgeBasePath},
+		"ListIngestionJobs":   {sourceKnowledgeBasePath},
+		"GetIngestionJob":     {sourceKnowledgeBasePath},
+	},
+
+	"bedrock-agent-runtime": {
+		"Retrieve":            {sourceKnowledgeBasePath},
+		"RetrieveAndGenerate": {sourceKnowledgeBaseBody},
+	},
+}
+
+// HasScope reports whether action has an explicit scope-table entry under
+// service.
+func HasScope(service, action string) bool {
+	_, ok := bedrockScopes[service][action]
+	return ok
+}
+
+// ScopedActions returns every action represented in service's scope table.
+func ScopedActions(service string) []string {
+	scopes := bedrockScopes[service]
+	actions := make([]string, 0, len(scopes))
+	for action := range scopes {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+	return actions
+}
+
+// ResourceARNs resolves the resources a Bedrock-family request authorizes
+// against from the path parameters and body the dispatcher already holds.
+// params are the route captures, already percent-decoded.
+func ResourceARNs(service, action, region, accountID string, params []string, body []byte) ([]string, error) {
+	sources, ok := bedrockScopes[service][action]
+	if !ok {
+		slog.Error("bedrock authz: action is served but absent from the scope table", "service", service, "action", action)
+		return nil, errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	scope := bodyscope.Parse(action, body)
+	resources := make([]string, 0, len(sources))
+	for _, source := range sources {
+		resource, err := resolve(source, service, action, region, accountID, params, scope)
+		if err != nil {
+			return nil, err
+		}
+		// An unresolved member drops out rather than contributing "*", which no
+		// scoped Allow can match and which would deny a call AWS permits.
+		if resource == anyResource || slices.Contains(resources, resource) {
+			continue
+		}
+		resources = append(resources, resource)
+	}
+	if len(resources) == 0 {
+		return []string{anyResource}, nil
+	}
+	return resources, nil
+}
+
+func resolve(source resourceSource, service, action, region, accountID string, params []string, scope bodyscope.Scope) (string, error) {
+	switch source {
+	case sourceAny:
+		return anyResource, nil
+
+	case sourceFoundationModelPath:
+		return foundationModelARN(region, param(params, 0)), nil
+
+	case sourceInferenceTargetPath:
+		return inferenceTargetARN(region, accountID, param(params, 0)), nil
+
+	case sourceGuardrailPath:
+		return guardrailARN(region, accountID, param(params, 0)), nil
+
+	case sourceNewGuardrail:
+		return FormatGuardrailARN(region, accountID, anyID), nil
+
+	case sourceProvisionedModelPath:
+		return provisionedModelARN(region, accountID, param(params, 0)), nil
+
+	case sourceNewProvisionedModel:
+		return FormatProvisionedModelARN(region, accountID, anyID), nil
+
+	case sourceProvisionedModelSourceBody:
+		return foundationModelARN(region, scope.String("modelId")), nil
+
+	case sourceKnowledgeBasePath:
+		return knowledgeBaseARN(region, accountID, param(params, 0)), nil
+
+	case sourceNewKnowledgeBase:
+		return FormatKnowledgeBaseARN(region, accountID, anyID), nil
+
+	case sourceKnowledgeBaseBody:
+		id := scope.Object("retrieveAndGenerateConfiguration").
+			Object("knowledgeBaseConfiguration").
+			String("knowledgeBaseId")
+		return knowledgeBaseARN(region, accountID, id), nil
+
+	default:
+		slog.Error("bedrock authz: unhandled resource source, failing closed",
+			"service", service, "action", action, "source", source)
+		return "", errors.New(awserrors.ErrorInternalError)
+	}
+}
+
+// An absent identifier authorizes account-wide, so a malformed request stays
+// the handler's validation fault rather than becoming an authorization failure.
+func foundationModelARN(region, modelID string) string {
+	if region == "" || modelID == "" {
+		return anyResource
+	}
+	return fmt.Sprintf("arn:aws:bedrock:%s::%s/%s", region, foundationModelResourceType, modelID)
+}
+
+// inferenceTargetARN names what the caller addressed: a commitment when the
+// modelId is a provisioned-throughput ARN, and the foundation model itself
+// otherwise, matching the translation resolveInferenceTarget performs.
+func inferenceTargetARN(region, accountID, modelID string) string {
+	if !looksLikeProvisionedModelARN(modelID) {
+		return foundationModelARN(region, modelID)
+	}
+	return provisionedModelARN(region, accountID, modelID)
+}
+
+// provisionedModelARN accepts the id-or-ARN spelling every PT op allows and
+// re-anchors it on gw.Region and the caller's account. An ARN naming another
+// account resolves account-wide: the handler rejects it, so a denial here would
+// replace a validation fault with an authorization one.
+func provisionedModelARN(region, accountID, idOrARN string) string {
+	if region == "" || accountID == "" || idOrARN == "" {
+		return anyResource
+	}
+	id, err := resolveProvisionedModelID(idOrARN, region, accountID)
+	if err != nil || id == "" {
+		return anyResource
+	}
+	return FormatProvisionedModelARN(region, accountID, id)
+}
+
+// guardrailARN accepts the id-or-ARN spelling every guardrail op allows,
+// mirroring provisionedModelARN.
+func guardrailARN(region, accountID, idOrARN string) string {
+	if region == "" || accountID == "" || idOrARN == "" {
+		return anyResource
+	}
+	id, err := resolveGuardrailID(idOrARN, region, accountID)
+	if err != nil || id == "" {
+		return anyResource
+	}
+	return FormatGuardrailARN(region, accountID, id)
+}
+
+func knowledgeBaseARN(region, accountID, id string) string {
+	if region == "" || accountID == "" || id == "" {
+		return anyResource
+	}
+	return FormatKnowledgeBaseARN(region, accountID, id)
+}
+
+func param(params []string, i int) string {
+	if i >= len(params) {
+		return ""
+	}
+	return params[i]
+}

--- a/spinifex/gateway/bedrock/authz.go
+++ b/spinifex/gateway/bedrock/authz.go
@@ -139,7 +139,11 @@ func ResourceARNs(service, action, region, accountID string, params []string, bo
 		return nil, errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	scope := bodyscope.Parse(action, body)
+	scope, err := bodyscope.Parse(action, body)
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
 	resources := make([]string, 0, len(sources))
 	for _, source := range sources {
 		resource, err := resolve(source, service, action, region, accountID, params, scope)
@@ -192,10 +196,15 @@ func resolve(source resourceSource, service, action, region, accountID string, p
 		return FormatKnowledgeBaseARN(region, accountID, anyID), nil
 
 	case sourceKnowledgeBaseBody:
-		id := scope.Object("retrieveAndGenerateConfiguration").
-			Object("knowledgeBaseConfiguration").
-			String("knowledgeBaseId")
-		return knowledgeBaseARN(region, accountID, id), nil
+		config, err := scope.Object("retrieveAndGenerateConfiguration")
+		if err != nil {
+			return "", errors.New(awserrors.ErrorInvalidParameterValue)
+		}
+		kb, err := config.Object("knowledgeBaseConfiguration")
+		if err != nil {
+			return "", errors.New(awserrors.ErrorInvalidParameterValue)
+		}
+		return knowledgeBaseARN(region, accountID, kb.String("knowledgeBaseId")), nil
 
 	default:
 		slog.Error("bedrock authz: unhandled resource source, failing closed",

--- a/spinifex/gateway/bedrock/authz_test.go
+++ b/spinifex/gateway/bedrock/authz_test.go
@@ -1,0 +1,129 @@
+package gateway_bedrock_test
+
+import (
+	"testing"
+
+	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	authzRegion    = "ap-southeast-2"
+	authzAccountID = "123456789012"
+)
+
+func bedrockARN(resource string) string {
+	return "arn:aws:bedrock:" + authzRegion + ":" + authzAccountID + ":" + resource
+}
+
+func resolveScope(t *testing.T, service, action string, params []string, body string) []string {
+	t.Helper()
+	resources, err := gateway_bedrock.ResourceARNs(service, action, authzRegion, authzAccountID, params, []byte(body))
+	require.NoError(t, err)
+	return resources
+}
+
+// AWS spells a foundation-model ARN with an empty account segment, and a policy
+// written against AWS must match here.
+func TestResourceARNs_FoundationModelARNHasNoAccount(t *testing.T) {
+	assert.Equal(t, []string{"arn:aws:bedrock:" + authzRegion + "::foundation-model/anthropic.claude-v2"},
+		resolveScope(t, "bedrock", "GetFoundationModel", []string{"anthropic.claude-v2"}, ""))
+	assert.Equal(t, []string{"arn:aws:bedrock:" + authzRegion + "::foundation-model/meta.llama3"},
+		resolveScope(t, "bedrock-runtime", "Converse", []string{"meta.llama3"}, ""))
+}
+
+// The inference path accepts a provisioned-throughput ARN in place of a model
+// id, and the gate names what the caller addressed.
+func TestResourceARNs_InferenceAgainstAProvisionedARNNamesTheCommitment(t *testing.T) {
+	pt := gateway_bedrock.FormatProvisionedModelARN(authzRegion, authzAccountID, "pm-1")
+	assert.Equal(t, []string{bedrockARN("provisioned-model/pm-1")},
+		resolveScope(t, "bedrock-runtime", "InvokeModel", []string{pt}, ""))
+}
+
+// A commitment or guardrail is addressable by bare id or by ARN; both resolve
+// to the same resource, and a foreign account resolves account-wide so the
+// handler's own validation fault survives.
+func TestResourceARNs_IDOrARNSpellingsAgree(t *testing.T) {
+	byID := resolveScope(t, "bedrock", "GetGuardrail", []string{"gr-1"}, "")
+	byARN := resolveScope(t, "bedrock", "GetGuardrail",
+		[]string{gateway_bedrock.FormatGuardrailARN(authzRegion, authzAccountID, "gr-1")}, "")
+	assert.Equal(t, []string{bedrockARN("guardrail/gr-1")}, byID)
+	assert.Equal(t, byID, byARN)
+
+	foreign := "arn:aws:bedrock:" + authzRegion + ":999999999999:provisioned-model/pm-1"
+	assert.Equal(t, []string{"*"},
+		resolveScope(t, "bedrock", "DeleteProvisionedModelThroughput", []string{foreign}, ""))
+}
+
+// A create evaluates the commitment it is about to create and the foundation
+// model it commits, matching AWS.
+func TestResourceARNs_CreateProvisionedThroughputNamesBoth(t *testing.T) {
+	assert.Equal(t,
+		[]string{
+			bedrockARN("provisioned-model/*"),
+			"arn:aws:bedrock:" + authzRegion + "::foundation-model/meta.llama3",
+		},
+		resolveScope(t, "bedrock", "CreateProvisionedModelThroughput", nil, `{"modelId":"meta.llama3"}`))
+}
+
+func TestResourceARNs_CreatesResolveTheResourceType(t *testing.T) {
+	assert.Equal(t, []string{bedrockARN("guardrail/*")},
+		resolveScope(t, "bedrock", "CreateGuardrail", nil, `{"name":"gr"}`))
+	assert.Equal(t, []string{bedrockARN("knowledge-base/*")},
+		resolveScope(t, "bedrock-agent", "CreateKnowledgeBase", nil, `{"name":"kb"}`))
+}
+
+// Data-source and ingestion-job actions are evaluated against the knowledge
+// base, so both path ids collapse to one resource.
+func TestResourceARNs_AgentActionsCollapseToTheKnowledgeBase(t *testing.T) {
+	for _, action := range []string{"GetDataSource", "StartIngestionJob", "GetIngestionJob"} {
+		assert.Equal(t, []string{bedrockARN("knowledge-base/kb-1")},
+			resolveScope(t, "bedrock-agent", action, []string{"kb-1", "ds-1", "job-1"}, ""),
+			"action %q", action)
+	}
+}
+
+// RetrieveAndGenerate names its knowledge base two levels down in the body,
+// which is why the body is read ahead of the gate.
+func TestResourceARNs_RetrieveAndGenerateScopesFromTheBody(t *testing.T) {
+	body := `{"retrieveAndGenerateConfiguration":{"type":"KNOWLEDGE_BASE","knowledgeBaseConfiguration":{"knowledgeBaseId":"kb-1"}}}`
+	assert.Equal(t, []string{bedrockARN("knowledge-base/kb-1")},
+		resolveScope(t, "bedrock-agent-runtime", "RetrieveAndGenerate", nil, body))
+	assert.Equal(t, []string{bedrockARN("knowledge-base/kb-1")},
+		resolveScope(t, "bedrock-agent-runtime", "Retrieve", []string{"kb-1"}, ""))
+}
+
+// A body the gate cannot parse, or an absent identifier, authorizes
+// account-wide: it is the handler that rejects a malformed request.
+func TestResourceARNs_UnparseableBodyAuthorizesAccountWide(t *testing.T) {
+	assert.Equal(t, []string{"*"},
+		resolveScope(t, "bedrock-agent-runtime", "RetrieveAndGenerate", nil, "{not json"))
+	// The commitment it is about to create still resolves; only the foundation
+	// model the unreadable body would have named drops out.
+	assert.Equal(t, []string{bedrockARN("provisioned-model/*")},
+		resolveScope(t, "bedrock", "CreateProvisionedModelThroughput", nil, "{not json"))
+	assert.Equal(t, []string{"*"}, resolveScope(t, "bedrock", "GetGuardrail", nil, ""))
+}
+
+// The account-level surface is what AWS evaluates against "*".
+func TestResourceARNs_AccountLevelActionsStayAccountWide(t *testing.T) {
+	for _, action := range []string{
+		"ListFoundationModels", "ListGuardrails", "ListProvisionedModelThroughputs",
+		"PutModelInvocationLoggingConfiguration", "GetModelInvocationLoggingConfiguration",
+		"DeleteModelInvocationLoggingConfiguration",
+	} {
+		assert.Equal(t, []string{"*"}, resolveScope(t, "bedrock", action, []string{"x"}, `{"modelId":"m"}`),
+			"action %q", action)
+	}
+	assert.Equal(t, []string{"*"}, resolveScope(t, "bedrock-agent", "ListKnowledgeBases", nil, ""))
+}
+
+// An action that is served but has no entry, or a service with no table at all,
+// fails closed rather than defaulting to an account-wide grant.
+func TestResourceARNs_UnknownActionOrServiceIsRejected(t *testing.T) {
+	_, err := gateway_bedrock.ResourceARNs("bedrock", "MadeUpAction", authzRegion, authzAccountID, nil, nil)
+	require.Error(t, err)
+	_, err = gateway_bedrock.ResourceARNs("bedrock-madeup", "GetGuardrail", authzRegion, authzAccountID, nil, nil)
+	require.Error(t, err)
+}

--- a/spinifex/gateway/bedrock_authz_completeness_test.go
+++ b/spinifex/gateway/bedrock_authz_completeness_test.go
@@ -1,0 +1,47 @@
+//test:in-package — the four Bedrock route tables are unexported here, and the
+// completeness test exists to compare them against the scope tables.
+
+package gateway
+
+import (
+	"testing"
+
+	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBedrockScopeTablesAreExhaustive is what stops the next Bedrock-family
+// route being added with a silent account-wide grant. It asserts both
+// directions per service, so a scope left behind by a deleted or renamed action
+// fails too.
+func TestBedrockScopeTablesAreExhaustive(t *testing.T) {
+	served := map[string][]string{
+		"bedrock":               actionsOf(bedrockRoutes, func(r bedrockRoute) string { return r.action }),
+		"bedrock-runtime":       actionsOf(bedrockRuntimeRoutes, func(r bedrockRuntimeRoute) string { return r.action }),
+		"bedrock-agent":         actionsOf(bedrockAgentRoutes, func(r bedrockAgentRoute) string { return r.action }),
+		"bedrock-agent-runtime": actionsOf(bedrockAgentRuntimeRoutes, func(r bedrockAgentRuntimeRoute) string { return r.action }),
+	}
+
+	for service, actions := range served {
+		names := make(map[string]bool, len(actions))
+		for _, action := range actions {
+			names[action] = true
+			assert.True(t, gateway_bedrock.HasScope(service, action),
+				"%s action %q has no resource scope entry: add one to bedrockScopes in gateway/bedrock/authz.go",
+				service, action)
+		}
+		for _, action := range gateway_bedrock.ScopedActions(service) {
+			assert.True(t, names[action],
+				"bedrockScopes[%q] has an entry for %q, which the dispatch table does not serve: remove it from gateway/bedrock/authz.go",
+				service, action)
+		}
+	}
+}
+
+func actionsOf[T any](routes []T, action func(T) string) []string {
+	actions := make([]string, 0, len(routes))
+	for _, route := range routes {
+		actions = append(actions, action(route))
+	}
+	return actions
+}

--- a/spinifex/gateway/bedrock_authz_test.go
+++ b/spinifex/gateway/bedrock_authz_test.go
@@ -1,0 +1,180 @@
+//test:in-package — drives the four Bedrock-family dispatchers through the
+// gateway's unexported test helpers (withTestIdentity, policyMockIAMService)
+// and auth context keys.
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dispatchBedrockFamily drives one of the four dispatchers with no NATS
+// connection and no stores. A permitted request therefore fails on that guard,
+// which is what proves the policy check ran ahead of the resource existing.
+func dispatchBedrockFamily(t *testing.T, gw *GatewayConfig, dispatch func(http.ResponseWriter, *http.Request) error, method, path, body string) error {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req = withTestIdentity(req.WithContext(context.WithValue(req.Context(), ctxAccountID, authzAccountID)))
+	return dispatch(httptest.NewRecorder(), req)
+}
+
+func bedrockScopeARN(resource string) string {
+	return "arn:aws:bedrock:" + authzRegion + ":" + authzAccountID + ":" + resource
+}
+
+// TestBedrockRequest_ScopedDenyFires is the bypass this work closes. An operator
+// fences a production guardrail; before the resolver the fence was inert and
+// DeleteGuardrail against it was permitted with nothing logged.
+func TestBedrockRequest_ScopedDenyFires(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "bedrock:*", "*"),
+		statement("Deny", "bedrock:DeleteGuardrail", bedrockScopeARN("guardrail/gr-prod")),
+	)
+
+	assertDenied(t, dispatchBedrockFamily(t, gw, gw.Bedrock_Request, http.MethodDelete, "/guardrails/gr-prod", ""))
+	assertPermitted(t, dispatchBedrockFamily(t, gw, gw.Bedrock_Request, http.MethodDelete, "/guardrails/gr-dev", ""))
+}
+
+// TestBedrockRequest_ScopedAllowGrants is the other half: a least-privilege
+// policy used to deny everything, so the only working shape was Resource "*".
+func TestBedrockRequest_ScopedAllowGrants(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "bedrock:GetProvisionedModelThroughput", bedrockScopeARN("provisioned-model/pm-dev")),
+	)
+
+	assertPermitted(t, dispatchBedrockFamily(t, gw, gw.Bedrock_Request,
+		http.MethodGet, "/provisioned-model-throughput/pm-dev", ""))
+	assertDenied(t, dispatchBedrockFamily(t, gw, gw.Bedrock_Request,
+		http.MethodGet, "/provisioned-model-throughput/pm-prod", ""))
+}
+
+// The foundation model a commitment names arrives in the body, so the body read
+// has to happen before the gate for a fence on the model to fire at all.
+func TestBedrockRequest_CreateProvisionedThroughputScopesFromBody(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "bedrock:*", "*"),
+		statement("Deny", "bedrock:CreateProvisionedModelThroughput",
+			"arn:aws:bedrock:*::foundation-model/anthropic.*"),
+	)
+
+	assertDenied(t, dispatchBedrockFamily(t, gw, gw.Bedrock_Request, http.MethodPost,
+		"/provisioned-model-throughput", `{"modelId":"anthropic.claude-v2"}`))
+	assertPermitted(t, dispatchBedrockFamily(t, gw, gw.Bedrock_Request, http.MethodPost,
+		"/provisioned-model-throughput", `{"modelId":"meta.llama3"}`))
+	// An unreadable body authorizes account-wide and stays the handler's fault.
+	assertPermitted(t, dispatchBedrockFamily(t, gw, gw.Bedrock_Request, http.MethodPost,
+		"/provisioned-model-throughput", "{not json"))
+}
+
+// bedrock-runtime names its model in the path, so a fence on a model prefix
+// fences inference against it.
+func TestBedrockRuntimeRequest_ScopedDenyFires(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "bedrock:*", "*"),
+		statement("Deny", "bedrock:InvokeModel", "arn:aws:bedrock:*::foundation-model/anthropic.*"),
+	)
+
+	assertDenied(t, dispatchBedrockFamily(t, gw, gw.BedrockRuntime_Request,
+		http.MethodPost, "/model/anthropic.claude-v2/invoke", `{}`))
+	assertPermitted(t, dispatchBedrockFamily(t, gw, gw.BedrockRuntime_Request,
+		http.MethodPost, "/model/meta.llama3/invoke", `{}`))
+}
+
+// bedrock-agent's data-source and ingestion-job actions are evaluated against
+// the knowledge base, so a fence on the base covers them.
+func TestBedrockAgentRequest_ScopedDenyCoversTheWholeKnowledgeBase(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "bedrock:*", "*"),
+		statement("Deny", "bedrock:StartIngestionJob", bedrockScopeARN("knowledge-base/kb-prod")),
+	)
+
+	assertPermitted(t, dispatchBedrockFamily(t, gw, gw.BedrockAgent_Request, http.MethodPut,
+		"/knowledgebases/kb-dev/datasources/ds-1/ingestionjobs/", `{}`))
+	assertDenied(t, dispatchBedrockFamily(t, gw, gw.BedrockAgent_Request, http.MethodPut,
+		"/knowledgebases/kb-prod/datasources/ds-1/ingestionjobs/", `{}`))
+}
+
+// RetrieveAndGenerate names its knowledge base in the body, two levels down.
+func TestBedrockAgentRuntimeRequest_RetrieveAndGenerateScopesFromBody(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "bedrock:*", "*"),
+		statement("Deny", "bedrock:RetrieveAndGenerate", bedrockScopeARN("knowledge-base/kb-prod")),
+	)
+	body := func(kb string) string {
+		return `{"input":{"text":"q"},"retrieveAndGenerateConfiguration":{"type":"KNOWLEDGE_BASE",` +
+			`"knowledgeBaseConfiguration":{"knowledgeBaseId":"` + kb + `","modelArn":"meta.llama3"}}}`
+	}
+
+	assertDenied(t, dispatchBedrockFamily(t, gw, gw.BedrockAgentRuntime_Request,
+		http.MethodPost, "/retrieveAndGenerate", body("kb-prod")))
+	assertPermitted(t, dispatchBedrockFamily(t, gw, gw.BedrockAgentRuntime_Request,
+		http.MethodPost, "/retrieveAndGenerate", body("kb-dev")))
+}
+
+// A body past the signed path's cap cannot be used to bypass the gate or to
+// exhaust memory: it is rejected before either the gate or the handler.
+func TestBedrockRequest_OversizedBodyIsRejected(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "bedrock:*", "*"))
+	body := `{"modelId":"` + strings.Repeat("a", sigv4.MaxPayloadLen) + `"}`
+
+	err := dispatchBedrockFamily(t, gw, gw.Bedrock_Request, http.MethodPost,
+		"/provisioned-model-throughput", body)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorRequestEntityTooLarge, err.Error())
+}
+
+// The property the per-service rollout rests on: passing a real ARN where "*"
+// was passed before cannot withdraw access a working policy already grants.
+func TestBedrockFamily_AccountWideGrantStillPermitsEveryAction(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "bedrock:*", "*"))
+	req := withTestIdentity(httptest.NewRequest(http.MethodGet, "/", nil).
+		WithContext(context.WithValue(context.Background(), ctxAccountID, authzAccountID)))
+	body := []byte(`{"modelId":"meta.llama3","retrieveAndGenerateConfiguration":` +
+		`{"knowledgeBaseConfiguration":{"knowledgeBaseId":"kb-1"}}}`)
+
+	for _, service := range []string{"bedrock", "bedrock-runtime", "bedrock-agent", "bedrock-agent-runtime"} {
+		for _, action := range gateway_bedrock.ScopedActions(service) {
+			t.Run(service+"/"+action, func(t *testing.T) {
+				resources, err := gateway_bedrock.ResourceARNs(service, action, authzRegion, authzAccountID,
+					[]string{"id-1", "id-2", "id-3"}, body)
+				require.NoError(t, err)
+				assert.NoError(t, gw.checkPolicyResources(req, service, action, resources))
+			})
+		}
+	}
+}
+
+// The account-ID read moved above the gate, which used to reject a missing
+// account itself. InternalError is the code the caller has always seen.
+func TestBedrockFamily_MissingAccountIDReturnsInternalError(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "bedrock:*", "*"))
+	dispatchers := map[string]struct {
+		dispatch func(http.ResponseWriter, *http.Request) error
+		method   string
+		path     string
+	}{
+		"bedrock":               {gw.Bedrock_Request, http.MethodGet, "/foundation-models"},
+		"bedrock-runtime":       {gw.BedrockRuntime_Request, http.MethodPost, "/model/m/invoke"},
+		"bedrock-agent":         {gw.BedrockAgent_Request, http.MethodPost, "/knowledgebases/"},
+		"bedrock-agent-runtime": {gw.BedrockAgentRuntime_Request, http.MethodPost, "/retrieveAndGenerate"},
+	}
+
+	for service, d := range dispatchers {
+		t.Run(service, func(t *testing.T) {
+			req := withTestIdentity(httptest.NewRequest(d.method, d.path, strings.NewReader("{}")))
+			err := d.dispatch(httptest.NewRecorder(), req)
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorInternalError, err.Error())
+		})
+	}
+}

--- a/spinifex/gateway/bedrockagent.go
+++ b/spinifex/gateway/bedrockagent.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math"
 	"net/http"
@@ -143,7 +142,21 @@ func (gw *GatewayConfig) BedrockAgent_Request(w http.ResponseWriter, r *http.Req
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "bedrock-agent", action); err != nil {
+	// Hoisted above the policy check because the resolver builds ARNs from it.
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.ErrorContext(r.Context(), "BedrockAgent_Request: no account ID in auth context")
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
+	}
+
+	// Every bedrock-agent action names its knowledge base in the path.
+	resources, err := gateway_bedrock.ResourceARNs("bedrock-agent", action, gw.Region, accountID, params, nil)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "bedrock-agent", action, resources); err != nil {
 		return err
 	}
 
@@ -151,16 +164,10 @@ func (gw *GatewayConfig) BedrockAgent_Request(w http.ResponseWriter, r *http.Req
 		return errors.New(awserrors.ErrorServerInternal)
 	}
 
-	accountID, _ := r.Context().Value(ctxAccountID).(string)
-	if accountID == "" {
-		slog.ErrorContext(r.Context(), "BedrockAgent_Request: no account ID in auth context")
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-
-	body, err := io.ReadAll(r.Body)
+	body, err := readBoundedBody(r)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "BedrockAgent_Request: failed to read body", "err", err)
-		return errors.New(awserrors.ErrorInvalidParameterValue)
+		return err
 	}
 
 	output, err := handler(r.Context(), accountID, gw.Region, params, body, gw.BedrockAgentKB, gw.BedrockAgentDataSources, gw.BedrockAgentVector)
@@ -170,17 +177,6 @@ func (gw *GatewayConfig) BedrockAgent_Request(w http.ResponseWriter, r *http.Req
 
 	gateway_bedrock.WriteJSONResponse(w, output)
 	return nil
-}
-
-// bedrockAgentKnowledgeBaseResourceType is the ARN resource-type segment a
-// knowledge base renders under. DataSource carries no ARN field in AWS's own
-// shape (only KnowledgeBase does), so there is no data-source counterpart.
-const bedrockAgentKnowledgeBaseResourceType = "knowledge-base"
-
-// formatKnowledgeBaseARN builds the ARN a CreateKnowledgeBase call returns,
-// mirroring gateway_bedrock.FormatGuardrailARN's shape.
-func formatKnowledgeBaseARN(region, accountID, id string) string {
-	return fmt.Sprintf("arn:aws:bedrock:%s:%s:%s/%s", region, accountID, bedrockAgentKnowledgeBaseResourceType, id)
 }
 
 // nonEmptyStringPtr returns nil for an empty string, so an optional field
@@ -316,7 +312,7 @@ func kbRecordToOutput(region, accountID string, rec handlers_ochrevector.KBRecor
 	return &bedrockagent.KnowledgeBase{
 		CreatedAt:        aws.Time(rec.CreatedAt),
 		Description:      nonEmptyStringPtr(rec.Description),
-		KnowledgeBaseArn: aws.String(formatKnowledgeBaseARN(region, accountID, rec.ID)),
+		KnowledgeBaseArn: aws.String(gateway_bedrock.FormatKnowledgeBaseARN(region, accountID, rec.ID)),
 		KnowledgeBaseConfiguration: &bedrockagent.KnowledgeBaseConfiguration{
 			Type: aws.String(bedrockagent.KnowledgeBaseTypeVector),
 			VectorKnowledgeBaseConfiguration: &bedrockagent.VectorKnowledgeBaseConfiguration{

--- a/spinifex/gateway/bedrockagentruntime.go
+++ b/spinifex/gateway/bedrockagentruntime.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -115,17 +114,32 @@ func (gw *GatewayConfig) BedrockAgentRuntime_Request(w http.ResponseWriter, r *h
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "bedrock-agent-runtime", action); err != nil {
+	// Hoisted above the policy check because the resolver builds ARNs from it.
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.ErrorContext(r.Context(), "BedrockAgentRuntime_Request: no account ID in auth context")
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
+	}
+
+	// RetrieveAndGenerate names its knowledge base in the body, so the body is
+	// read ahead of the gate; Retrieve names it in the path.
+	body, err := readBoundedBody(r)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "BedrockAgentRuntime_Request: failed to read body", "err", err)
+		return err
+	}
+
+	resources, err := gateway_bedrock.ResourceARNs("bedrock-agent-runtime", action, gw.Region, accountID, params, body)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "bedrock-agent-runtime", action, resources); err != nil {
 		return err
 	}
 
 	if gw.BedrockAgentKB == nil || gw.BedrockAgentVector == nil {
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-
-	accountID, _ := r.Context().Value(ctxAccountID).(string)
-	if accountID == "" {
-		slog.ErrorContext(r.Context(), "BedrockAgentRuntime_Request: no account ID in auth context")
 		return errors.New(awserrors.ErrorServerInternal)
 	}
 
@@ -136,12 +150,6 @@ func (gw *GatewayConfig) BedrockAgentRuntime_Request(w http.ResponseWriter, r *h
 		if err := gw.Quota.CheckBedrockTokens(r.Context(), accountID); err != nil {
 			return err
 		}
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "BedrockAgentRuntime_Request: failed to read body", "err", err)
-		return errors.New(awserrors.ErrorInvalidParameterValue)
 	}
 
 	converse := func(ctx context.Context, acct, modelID string, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {

--- a/spinifex/gateway/bedrockruntime.go
+++ b/spinifex/gateway/bedrockruntime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -112,17 +111,26 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "bedrock-runtime", action); err != nil {
+	// Hoisted above the policy check because the resolver builds ARNs from it.
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.ErrorContext(r.Context(), "BedrockRuntime_Request: no account ID in auth context")
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
+	}
+
+	// Every bedrock-runtime action names its model or guardrail in the path, so
+	// the gate resolves before the body is read at all.
+	resources, err := gateway_bedrock.ResourceARNs("bedrock-runtime", action, gw.Region, accountID, params, nil)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "bedrock-runtime", action, resources); err != nil {
 		return err
 	}
 
 	if gw.NATSConn == nil {
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-
-	accountID, _ := r.Context().Value(ctxAccountID).(string)
-	if accountID == "" {
-		slog.ErrorContext(r.Context(), "BedrockRuntime_Request: no account ID in auth context")
 		return errors.New(awserrors.ErrorServerInternal)
 	}
 
@@ -137,10 +145,10 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 		return err
 	}
 
-	body, err := io.ReadAll(r.Body)
+	body, err := readBoundedBody(r)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "BedrockRuntime_Request: failed to read body", "err", err)
-		return errors.New(awserrors.ErrorInvalidParameterValue)
+		return err
 	}
 
 	// InvokeModel returns provider-native bytes, not a struct WriteJSONResponse

--- a/spinifex/gateway/bodyscope/bodyscope.go
+++ b/spinifex/gateway/bodyscope/bodyscope.go
@@ -11,9 +11,17 @@ package bodyscope
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"strings"
 )
+
+// ErrAmbiguousBody reports a body carrying two spellings of one field that
+// differ only in case. encoding/json resolves those in document order when the
+// handler builds its typed input, while a case-folded map cannot resolve them
+// at all, so the gate and the handler would name different objects. The caller
+// must reject the request rather than resolve it or widen to "*".
+var ErrAmbiguousBody = errors.New("bodyscope: field spelled two ways in one body")
 
 // Scope is a parsed request body. The zero value is usable and reports every
 // field as absent, which is what a body the gate cannot parse resolves to.
@@ -22,23 +30,30 @@ type Scope struct {
 }
 
 // Parse reads body as a JSON object. A body that is empty or does not parse
-// yields an empty Scope rather than an error: it is the handler that rejects a
+// yields an empty Scope and no error: it is the handler that rejects a
 // malformed request, so the caller sees a validation fault rather than a
-// denial. action names the caller for the debug line only.
-func Parse(action string, body []byte) Scope {
+// denial. A body whose fields collide under the case fold yields
+// ErrAmbiguousBody. action names the caller for the log lines only.
+func Parse(action string, body []byte) (Scope, error) {
 	if len(body) == 0 {
-		return Scope{}
+		return Scope{}, nil
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(body, &raw); err != nil {
 		slog.Debug("bodyscope: body does not parse, authorizing account-wide", "action", action, "err", err)
-		return Scope{}
+		return Scope{}, nil
 	}
 	fields := make(map[string]json.RawMessage, len(raw))
 	for name, value := range raw {
-		fields[strings.ToLower(name)] = value
+		lower := strings.ToLower(name)
+		if _, duplicate := fields[lower]; duplicate {
+			slog.Error("bodyscope: field spelled two ways in one body, refusing to resolve a scope",
+				"action", action, "field", lower)
+			return Scope{}, ErrAmbiguousBody
+		}
+		fields[lower] = value
 	}
-	return Scope{fields: fields}
+	return Scope{fields: fields}, nil
 }
 
 // String returns the first field in names that holds a JSON string, or "" when
@@ -88,19 +103,23 @@ func (s Scope) Strings(names ...string) []string {
 
 // Object returns the nested object held by the first field in names that holds
 // one, or an empty Scope when none does. Some identifiers sit below the top
-// level of the request.
-func (s Scope) Object(names ...string) Scope {
+// level of the request, and a nested object folds under the same rule as the
+// top level, so ErrAmbiguousBody propagates.
+func (s Scope) Object(names ...string) (Scope, error) {
 	for _, name := range names {
 		raw, ok := s.fields[strings.ToLower(name)]
 		if !ok {
 			continue
 		}
-		nested := Parse(name, raw)
+		nested, err := Parse(name, raw)
+		if err != nil {
+			return Scope{}, err
+		}
 		if len(nested.fields) > 0 {
-			return nested
+			return nested, nil
 		}
 	}
-	return Scope{}
+	return Scope{}, nil
 }
 
 // Has reports whether the body carried any of names, whatever its shape. Used

--- a/spinifex/gateway/bodyscope/bodyscope.go
+++ b/spinifex/gateway/bodyscope/bodyscope.go
@@ -1,0 +1,116 @@
+// Package bodyscope reads the handful of identifier fields a policy scope
+// resolver needs out of a JSON request body, without deserialising the typed
+// input the handler will build from the same bytes.
+//
+// Two properties matter here. A type mismatch on an unrelated field cannot
+// poison the parse and silently widen the request to "*", because every field
+// is decoded on demand. And AWS JSON 1.1 spells fields lower-camel while the
+// SDK structs are upper-camel, so lookups are case-insensitive by design
+// rather than by relying on encoding/json's own fallback.
+package bodyscope
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+)
+
+// Scope is a parsed request body. The zero value is usable and reports every
+// field as absent, which is what a body the gate cannot parse resolves to.
+type Scope struct {
+	fields map[string]json.RawMessage
+}
+
+// Parse reads body as a JSON object. A body that is empty or does not parse
+// yields an empty Scope rather than an error: it is the handler that rejects a
+// malformed request, so the caller sees a validation fault rather than a
+// denial. action names the caller for the debug line only.
+func Parse(action string, body []byte) Scope {
+	if len(body) == 0 {
+		return Scope{}
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		slog.Debug("bodyscope: body does not parse, authorizing account-wide", "action", action, "err", err)
+		return Scope{}
+	}
+	fields := make(map[string]json.RawMessage, len(raw))
+	for name, value := range raw {
+		fields[strings.ToLower(name)] = value
+	}
+	return Scope{fields: fields}
+}
+
+// String returns the first field in names that holds a JSON string, or "" when
+// none does. Several names are accepted because one action's identifier is
+// spelled differently across the surfaces that carry it.
+func (s Scope) String(names ...string) string {
+	for _, name := range names {
+		raw, ok := s.fields[strings.ToLower(name)]
+		if !ok {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			continue
+		}
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// Strings returns the first field in names that holds a JSON array of strings,
+// with empty elements dropped. A field of any other shape is skipped.
+func (s Scope) Strings(names ...string) []string {
+	for _, name := range names {
+		raw, ok := s.fields[strings.ToLower(name)]
+		if !ok {
+			continue
+		}
+		var values []string
+		if err := json.Unmarshal(raw, &values); err != nil {
+			continue
+		}
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			if value != "" {
+				out = append(out, value)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return nil
+}
+
+// Object returns the nested object held by the first field in names that holds
+// one, or an empty Scope when none does. Some identifiers sit below the top
+// level of the request.
+func (s Scope) Object(names ...string) Scope {
+	for _, name := range names {
+		raw, ok := s.fields[strings.ToLower(name)]
+		if !ok {
+			continue
+		}
+		nested := Parse(name, raw)
+		if len(nested.fields) > 0 {
+			return nested
+		}
+	}
+	return Scope{}
+}
+
+// Has reports whether the body carried any of names, whatever its shape. Used
+// where the presence of an optional field decides whether a scope applies at
+// all, rather than its value.
+func (s Scope) Has(names ...string) bool {
+	for _, name := range names {
+		if _, ok := s.fields[strings.ToLower(name)]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/spinifex/gateway/bodyscope/bodyscope_test.go
+++ b/spinifex/gateway/bodyscope/bodyscope_test.go
@@ -5,16 +5,24 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func mustParse(t *testing.T, action, body string) bodyscope.Scope {
+	t.Helper()
+	scope, err := bodyscope.Parse(action, []byte(body))
+	require.NoError(t, err)
+	return scope
+}
+
 func TestParse_LookupIsCaseInsensitive(t *testing.T) {
-	scope := bodyscope.Parse("DeleteCluster", []byte(`{"Cluster":"prod"}`))
+	scope := mustParse(t, "DeleteCluster", `{"Cluster":"prod"}`)
 	assert.Equal(t, "prod", scope.String("cluster"))
 	assert.Equal(t, "prod", scope.String("CLUSTER"))
 }
 
 func TestParse_FirstNamePresentWins(t *testing.T) {
-	scope := bodyscope.Parse("StopTask", []byte(`{"task":"t-1","taskId":"t-2"}`))
+	scope := mustParse(t, "StopTask", `{"task":"t-1","taskId":"t-2"}`)
 	assert.Equal(t, "t-1", scope.String("task", "taskId"))
 	assert.Equal(t, "t-2", scope.String("taskId", "task"))
 }
@@ -22,18 +30,50 @@ func TestParse_FirstNamePresentWins(t *testing.T) {
 // The reason for map[string]json.RawMessage over a shared struct: a mismatch on
 // a field the scope does not read must not widen the request to "*".
 func TestParse_UnrelatedFieldTypeMismatchDoesNotPoisonTheParse(t *testing.T) {
-	scope := bodyscope.Parse("RunTask", []byte(`{"cluster":"prod","count":"not-a-number"}`))
+	scope := mustParse(t, "RunTask", `{"cluster":"prod","count":"not-a-number"}`)
 	assert.Equal(t, "prod", scope.String("cluster"))
 }
 
 func TestParse_WrongShapeFieldIsSkipped(t *testing.T) {
-	scope := bodyscope.Parse("DescribeClusters", []byte(`{"clusters":"prod"}`))
+	scope := mustParse(t, "DescribeClusters", `{"clusters":"prod"}`)
 	assert.Empty(t, scope.Strings("clusters"))
-	assert.Empty(t, bodyscope.Parse("x", []byte(`{"cluster":["prod"]}`)).String("cluster"))
+	assert.Empty(t, mustParse(t, "x", `{"cluster":["prod"]}`).String("cluster"))
+}
+
+// encoding/json resolves two spellings of one field in document order when the
+// handler builds its typed input; a case-folded map resolves them at random.
+// The gate must refuse rather than name a different object than the handler.
+func TestParse_FieldSpelledTwoWaysIsRejected(t *testing.T) {
+	for _, body := range []string{
+		`{"cluster":"dev","Cluster":"prod"}`,
+		`{"repositoryName":"a","REPOSITORYNAME":"b"}`,
+		`{"accountId":"1","AccountId":"2"}`,
+	} {
+		// Run repeatedly: the collision must be detected whichever order the
+		// map yields, not on the runs where the fold happens to disagree.
+		for range 50 {
+			_, err := bodyscope.Parse("DeleteCluster", []byte(body))
+			require.ErrorIs(t, err, bodyscope.ErrAmbiguousBody, "body %q", body)
+		}
+	}
+}
+
+func TestObject_FieldSpelledTwoWaysInANestedObjectIsRejected(t *testing.T) {
+	body := `{"retrieveAndGenerateConfiguration":{"knowledgeBaseId":"kb-1","KnowledgeBaseId":"kb-2"}}`
+	scope := mustParse(t, "RetrieveAndGenerate", body)
+	_, err := scope.Object("retrieveAndGenerateConfiguration")
+	require.ErrorIs(t, err, bodyscope.ErrAmbiguousBody)
+}
+
+// A field repeated under one spelling is not ambiguous: encoding/json takes the
+// last occurrence and so does the map, so both sides agree.
+func TestParse_RepeatedIdenticalSpellingIsNotAmbiguous(t *testing.T) {
+	scope := mustParse(t, "DeleteCluster", `{"cluster":"dev","cluster":"prod"}`)
+	assert.Equal(t, "prod", scope.String("cluster"))
 }
 
 func TestStrings_DropsEmptyElements(t *testing.T) {
-	scope := bodyscope.Parse("DescribeClusters", []byte(`{"clusters":["prod","","dev"]}`))
+	scope := mustParse(t, "DescribeClusters", `{"clusters":["prod","","dev"]}`)
 	assert.Equal(t, []string{"prod", "dev"}, scope.Strings("clusters"))
 }
 
@@ -41,7 +81,8 @@ func TestStrings_DropsEmptyElements(t *testing.T) {
 // rejects it, so the caller keeps its validation fault.
 func TestParse_UnparseableAndEmptyBodiesResolveToNothing(t *testing.T) {
 	for _, body := range []string{"", "{not json", "[]", "null"} {
-		scope := bodyscope.Parse("CreateCluster", []byte(body))
+		scope, err := bodyscope.Parse("CreateCluster", []byte(body))
+		require.NoError(t, err, "body %q", body)
 		assert.Empty(t, scope.String("clusterName"), "body %q", body)
 		assert.Empty(t, scope.Strings("clusters"), "body %q", body)
 		assert.False(t, scope.Has("clusterName"), "body %q", body)
@@ -49,20 +90,26 @@ func TestParse_UnparseableAndEmptyBodiesResolveToNothing(t *testing.T) {
 }
 
 func TestObject_ReachesANestedIdentifier(t *testing.T) {
-	body := []byte(`{"retrieveAndGenerateConfiguration":{"knowledgeBaseConfiguration":{"knowledgeBaseId":"kb-1"}}}`)
-	scope := bodyscope.Parse("RetrieveAndGenerate", body)
-	nested := scope.Object("retrieveAndGenerateConfiguration").Object("knowledgeBaseConfiguration")
+	body := `{"retrieveAndGenerateConfiguration":{"knowledgeBaseConfiguration":{"knowledgeBaseId":"kb-1"}}}`
+	scope := mustParse(t, "RetrieveAndGenerate", body)
+	config, err := scope.Object("retrieveAndGenerateConfiguration")
+	require.NoError(t, err)
+	nested, err := config.Object("knowledgeBaseConfiguration")
+	require.NoError(t, err)
 	assert.Equal(t, "kb-1", nested.String("knowledgeBaseId"))
 }
 
 func TestObject_MissingOrWrongShapeYieldsAnEmptyScope(t *testing.T) {
-	scope := bodyscope.Parse("RetrieveAndGenerate", []byte(`{"config":"not-an-object"}`))
-	assert.Empty(t, scope.Object("config").String("knowledgeBaseId"))
-	assert.Empty(t, scope.Object("absent").String("knowledgeBaseId"))
+	scope := mustParse(t, "RetrieveAndGenerate", `{"config":"not-an-object"}`)
+	for _, name := range []string{"config", "absent"} {
+		nested, err := scope.Object(name)
+		require.NoError(t, err, "field %q", name)
+		assert.Empty(t, nested.String("knowledgeBaseId"), "field %q", name)
+	}
 }
 
 func TestHas_ReportsPresenceWhateverTheShape(t *testing.T) {
-	scope := bodyscope.Parse("RunTask", []byte(`{"cluster":null,"count":3}`))
+	scope := mustParse(t, "RunTask", `{"cluster":null,"count":3}`)
 	assert.True(t, scope.Has("cluster"))
 	assert.True(t, scope.Has("count"))
 	assert.False(t, scope.Has("group"))

--- a/spinifex/gateway/bodyscope/bodyscope_test.go
+++ b/spinifex/gateway/bodyscope/bodyscope_test.go
@@ -1,0 +1,69 @@
+package bodyscope_test
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse_LookupIsCaseInsensitive(t *testing.T) {
+	scope := bodyscope.Parse("DeleteCluster", []byte(`{"Cluster":"prod"}`))
+	assert.Equal(t, "prod", scope.String("cluster"))
+	assert.Equal(t, "prod", scope.String("CLUSTER"))
+}
+
+func TestParse_FirstNamePresentWins(t *testing.T) {
+	scope := bodyscope.Parse("StopTask", []byte(`{"task":"t-1","taskId":"t-2"}`))
+	assert.Equal(t, "t-1", scope.String("task", "taskId"))
+	assert.Equal(t, "t-2", scope.String("taskId", "task"))
+}
+
+// The reason for map[string]json.RawMessage over a shared struct: a mismatch on
+// a field the scope does not read must not widen the request to "*".
+func TestParse_UnrelatedFieldTypeMismatchDoesNotPoisonTheParse(t *testing.T) {
+	scope := bodyscope.Parse("RunTask", []byte(`{"cluster":"prod","count":"not-a-number"}`))
+	assert.Equal(t, "prod", scope.String("cluster"))
+}
+
+func TestParse_WrongShapeFieldIsSkipped(t *testing.T) {
+	scope := bodyscope.Parse("DescribeClusters", []byte(`{"clusters":"prod"}`))
+	assert.Empty(t, scope.Strings("clusters"))
+	assert.Empty(t, bodyscope.Parse("x", []byte(`{"cluster":["prod"]}`)).String("cluster"))
+}
+
+func TestStrings_DropsEmptyElements(t *testing.T) {
+	scope := bodyscope.Parse("DescribeClusters", []byte(`{"clusters":["prod","","dev"]}`))
+	assert.Equal(t, []string{"prod", "dev"}, scope.Strings("clusters"))
+}
+
+// A body the gate cannot read authorizes account-wide; the handler still
+// rejects it, so the caller keeps its validation fault.
+func TestParse_UnparseableAndEmptyBodiesResolveToNothing(t *testing.T) {
+	for _, body := range []string{"", "{not json", "[]", "null"} {
+		scope := bodyscope.Parse("CreateCluster", []byte(body))
+		assert.Empty(t, scope.String("clusterName"), "body %q", body)
+		assert.Empty(t, scope.Strings("clusters"), "body %q", body)
+		assert.False(t, scope.Has("clusterName"), "body %q", body)
+	}
+}
+
+func TestObject_ReachesANestedIdentifier(t *testing.T) {
+	body := []byte(`{"retrieveAndGenerateConfiguration":{"knowledgeBaseConfiguration":{"knowledgeBaseId":"kb-1"}}}`)
+	scope := bodyscope.Parse("RetrieveAndGenerate", body)
+	nested := scope.Object("retrieveAndGenerateConfiguration").Object("knowledgeBaseConfiguration")
+	assert.Equal(t, "kb-1", nested.String("knowledgeBaseId"))
+}
+
+func TestObject_MissingOrWrongShapeYieldsAnEmptyScope(t *testing.T) {
+	scope := bodyscope.Parse("RetrieveAndGenerate", []byte(`{"config":"not-an-object"}`))
+	assert.Empty(t, scope.Object("config").String("knowledgeBaseId"))
+	assert.Empty(t, scope.Object("absent").String("knowledgeBaseId"))
+}
+
+func TestHas_ReportsPresenceWhateverTheShape(t *testing.T) {
+	scope := bodyscope.Parse("RunTask", []byte(`{"cluster":null,"count":3}`))
+	assert.True(t, scope.Has("cluster"))
+	assert.True(t, scope.Has("count"))
+	assert.False(t, scope.Has("group"))
+}

--- a/spinifex/gateway/ecr_authz_test.go
+++ b/spinifex/gateway/ecr_authz_test.go
@@ -53,6 +53,46 @@ func TestECRRequest_ScopedAllowGrants(t *testing.T) {
 	assertDenied(t, dispatchECR(t, gw, "BatchCheckLayerAvailability", `{"repositoryName":"prod"}`))
 }
 
+// A body spelling one field two ways is rejected rather than authorized against
+// whichever spelling the case fold happened to keep.
+func TestECRRequest_FieldSpelledTwoWaysIsRejected(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecr:*", "*"),
+		statement("Deny", "ecr:BatchCheckLayerAvailability", "arn:aws:ecr:*:*:repository/prod"),
+	)
+
+	// Repeated: the fold's disagreement is random, the rejection must not be.
+	for range 50 {
+		err := dispatchECR(t, gw, "BatchCheckLayerAvailability",
+			`{"repositoryName":"dev","RepositoryName":"prod"}`)
+		require.Error(t, err)
+		assert.Equal(t, awserrors.ErrorInvalidParameterValue, err.Error())
+	}
+}
+
+// DescribeRepositories naming no repository enumerates the whole registry, so a
+// grant scoped to one repository does not reach it.
+func TestECRRequest_OmittedRepositoryListEnumeratesTheRegistry(t *testing.T) {
+	scoped := scopedPolicyGateway(
+		statement("Allow", "ecr:DescribeRepositories", "arn:aws:ecr:*:*:repository/dev"),
+	)
+	assertDenied(t, dispatchECR(t, scoped, "DescribeRepositories", `{}`))
+	assertDenied(t, dispatchECR(t, scoped, "DescribeRepositories", `{"repositoryNames":[]}`))
+
+	wide := scopedPolicyGateway(
+		statement("Allow", "ecr:DescribeRepositories", "arn:aws:ecr:*:*:repository/*"),
+	)
+	assert.NotEqual(t, awserrors.ErrorAccessDenied,
+		errString(dispatchECR(t, wide, "DescribeRepositories", `{}`)))
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
 // A caller-supplied registryId would let a request slide out from under a Deny
 // scoped to the real account, so the ARN is built under the caller's.
 func TestECRRequest_RegistryIDInTheBodyIsIgnored(t *testing.T) {

--- a/spinifex/gateway/ecr_authz_test.go
+++ b/spinifex/gateway/ecr_authz_test.go
@@ -1,0 +1,120 @@
+//test:in-package — drives ECR_Request through the gateway's unexported test
+// helpers (setupECRRequest, policyMockIAMService) and auth context keys.
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_ecrapi "github.com/mulgadc/spinifex/spinifex/gateway/ecrapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dispatchECR drives the gateway at an action whose handler is the 501 stub, so
+// a permitted request fails there rather than on authorization.
+func dispatchECR(t *testing.T, gw *GatewayConfig, action, body string) error {
+	t.Helper()
+	return gw.ECR_Request(httptest.NewRecorder(), setupECRRequest(gateway_ecrapi.TargetPrefix+"."+action, body))
+}
+
+func assertECRPermitted(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorNotImplemented, err.Error())
+}
+
+// TestECRRequest_ScopedDenyFires is the bypass this work closes. An operator
+// fences a production repository; before the resolver the fence was inert.
+func TestECRRequest_ScopedDenyFires(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecr:*", "*"),
+		statement("Deny", "ecr:BatchCheckLayerAvailability", "arn:aws:ecr:*:*:repository/prod"),
+	)
+
+	assertDenied(t, dispatchECR(t, gw, "BatchCheckLayerAvailability", `{"repositoryName":"prod"}`))
+	assertECRPermitted(t, dispatchECR(t, gw, "BatchCheckLayerAvailability", `{"repositoryName":"dev"}`))
+}
+
+// TestECRRequest_ScopedAllowGrants is the other half: a least-privilege policy
+// used to deny everything, so the only working policy shape was Resource "*".
+func TestECRRequest_ScopedAllowGrants(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecr:BatchCheckLayerAvailability", "arn:aws:ecr:*:*:repository/dev"),
+	)
+
+	assertECRPermitted(t, dispatchECR(t, gw, "BatchCheckLayerAvailability", `{"repositoryName":"dev"}`))
+	assertDenied(t, dispatchECR(t, gw, "BatchCheckLayerAvailability", `{"repositoryName":"prod"}`))
+}
+
+// A caller-supplied registryId would let a request slide out from under a Deny
+// scoped to the real account, so the ARN is built under the caller's.
+func TestECRRequest_RegistryIDInTheBodyIsIgnored(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecr:*", "*"),
+		statement("Deny", "ecr:BatchCheckLayerAvailability",
+			"arn:aws:ecr:"+authzRegion+":"+authzAccountID+":repository/prod"),
+	)
+
+	assertDenied(t, dispatchECR(t, gw, "BatchCheckLayerAvailability",
+		`{"registryId":"999999999999","repositoryName":"prod"}`))
+}
+
+// A body the gate cannot parse authorizes account-wide, and the handler still
+// reports its own fault.
+func TestECRRequest_UnparseableBodyStaysTheHandlersFault(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecr:*", "*"),
+		statement("Deny", "ecr:BatchCheckLayerAvailability", "arn:aws:ecr:*:*:repository/prod"),
+	)
+
+	assertECRPermitted(t, dispatchECR(t, gw, "BatchCheckLayerAvailability", "{not json"))
+}
+
+// A body past the signed path's cap cannot be used to bypass the gate or to
+// exhaust memory: it is rejected before either the gate or the handler.
+func TestECRRequest_OversizedBodyIsRejected(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "ecr:*", "*"))
+	body := `{"repositoryName":"` + strings.Repeat("a", sigv4.MaxPayloadLen) + `"}`
+
+	err := dispatchECR(t, gw, "BatchCheckLayerAvailability", body)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorRequestEntityTooLarge, err.Error())
+}
+
+// The property the per-service rollout rests on: passing a real ARN where "*"
+// was passed before cannot withdraw access a working policy already grants.
+func TestECRRequest_AccountWideGrantStillPermitsEveryAction(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "ecr:*", "*"))
+	req := withTestIdentity(httptest.NewRequest(http.MethodPost, "/", nil).
+		WithContext(context.WithValue(context.Background(), ctxAccountID, authzAccountID)))
+	body := []byte(`{"repositoryName":"app","repositoryNames":["app"],` +
+		`"resourceArn":"arn:aws:ecr:` + authzRegion + `:` + authzAccountID + `:repository/app"}`)
+
+	for _, action := range gateway_ecrapi.ScopedActions() {
+		t.Run(action, func(t *testing.T) {
+			resources, err := gateway_ecrapi.ResourceARNs(action, authzRegion, authzAccountID, body)
+			require.NoError(t, err)
+			assert.NoError(t, gw.checkPolicyResources(req, "ecr", action, resources))
+		})
+	}
+}
+
+// The account-ID read moved above the gate, which used to reject a missing
+// account itself. InternalError is the code the caller has always seen.
+func TestECRRequest_MissingAccountIDReturnsInternalError(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "ecr:*", "*"))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
+	req.Header.Set("X-Amz-Target", gateway_ecrapi.TargetPrefix+".ListRepositories")
+	req = withTestIdentity(req.WithContext(context.WithValue(req.Context(), ctxService, "ecr")))
+
+	err := gw.ECR_Request(httptest.NewRecorder(), req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
+}

--- a/spinifex/gateway/ecrapi.go
+++ b/spinifex/gateway/ecrapi.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"log/slog"
@@ -56,24 +57,35 @@ func (gw *GatewayConfig) ECR_Request(w http.ResponseWriter, r *http.Request) err
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "ecr", action); err != nil {
+	// Hoisted above the policy check because the resolver builds ARNs from the
+	// caller's account and from the same body bytes the handler unmarshals.
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.Error("ECR_Request: no account ID in auth context")
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
+	}
+
+	body, err := readBoundedBody(r)
+	if err != nil {
+		slog.Error("ECR_Request: failed to read body", "err", err)
+		return err
+	}
+
+	resources, err := gateway_ecrapi.ResourceARNs(action, gw.Region, accountID, body)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "ecr", action, resources); err != nil {
 		return err
 	}
 
 	if inline, ok := ecrInlineActions[action]; ok {
+		// The inline handlers read r.Body themselves, so it is rewound over the
+		// bytes the gate consumed, the same discipline the auth middleware uses.
+		r.Body = io.NopCloser(bytes.NewReader(body))
 		return inline(gw, w, r)
-	}
-
-	accountID, _ := r.Context().Value(ctxAccountID).(string)
-	if accountID == "" {
-		slog.Error("ECR_Request: no account ID in auth context")
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		slog.Error("ECR_Request: failed to read body", "err", err)
-		return errors.New(awserrors.ErrorInvalidParameterValue)
 	}
 
 	output, err := handler(r.Context(), gw.NATSConn, accountID, body)

--- a/spinifex/gateway/ecrapi/authz.go
+++ b/spinifex/gateway/ecrapi/authz.go
@@ -1,0 +1,190 @@
+package gateway_ecrapi
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
+)
+
+// The resource a policy check evaluates against when the request names nothing
+// in particular, or when the identifier cannot be resolved at gate time.
+const anyResource = "*"
+
+// repositoryResourceType is the ARN resource-type segment for a repository.
+const repositoryResourceType = "repository"
+
+// Where an action's resource is named in the JSON body.
+type resourceSource uint8
+
+const (
+	sourceAny resourceSource = iota
+	sourceRepository
+	sourceRepositories
+	sourceTagARN
+)
+
+// Every action ECR_Request serves, with the resources AWS evaluates it against.
+// Exhaustive by contract: a completeness test compares this table with the
+// dispatch table in both directions, so an action cannot be added with a silent
+// account-wide grant.
+var ecrScopes = map[string][]resourceSource{
+	// The registry-level surface AWS evaluates against "*": an authorization
+	// token, the registry policy, replication and the scanning configuration
+	// are properties of the registry, not of any one repository.
+	"GetAuthorizationToken":                   {sourceAny},
+	"GetRegistryPolicy":                       {sourceAny},
+	"PutRegistryPolicy":                       {sourceAny},
+	"DescribeRegistry":                        {sourceAny},
+	"GetRegistryScanningConfiguration":        {sourceAny},
+	"PutRegistryScanningConfiguration":        {sourceAny},
+	"BatchGetRepositoryScanningConfiguration": {sourceAny},
+	"PutReplicationConfiguration":             {sourceAny},
+	// The repository list is account-level.
+	"ListRepositories": {sourceAny},
+
+	// Repositories.
+	"CreateRepository":      {sourceRepository},
+	"DeleteRepository":      {sourceRepository},
+	"DescribeRepositories":  {sourceRepositories},
+	"PutImageTagMutability": {sourceRepository},
+
+	// Images and layers.
+	"BatchGetImage":               {sourceRepository},
+	"BatchCheckLayerAvailability": {sourceRepository},
+	"BatchDeleteImage":            {sourceRepository},
+	"PutImage":                    {sourceRepository},
+	"ListImages":                  {sourceRepository},
+	"DescribeImages":              {sourceRepository},
+	"GetDownloadUrlForLayer":      {sourceRepository},
+	"InitiateLayerUpload":         {sourceRepository},
+	"UploadLayerPart":             {sourceRepository},
+	"CompleteLayerUpload":         {sourceRepository},
+	"ReplicateImage":              {sourceRepository},
+
+	// Repository policy.
+	"SetRepositoryPolicy":    {sourceRepository},
+	"GetRepositoryPolicy":    {sourceRepository},
+	"DeleteRepositoryPolicy": {sourceRepository},
+
+	// Repository scanning.
+	"PutImageScanningConfiguration": {sourceRepository},
+	"GetImageScanningConfiguration": {sourceRepository},
+	"StartImageScan":                {sourceRepository},
+	"DescribeImageScanFindings":     {sourceRepository},
+
+	// Lifecycle policy.
+	"PutLifecyclePolicy":          {sourceRepository},
+	"GetLifecyclePolicy":          {sourceRepository},
+	"DeleteLifecyclePolicy":       {sourceRepository},
+	"StartLifecyclePolicyPreview": {sourceRepository},
+	"GetLifecyclePolicyPreview":   {sourceRepository},
+
+	// Tags.
+	"TagResource":         {sourceTagARN},
+	"UntagResource":       {sourceTagARN},
+	"ListTagsForResource": {sourceTagARN},
+}
+
+// HasScope reports whether action has an explicit ECR scope-table entry.
+func HasScope(action string) bool {
+	_, ok := ecrScopes[action]
+	return ok
+}
+
+// ScopedActions returns every action represented in the ECR scope table.
+func ScopedActions() []string {
+	actions := make([]string, 0, len(ecrScopes))
+	for action := range ecrScopes {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+	return actions
+}
+
+// ResourceARNs resolves the resources an ECR control-plane request authorizes
+// against from the same body bytes the handler will unmarshal. The registryId a
+// body may carry is ignored: a caller-supplied account would let a request slide
+// out from under a Deny scoped to the real one.
+func ResourceARNs(action, region, accountID string, body []byte) ([]string, error) {
+	sources, ok := ecrScopes[action]
+	if !ok {
+		slog.Error("ECR authz: action is served but absent from the scope table", "action", action)
+		return nil, errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	scope := bodyscope.Parse(action, body)
+	resources := make([]string, 0, len(sources))
+	for _, source := range sources {
+		resolved, err := resolve(source, action, region, accountID, scope)
+		if err != nil {
+			return nil, err
+		}
+		for _, resource := range resolved {
+			// An unresolved member drops out rather than contributing "*", which
+			// no scoped Allow can match and which would deny a call AWS permits.
+			if resource == anyResource || slices.Contains(resources, resource) {
+				continue
+			}
+			resources = append(resources, resource)
+		}
+	}
+	if len(resources) == 0 {
+		return []string{anyResource}, nil
+	}
+	return resources, nil
+}
+
+func resolve(source resourceSource, action, region, accountID string, scope bodyscope.Scope) ([]string, error) {
+	switch source {
+	case sourceAny:
+		return nil, nil
+
+	case sourceRepository:
+		return []string{repositoryARN(region, accountID, scope.String("repositoryName"))}, nil
+
+	case sourceRepositories:
+		names := scope.Strings("repositoryNames")
+		out := make([]string, 0, len(names))
+		for _, name := range names {
+			out = append(out, repositoryARN(region, accountID, name))
+		}
+		return out, nil
+
+	case sourceTagARN:
+		return []string{tagARN(region, accountID, scope.String("resourceArn"))}, nil
+
+	default:
+		slog.Error("ECR authz: unhandled resource source, failing closed", "action", action, "source", source)
+		return nil, errors.New(awserrors.ErrorInternalError)
+	}
+}
+
+// An absent identifier authorizes account-wide, so a malformed request stays
+// the handler's validation fault rather than becoming an authorization failure.
+func repositoryARN(region, accountID, name string) string {
+	if region == "" || accountID == "" || name == "" {
+		return anyResource
+	}
+	return fmt.Sprintf("arn:aws:ecr:%s:%s:%s/%s", region, accountID, repositoryResourceType, name)
+}
+
+// tagARN re-anchors the caller-supplied resource ARN on gw.Region and the
+// caller's account: the tag handler keys off the repository name alone and
+// operates in the caller's own account bucket.
+func tagARN(region, accountID, resourceARN string) string {
+	parts := strings.SplitN(resourceARN, ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[2] != "ecr" {
+		return anyResource
+	}
+	kind, name, found := strings.Cut(parts[5], "/")
+	if !found || kind != repositoryResourceType || name == "" {
+		return anyResource
+	}
+	return repositoryARN(region, accountID, name)
+}

--- a/spinifex/gateway/ecrapi/authz.go
+++ b/spinifex/gateway/ecrapi/authz.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"sort"
 	"strings"
 
+	"github.com/mulgadc/spinifex/spinifex/awsec2query"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
 )
@@ -15,6 +15,12 @@ import (
 // The resource a policy check evaluates against when the request names nothing
 // in particular, or when the identifier cannot be resolved at gate time.
 const anyResource = "*"
+
+// Stands in for the name of every repository, where a describe with no list
+// enumerates the registry. It is a value, so a policy scoped to the type
+// matches it where "*" would not; a Deny naming one repository cannot fire,
+// which would need a store read the gate does not do.
+const anyName = "*"
 
 // repositoryResourceType is the ARN resource-type segment for a repository.
 const repositoryResourceType = "repository"
@@ -118,8 +124,13 @@ func ResourceARNs(action, region, accountID string, body []byte) ([]string, erro
 		return nil, errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	scope := bodyscope.Parse(action, body)
+	scope, err := bodyscope.Parse(action, body)
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
 	resources := make([]string, 0, len(sources))
+	seen := make(map[string]struct{}, len(sources))
 	for _, source := range sources {
 		resolved, err := resolve(source, action, region, accountID, scope)
 		if err != nil {
@@ -128,9 +139,16 @@ func ResourceARNs(action, region, accountID string, body []byte) ([]string, erro
 		for _, resource := range resolved {
 			// An unresolved member drops out rather than contributing "*", which
 			// no scoped Allow can match and which would deny a call AWS permits.
-			if resource == anyResource || slices.Contains(resources, resource) {
+			if resource == anyResource {
 				continue
 			}
+			if _, duplicate := seen[resource]; duplicate {
+				continue
+			}
+			if len(resources) >= awsec2query.MaxSliceLen {
+				return nil, errors.New(awserrors.ErrorMalformedQueryString)
+			}
+			seen[resource] = struct{}{}
 			resources = append(resources, resource)
 		}
 	}
@@ -150,6 +168,15 @@ func resolve(source resourceSource, action, region, accountID string, scope body
 
 	case sourceRepositories:
 		names := scope.Strings("repositoryNames")
+		if len(names) == 0 {
+			// A describe naming none enumerates every repository in the registry.
+			return []string{repositoryARN(region, accountID, anyName)}, nil
+		}
+		// Capped so a body-supplied list cannot make the gate do unbounded work
+		// ahead of the authorization decision.
+		if len(names) > awsec2query.MaxSliceLen {
+			return nil, errors.New(awserrors.ErrorMalformedQueryString)
+		}
 		out := make([]string, 0, len(names))
 		for _, name := range names {
 			out = append(out, repositoryARN(region, accountID, name))

--- a/spinifex/gateway/ecrapi/authz_test.go
+++ b/spinifex/gateway/ecrapi/authz_test.go
@@ -1,8 +1,12 @@
 package gateway_ecrapi_test
 
 import (
+	"encoding/json"
+	"strconv"
 	"testing"
 
+	"github.com/mulgadc/spinifex/spinifex/awsec2query"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_ecrapi "github.com/mulgadc/spinifex/spinifex/gateway/ecrapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,4 +89,46 @@ func TestResourceARNs_UnparseableOrAbsentIdentifierAuthorizesAccountWide(t *test
 func TestResourceARNs_UnknownActionIsRejected(t *testing.T) {
 	_, err := gateway_ecrapi.ResourceARNs("MadeUpAction", testRegion, testAccountID, nil)
 	require.Error(t, err)
+}
+
+// A describe naming no repository enumerates the whole registry, so the gate
+// names the type rather than widening to "*", which no scoped statement reaches.
+func TestResourceARNs_OmittedRepositoryListEnumeratesTheRegistry(t *testing.T) {
+	assert.Equal(t, []string{ecrARN("repository/*")}, resolve(t, "DescribeRepositories", `{}`))
+	assert.Equal(t, []string{ecrARN("repository/*")},
+		resolve(t, "DescribeRepositories", `{"repositoryNames":[]}`))
+}
+
+// A body-supplied list is capped, so the gate cannot be made to do unbounded
+// work ahead of the authorization decision.
+func TestResourceARNs_OversizedListIsRejected(t *testing.T) {
+	namesBody := func(n int) []byte {
+		refs := make([]string, 0, n)
+		for i := range n {
+			refs = append(refs, "r-"+strconv.Itoa(i))
+		}
+		names, err := json.Marshal(refs)
+		require.NoError(t, err)
+		return []byte(`{"repositoryNames":` + string(names) + `}`)
+	}
+
+	_, err := gateway_ecrapi.ResourceARNs("DescribeRepositories", testRegion, testAccountID,
+		namesBody(awsec2query.MaxSliceLen+1))
+	require.EqualError(t, err, awserrors.ErrorMalformedQueryString)
+
+	resources, err := gateway_ecrapi.ResourceARNs("DescribeRepositories", testRegion, testAccountID,
+		namesBody(awsec2query.MaxSliceLen))
+	require.NoError(t, err)
+	assert.Len(t, resources, awsec2query.MaxSliceLen)
+}
+
+// encoding/json resolves two spellings of one field in document order when the
+// handler builds its input; the gate cannot, so it refuses rather than name a
+// different repository than the handler acts on.
+func TestResourceARNs_FieldSpelledTwoWaysIsRejected(t *testing.T) {
+	for range 50 {
+		_, err := gateway_ecrapi.ResourceARNs("DeleteRepository", testRegion, testAccountID,
+			[]byte(`{"repositoryName":"dev","RepositoryName":"prod"}`))
+		require.EqualError(t, err, awserrors.ErrorInvalidParameterValue)
+	}
 }

--- a/spinifex/gateway/ecrapi/authz_test.go
+++ b/spinifex/gateway/ecrapi/authz_test.go
@@ -1,0 +1,88 @@
+package gateway_ecrapi_test
+
+import (
+	"testing"
+
+	gateway_ecrapi "github.com/mulgadc/spinifex/spinifex/gateway/ecrapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testRegion    = "ap-southeast-2"
+	testAccountID = "123456789012"
+)
+
+func ecrARN(resource string) string {
+	return "arn:aws:ecr:" + testRegion + ":" + testAccountID + ":" + resource
+}
+
+func resolve(t *testing.T, action, body string) []string {
+	t.Helper()
+	resources, err := gateway_ecrapi.ResourceARNs(action, testRegion, testAccountID, []byte(body))
+	require.NoError(t, err)
+	return resources
+}
+
+// TestScopeTableIsExhaustive is what stops the next ECR action being added with
+// a silent account-wide grant. Both directions, so a scope left behind by a
+// deleted or renamed action fails too.
+func TestScopeTableIsExhaustive(t *testing.T) {
+	for action := range gateway_ecrapi.Actions {
+		assert.True(t, gateway_ecrapi.HasScope(action),
+			"ecr action %q has no resource scope entry: add one to ecrScopes in gateway/ecrapi/authz.go", action)
+	}
+	for _, action := range gateway_ecrapi.ScopedActions() {
+		_, served := gateway_ecrapi.Actions[action]
+		assert.True(t, served,
+			"ecrScopes has an entry for %q, which the dispatch table does not serve: remove it from gateway/ecrapi/authz.go", action)
+	}
+}
+
+func TestResourceARNs_RepositoryIsResolvedFromTheBody(t *testing.T) {
+	assert.Equal(t, []string{ecrARN("repository/app")},
+		resolve(t, "DeleteRepository", `{"repositoryName":"app"}`))
+	assert.Equal(t, []string{ecrARN("repository/app"), ecrARN("repository/api")},
+		resolve(t, "DescribeRepositories", `{"repositoryNames":["app","api"]}`))
+}
+
+// A caller-supplied account would let a request slide out from under a Deny
+// scoped to the real one, so registryId is ignored.
+func TestResourceARNs_RegistryIDInTheBodyIsIgnored(t *testing.T) {
+	assert.Equal(t, []string{ecrARN("repository/app")},
+		resolve(t, "PutImage", `{"registryId":"999999999999","repositoryName":"app"}`))
+}
+
+// The registry-level surface is what AWS evaluates against "*".
+func TestResourceARNs_RegistryLevelActionsStayAccountWide(t *testing.T) {
+	for _, action := range []string{
+		"GetAuthorizationToken", "GetRegistryPolicy", "PutRegistryPolicy", "DescribeRegistry",
+		"GetRegistryScanningConfiguration", "PutRegistryScanningConfiguration",
+		"BatchGetRepositoryScanningConfiguration", "PutReplicationConfiguration", "ListRepositories",
+	} {
+		assert.Equal(t, []string{"*"}, resolve(t, action, `{"repositoryName":"app"}`), "action %q", action)
+	}
+}
+
+// A tag request names its resource by ARN; the tag handler keys off the
+// repository name alone, so the gate re-anchors on the caller's account.
+func TestResourceARNs_TagARNIsReanchored(t *testing.T) {
+	foreign := `{"resourceArn":"arn:aws:ecr:us-east-1:999999999999:repository/app"}`
+	assert.Equal(t, []string{ecrARN("repository/app")}, resolve(t, "ListTagsForResource", foreign))
+	assert.Equal(t, []string{"*"},
+		resolve(t, "TagResource", `{"resourceArn":"arn:aws:ecr:::registry/app"}`))
+}
+
+// A body the gate cannot parse authorizes account-wide: it is the handler that
+// rejects a malformed request.
+func TestResourceARNs_UnparseableOrAbsentIdentifierAuthorizesAccountWide(t *testing.T) {
+	assert.Equal(t, []string{"*"}, resolve(t, "DeleteRepository", "{not json"))
+	assert.Equal(t, []string{"*"}, resolve(t, "DeleteRepository", `{}`))
+}
+
+// An action that is served but has no entry fails closed rather than defaulting
+// to an account-wide grant.
+func TestResourceARNs_UnknownActionIsRejected(t *testing.T) {
+	_, err := gateway_ecrapi.ResourceARNs("MadeUpAction", testRegion, testAccountID, nil)
+	require.Error(t, err)
+}

--- a/spinifex/gateway/ecs.go
+++ b/spinifex/gateway/ecs.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -36,20 +35,28 @@ func (gw *GatewayConfig) ECS_Request(w http.ResponseWriter, r *http.Request) err
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "ecs", action); err != nil {
-		return err
-	}
-
+	// Hoisted above the policy check because the resolver builds ARNs from the
+	// caller's account and from the same body bytes the handler unmarshals.
 	accountID, _ := r.Context().Value(ctxAccountID).(string)
 	if accountID == "" {
 		slog.ErrorContext(r.Context(), "ECS_Request: no account ID in auth context")
-		return errors.New(awserrors.ErrorServerInternal)
+		// InternalError, not ServerInternal: the policy gate used to reach this
+		// case first and that is the code the caller has always seen.
+		return errors.New(awserrors.ErrorInternalError)
 	}
 
-	body, err := io.ReadAll(r.Body)
+	body, err := readBoundedBody(r)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "ECS_Request: failed to read body", "err", err)
-		return errors.New(awserrors.ErrorInvalidParameterValue)
+		return err
+	}
+
+	resources, err := gateway_ecs.ResourceARNs(action, gw.Region, accountID, body)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResources(r, "ecs", action, resources); err != nil {
+		return err
 	}
 
 	// Mirrors gateway/ec2.go's RunInstances/AssociateIamInstanceProfile closures:

--- a/spinifex/gateway/ecs/authz.go
+++ b/spinifex/gateway/ecs/authz.go
@@ -1,0 +1,328 @@
+package gateway_ecs
+
+import (
+	"errors"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
+	handlers_ecs "github.com/mulgadc/spinifex/spinifex/handlers/ecs"
+)
+
+// The resource a policy check evaluates against when the request names nothing
+// in particular, or when the identifier cannot be resolved at gate time.
+const anyResource = "*"
+
+// A task-definition reference without a revision means "latest", which the gate
+// cannot resolve without a store read. The literal "*" is a value, so it matches
+// the AWS-documented spelling without widening a grant.
+const anyRevision = "*"
+
+// Where an action's resource is named in the JSON body. Cluster-scoped sources
+// read the request's "cluster" field alongside their own identifier.
+type resourceSource uint8
+
+const (
+	sourceAny resourceSource = iota
+	sourceCluster
+	sourceNewCluster
+	sourceClusters
+	sourceService
+	sourceNewService
+	sourceServices
+	sourceTask
+	sourceTasks
+	sourceContainerInstance
+	sourceContainerInstances
+	sourceTaskDefinition
+	sourceNewCapacityProvider
+	sourceCapacityProvider
+	sourceCapacityProviders
+	sourceTagARN
+)
+
+// Every action ECS_Request serves, with the resources AWS evaluates it against.
+// Exhaustive by contract: a completeness test compares this table with the
+// dispatch table in both directions, so an action cannot be added with a silent
+// account-wide grant.
+var ecsScopes = map[string][]resourceSource{
+	// Clusters.
+	"CreateCluster":               {sourceNewCluster},
+	"DeleteCluster":               {sourceCluster},
+	"UpdateCluster":               {sourceCluster},
+	"DescribeClusters":            {sourceClusters},
+	"PutClusterCapacityProviders": {sourceCluster},
+	// Internal capacity launch. Not an AWS action, but it names the cluster it
+	// launches container instances into.
+	"ProvisionCapacity": {sourceCluster},
+	// The cluster list is account-level.
+	"ListClusters": {sourceAny},
+
+	// Services.
+	"CreateService":    {sourceNewService},
+	"UpdateService":    {sourceService},
+	"DeleteService":    {sourceService},
+	"DescribeServices": {sourceServices},
+	// AWS documents no resource type for the service lists.
+	"ListServices":            {sourceAny},
+	"ListServicesByNamespace": {sourceAny},
+
+	// Tasks.
+	"StopTask":      {sourceTask},
+	"DescribeTasks": {sourceTasks},
+	// Internal agent report; it names the task it reports devices for.
+	"ReportTaskGPU": {sourceTask},
+	// AWS documents no resource type for ListTasks, and a state change names
+	// its task by ARN in a field the handler resolves rather than the gate.
+	"ListTasks":             {sourceAny},
+	"SubmitTaskStateChange": {sourceAny},
+
+	// Container instances.
+	"DeregisterContainerInstance":   {sourceContainerInstance},
+	"DescribeContainerInstances":    {sourceContainerInstances},
+	"UpdateContainerInstancesState": {sourceContainerInstances},
+	// Internal agent poll; it names the instance whose inbox it drains.
+	"PollAssignments": {sourceContainerInstance},
+	// A container instance has no id until the handler mints one, and AWS
+	// documents no resource type for the list.
+	"RegisterContainerInstance": {sourceAny},
+	"ListContainerInstances":    {sourceAny},
+
+	// Task definitions. AWS evaluates a run against the definition it launches.
+	"DeregisterTaskDefinition": {sourceTaskDefinition},
+	"RunTask":                  {sourceTaskDefinition},
+	"StartTask":                {sourceTaskDefinition},
+	// AWS documents no resource type for these four.
+	"RegisterTaskDefinition":     {sourceAny},
+	"DescribeTaskDefinition":     {sourceAny},
+	"ListTaskDefinitions":        {sourceAny},
+	"ListTaskDefinitionFamilies": {sourceAny},
+
+	// Capacity providers.
+	"CreateCapacityProvider":    {sourceNewCapacityProvider},
+	"DeleteCapacityProvider":    {sourceCapacityProvider},
+	"DescribeCapacityProviders": {sourceCapacityProviders},
+
+	// Account settings are account-level.
+	"PutAccountSetting":   {sourceAny},
+	"ListAccountSettings": {sourceAny},
+
+	// Tags.
+	"TagResource":         {sourceTagARN},
+	"UntagResource":       {sourceTagARN},
+	"ListTagsForResource": {sourceTagARN},
+}
+
+// HasScope reports whether action has an explicit ECS scope-table entry.
+func HasScope(action string) bool {
+	_, ok := ecsScopes[action]
+	return ok
+}
+
+// ScopedActions returns every action represented in the ECS scope table.
+func ScopedActions() []string {
+	actions := make([]string, 0, len(ecsScopes))
+	for action := range ecsScopes {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+	return actions
+}
+
+// ResourceARNs resolves the resources an ECS request authorizes against from
+// the same body bytes the handler will unmarshal.
+func ResourceARNs(action, region, accountID string, body []byte) ([]string, error) {
+	sources, ok := ecsScopes[action]
+	if !ok {
+		slog.Error("ECS authz: action is served but absent from the scope table", "action", action)
+		return nil, errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	scope := bodyscope.Parse(action, body)
+	resources := make([]string, 0, len(sources))
+	for _, source := range sources {
+		resolved, err := resolve(source, action, region, accountID, scope)
+		if err != nil {
+			return nil, err
+		}
+		for _, resource := range resolved {
+			// An unresolved member drops out rather than contributing "*", which
+			// no scoped Allow can match and which would deny a call AWS permits.
+			if resource == anyResource || slices.Contains(resources, resource) {
+				continue
+			}
+			resources = append(resources, resource)
+		}
+	}
+	if len(resources) == 0 {
+		return []string{anyResource}, nil
+	}
+	return resources, nil
+}
+
+func resolve(source resourceSource, action, region, accountID string, scope bodyscope.Scope) ([]string, error) {
+	// The handler resolves an omitted cluster to "default", so the gate must
+	// too, or a fence on the default cluster never fires.
+	cluster := handlers_ecs.ClusterShortName(scope.String("cluster"))
+
+	switch source {
+	case sourceAny:
+		return nil, nil
+
+	case sourceCluster:
+		return one(clusterARN(region, accountID, cluster)), nil
+
+	case sourceNewCluster:
+		name := handlers_ecs.ClusterShortName(scope.String("clusterName"))
+		return one(clusterARN(region, accountID, name)), nil
+
+	case sourceClusters:
+		return each(scope.Strings("clusters"), func(ref string) string {
+			return clusterARN(region, accountID, handlers_ecs.ClusterShortName(ref))
+		}), nil
+
+	case sourceService:
+		return one(serviceARN(region, accountID, cluster, scope.String("service"))), nil
+
+	case sourceNewService:
+		return one(serviceARN(region, accountID, cluster, scope.String("serviceName"))), nil
+
+	case sourceServices:
+		return each(scope.Strings("services"), func(ref string) string {
+			return serviceARN(region, accountID, cluster, ref)
+		}), nil
+
+	case sourceTask:
+		return one(taskARN(region, accountID, cluster, scope.String("task"))), nil
+
+	case sourceTasks:
+		return each(scope.Strings("tasks"), func(ref string) string {
+			return taskARN(region, accountID, cluster, ref)
+		}), nil
+
+	case sourceContainerInstance:
+		return one(containerInstanceARN(region, accountID, cluster, scope.String("containerInstance"))), nil
+
+	case sourceContainerInstances:
+		return each(scope.Strings("containerInstances"), func(ref string) string {
+			return containerInstanceARN(region, accountID, cluster, ref)
+		}), nil
+
+	case sourceTaskDefinition:
+		return one(taskDefARN(region, accountID, scope.String("taskDefinition"))), nil
+
+	case sourceNewCapacityProvider:
+		return one(capacityProviderARN(region, accountID, scope.String("name"))), nil
+
+	case sourceCapacityProvider:
+		return one(capacityProviderARN(region, accountID, scope.String("capacityProvider"))), nil
+
+	case sourceCapacityProviders:
+		return each(scope.Strings("capacityProviders"), func(ref string) string {
+			return capacityProviderARN(region, accountID, ref)
+		}), nil
+
+	case sourceTagARN:
+		return one(tagARN(region, accountID, scope.String("resourceArn"))), nil
+
+	default:
+		slog.Error("ECS authz: unhandled resource source, failing closed", "action", action, "source", source)
+		return nil, errors.New(awserrors.ErrorInternalError)
+	}
+}
+
+func one(resource string) []string {
+	return []string{resource}
+}
+
+func each(refs []string, build func(string) string) []string {
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, build(ref))
+	}
+	return out
+}
+
+// An absent identifier authorizes account-wide, so a malformed request stays
+// the handler's validation fault rather than becoming an authorization failure.
+func clusterARN(region, accountID, cluster string) string {
+	if region == "" || accountID == "" || cluster == "" {
+		return anyResource
+	}
+	return handlers_ecs.ClusterARN(region, accountID, cluster)
+}
+
+func serviceARN(region, accountID, cluster, ref string) string {
+	name := handlers_ecs.ServiceShortName(ref)
+	if region == "" || accountID == "" || cluster == "" || name == "" {
+		return anyResource
+	}
+	return handlers_ecs.ServiceARN(region, accountID, cluster, name)
+}
+
+func taskARN(region, accountID, cluster, ref string) string {
+	id := handlers_ecs.TaskShortID(ref)
+	if region == "" || accountID == "" || cluster == "" || id == "" {
+		return anyResource
+	}
+	return handlers_ecs.TaskARN(region, accountID, cluster, id)
+}
+
+func containerInstanceARN(region, accountID, cluster, ref string) string {
+	id := handlers_ecs.ContainerInstanceShortID(ref)
+	if region == "" || accountID == "" || cluster == "" || id == "" {
+		return anyResource
+	}
+	return handlers_ecs.ContainerInstanceARN(region, accountID, cluster, id)
+}
+
+func capacityProviderARN(region, accountID, ref string) string {
+	name := handlers_ecs.CapacityProviderShortName(ref)
+	if region == "" || accountID == "" || name == "" {
+		return anyResource
+	}
+	return handlers_ecs.CapacityProviderARN(region, accountID, name)
+}
+
+// taskDefARN resolves "family", "family:revision" or a full ARN the way the
+// handler does. A reference naming no revision wildcards it.
+func taskDefARN(region, accountID, ref string) string {
+	if ref == "" || region == "" || accountID == "" {
+		return anyResource
+	}
+	family, rev := handlers_ecs.ParseTaskDefRef(ref)
+	if family == "" {
+		return anyResource
+	}
+	if rev <= 0 {
+		return handlers_ecs.TaskDefRefARN(region, accountID, family, anyRevision)
+	}
+	return handlers_ecs.TaskDefARN(region, accountID, family, rev)
+}
+
+// tagARN re-anchors the caller-supplied resource ARN on gw.Region and the
+// caller's account, because the tag handler ignores those segments and operates
+// in the caller's own account bucket.
+func tagARN(region, accountID, resourceARN string) string {
+	if region == "" || accountID == "" {
+		return anyResource
+	}
+	parts := strings.SplitN(resourceARN, ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[2] != "ecs" {
+		return anyResource
+	}
+	kind, resource, found := strings.Cut(parts[5], "/")
+	if !found || resource == "" {
+		return anyResource
+	}
+	switch kind {
+	case "cluster", "task-definition", "service", "task", "container-instance":
+		return "arn:aws:ecs:" + region + ":" + accountID + ":" + parts[5]
+	default:
+		// An ARN the tag handler rejects stays its own validation fault.
+		return anyResource
+	}
+}

--- a/spinifex/gateway/ecs/authz.go
+++ b/spinifex/gateway/ecs/authz.go
@@ -3,10 +3,9 @@ package gateway_ecs
 import (
 	"errors"
 	"log/slog"
-	"slices"
 	"sort"
-	"strings"
 
+	"github.com/mulgadc/spinifex/spinifex/awsec2query"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
 	handlers_ecs "github.com/mulgadc/spinifex/spinifex/handlers/ecs"
@@ -20,6 +19,12 @@ const anyResource = "*"
 // cannot resolve without a store read. The literal "*" is a value, so it matches
 // the AWS-documented spelling without widening a grant.
 const anyRevision = "*"
+
+// Stands in for the name of every resource of a type, where a describe with no
+// list enumerates the account. It is a value, so a policy scoped to the type
+// matches it where "*" would not; a Deny naming one member cannot fire, which
+// would need a store read the gate does not do.
+const anyName = "*"
 
 // Where an action's resource is named in the JSON body. Cluster-scoped sources
 // read the request's "cluster" field alongside their own identifier.
@@ -75,10 +80,11 @@ var ecsScopes = map[string][]resourceSource{
 	"DescribeTasks": {sourceTasks},
 	// Internal agent report; it names the task it reports devices for.
 	"ReportTaskGPU": {sourceTask},
-	// AWS documents no resource type for ListTasks, and a state change names
-	// its task by ARN in a field the handler resolves rather than the gate.
-	"ListTasks":             {sourceAny},
-	"SubmitTaskStateChange": {sourceAny},
+	// The agent's state report names the task it reports, in the same two
+	// fields the handler resolves it from.
+	"SubmitTaskStateChange": {sourceTask},
+	// AWS documents no resource type for ListTasks.
+	"ListTasks": {sourceAny},
 
 	// Container instances.
 	"DeregisterContainerInstance":   {sourceContainerInstance},
@@ -141,8 +147,13 @@ func ResourceARNs(action, region, accountID string, body []byte) ([]string, erro
 		return nil, errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	scope := bodyscope.Parse(action, body)
+	scope, err := bodyscope.Parse(action, body)
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
 	resources := make([]string, 0, len(sources))
+	seen := make(map[string]struct{}, len(sources))
 	for _, source := range sources {
 		resolved, err := resolve(source, action, region, accountID, scope)
 		if err != nil {
@@ -151,9 +162,16 @@ func ResourceARNs(action, region, accountID string, body []byte) ([]string, erro
 		for _, resource := range resolved {
 			// An unresolved member drops out rather than contributing "*", which
 			// no scoped Allow can match and which would deny a call AWS permits.
-			if resource == anyResource || slices.Contains(resources, resource) {
+			if resource == anyResource {
 				continue
 			}
+			if _, duplicate := seen[resource]; duplicate {
+				continue
+			}
+			if len(resources) >= awsec2query.MaxSliceLen {
+				return nil, errors.New(awserrors.ErrorMalformedQueryString)
+			}
+			seen[resource] = struct{}{}
 			resources = append(resources, resource)
 		}
 	}
@@ -180,9 +198,15 @@ func resolve(source resourceSource, action, region, accountID string, scope body
 		return one(clusterARN(region, accountID, name)), nil
 
 	case sourceClusters:
-		return each(scope.Strings("clusters"), func(ref string) string {
+		refs := scope.Strings("clusters")
+		if len(refs) == 0 {
+			// A describe naming no cluster describes the default one, exactly
+			// as the handler resolves it.
+			return one(clusterARN(region, accountID, cluster)), nil
+		}
+		return each(refs, func(ref string) string {
 			return clusterARN(region, accountID, handlers_ecs.ClusterShortName(ref))
-		}), nil
+		})
 
 	case sourceService:
 		return one(serviceARN(region, accountID, cluster, scope.String("service"))), nil
@@ -193,7 +217,7 @@ func resolve(source resourceSource, action, region, accountID string, scope body
 	case sourceServices:
 		return each(scope.Strings("services"), func(ref string) string {
 			return serviceARN(region, accountID, cluster, ref)
-		}), nil
+		})
 
 	case sourceTask:
 		return one(taskARN(region, accountID, cluster, scope.String("task"))), nil
@@ -201,7 +225,7 @@ func resolve(source resourceSource, action, region, accountID string, scope body
 	case sourceTasks:
 		return each(scope.Strings("tasks"), func(ref string) string {
 			return taskARN(region, accountID, cluster, ref)
-		}), nil
+		})
 
 	case sourceContainerInstance:
 		return one(containerInstanceARN(region, accountID, cluster, scope.String("containerInstance"))), nil
@@ -209,7 +233,7 @@ func resolve(source resourceSource, action, region, accountID string, scope body
 	case sourceContainerInstances:
 		return each(scope.Strings("containerInstances"), func(ref string) string {
 			return containerInstanceARN(region, accountID, cluster, ref)
-		}), nil
+		})
 
 	case sourceTaskDefinition:
 		return one(taskDefARN(region, accountID, scope.String("taskDefinition"))), nil
@@ -221,9 +245,14 @@ func resolve(source resourceSource, action, region, accountID string, scope body
 		return one(capacityProviderARN(region, accountID, scope.String("capacityProvider"))), nil
 
 	case sourceCapacityProviders:
-		return each(scope.Strings("capacityProviders"), func(ref string) string {
+		refs := scope.Strings("capacityProviders")
+		if len(refs) == 0 {
+			// A describe naming none enumerates every provider in the account.
+			return one(capacityProviderARN(region, accountID, anyName)), nil
+		}
+		return each(refs, func(ref string) string {
 			return capacityProviderARN(region, accountID, ref)
-		}), nil
+		})
 
 	case sourceTagARN:
 		return one(tagARN(region, accountID, scope.String("resourceArn"))), nil
@@ -238,12 +267,17 @@ func one(resource string) []string {
 	return []string{resource}
 }
 
-func each(refs []string, build func(string) string) []string {
+// each builds one ARN per reference, capped so a body-supplied list cannot make
+// the gate do unbounded work ahead of the authorization decision.
+func each(refs []string, build func(string) string) ([]string, error) {
+	if len(refs) > awsec2query.MaxSliceLen {
+		return nil, errors.New(awserrors.ErrorMalformedQueryString)
+	}
 	out := make([]string, 0, len(refs))
 	for _, ref := range refs {
 		out = append(out, build(ref))
 	}
-	return out
+	return out, nil
 }
 
 // An absent identifier authorizes account-wide, so a malformed request stays
@@ -305,24 +339,16 @@ func taskDefARN(region, accountID, ref string) string {
 
 // tagARN re-anchors the caller-supplied resource ARN on gw.Region and the
 // caller's account, because the tag handler ignores those segments and operates
-// in the caller's own account bucket.
+// in the caller's own account bucket. The handler's own parser decides which
+// ARNs are acceptable, so the gate cannot come to name a different object.
 func tagARN(region, accountID, resourceARN string) string {
 	if region == "" || accountID == "" {
 		return anyResource
 	}
-	parts := strings.SplitN(resourceARN, ":", 6)
-	if len(parts) != 6 || parts[0] != "arn" || parts[2] != "ecs" {
-		return anyResource
-	}
-	kind, resource, found := strings.Cut(parts[5], "/")
-	if !found || resource == "" {
-		return anyResource
-	}
-	switch kind {
-	case "cluster", "task-definition", "service", "task", "container-instance":
-		return "arn:aws:ecs:" + region + ":" + accountID + ":" + parts[5]
-	default:
+	segment, err := handlers_ecs.ResourceARNSegment(resourceARN)
+	if err != nil {
 		// An ARN the tag handler rejects stays its own validation fault.
 		return anyResource
 	}
+	return "arn:aws:ecs:" + region + ":" + accountID + ":" + segment
 }

--- a/spinifex/gateway/ecs/authz_test.go
+++ b/spinifex/gateway/ecs/authz_test.go
@@ -1,8 +1,12 @@
 package gateway_ecs_test
 
 import (
+	"encoding/json"
+	"strconv"
 	"testing"
 
+	"github.com/mulgadc/spinifex/spinifex/awsec2query"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_ecs "github.com/mulgadc/spinifex/spinifex/gateway/ecs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,7 +113,7 @@ func TestResourceARNs_AccountWideActionsStayAccountWide(t *testing.T) {
 		"ListClusters", "ListServices", "ListTasks", "ListTaskDefinitions",
 		"ListTaskDefinitionFamilies", "ListContainerInstances", "ListServicesByNamespace",
 		"RegisterTaskDefinition", "DescribeTaskDefinition", "RegisterContainerInstance",
-		"SubmitTaskStateChange", "PutAccountSetting", "ListAccountSettings",
+		"PutAccountSetting", "ListAccountSettings",
 	} {
 		assert.Equal(t, []string{"*"}, resolve(t, action, `{"cluster":"prod"}`), "action %q", action)
 	}
@@ -120,4 +124,70 @@ func TestResourceARNs_AccountWideActionsStayAccountWide(t *testing.T) {
 func TestResourceARNs_UnknownActionIsRejected(t *testing.T) {
 	_, err := gateway_ecs.ResourceARNs("MadeUpAction", testRegion, testAccountID, nil)
 	require.Error(t, err)
+}
+
+// The agent's state report names its task in the same two fields the handler
+// resolves it from, so a fence on the task applies to the report.
+func TestResourceARNs_SubmitTaskStateChangeIsScopedToItsTask(t *testing.T) {
+	assert.Equal(t, []string{ecsARN("task/prod/t-1")},
+		resolve(t, "SubmitTaskStateChange", `{"cluster":"prod","task":"t-1"}`))
+	assert.Equal(t, []string{ecsARN("task/prod/t-1")},
+		resolve(t, "SubmitTaskStateChange", `{"cluster":"prod","task":"`+ecsARN("task/prod/t-1")+`"}`))
+}
+
+// A describe naming no cluster describes the default one, and naming no
+// capacity provider enumerates them all. Either way the gate must not widen to
+// "*", which no scoped statement can reach.
+func TestResourceARNs_OmittedListResolvesTheWayTheHandlerDoes(t *testing.T) {
+	assert.Equal(t, []string{ecsARN("cluster/default")}, resolve(t, "DescribeClusters", `{}`))
+	assert.Equal(t, []string{ecsARN("cluster/default")}, resolve(t, "DescribeClusters", `{"clusters":[]}`))
+	assert.Equal(t, []string{ecsARN("capacity-provider/*")},
+		resolve(t, "DescribeCapacityProviders", `{}`))
+}
+
+// The gate accepts exactly the ARNs the tag handler accepts, because both go
+// through the handler's own parser. A wrong service segment is rejected by both.
+func TestResourceARNs_TagARNMatchesTheHandlersParser(t *testing.T) {
+	for _, resourceARN := range []string{
+		"arn:aws:ecsx:us-east-1:999999999999:cluster/prod",
+		"arn:aws:ecs:us-east-1:999999999999:service/web",
+		"arn:aws:ecs:us-east-1:999999999999:widget/prod",
+	} {
+		assert.Equal(t, []string{"*"},
+			resolve(t, "TagResource", `{"resourceArn":"`+resourceARN+`"}`), "arn %q", resourceARN)
+	}
+}
+
+// A body-supplied list is capped, so the gate cannot be made to do unbounded
+// work ahead of the authorization decision.
+func TestResourceARNs_OversizedListIsRejected(t *testing.T) {
+	clustersBody := func(n int) []byte {
+		refs := make([]string, 0, n)
+		for i := range n {
+			refs = append(refs, "c-"+strconv.Itoa(i))
+		}
+		names, err := json.Marshal(refs)
+		require.NoError(t, err)
+		return []byte(`{"clusters":` + string(names) + `}`)
+	}
+
+	_, err := gateway_ecs.ResourceARNs("DescribeClusters", testRegion, testAccountID,
+		clustersBody(awsec2query.MaxSliceLen+1))
+	require.EqualError(t, err, awserrors.ErrorMalformedQueryString)
+
+	resources, err := gateway_ecs.ResourceARNs("DescribeClusters", testRegion, testAccountID,
+		clustersBody(awsec2query.MaxSliceLen))
+	require.NoError(t, err)
+	assert.Len(t, resources, awsec2query.MaxSliceLen)
+}
+
+// encoding/json resolves two spellings of one field in document order when the
+// handler builds its input; the gate cannot, so it refuses rather than name a
+// different cluster than the handler acts on.
+func TestResourceARNs_FieldSpelledTwoWaysIsRejected(t *testing.T) {
+	for range 50 {
+		_, err := gateway_ecs.ResourceARNs("DeleteCluster", testRegion, testAccountID,
+			[]byte(`{"cluster":"dev","Cluster":"prod"}`))
+		require.EqualError(t, err, awserrors.ErrorInvalidParameterValue)
+	}
 }

--- a/spinifex/gateway/ecs/authz_test.go
+++ b/spinifex/gateway/ecs/authz_test.go
@@ -1,0 +1,123 @@
+package gateway_ecs_test
+
+import (
+	"testing"
+
+	gateway_ecs "github.com/mulgadc/spinifex/spinifex/gateway/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testRegion    = "ap-southeast-2"
+	testAccountID = "123456789012"
+)
+
+func ecsARN(resource string) string {
+	return "arn:aws:ecs:" + testRegion + ":" + testAccountID + ":" + resource
+}
+
+func resolve(t *testing.T, action, body string) []string {
+	t.Helper()
+	resources, err := gateway_ecs.ResourceARNs(action, testRegion, testAccountID, []byte(body))
+	require.NoError(t, err)
+	return resources
+}
+
+// TestScopeTableIsExhaustive is what stops the next ECS action being added with
+// a silent account-wide grant. Both directions, so a scope left behind by a
+// deleted or renamed action fails too.
+func TestScopeTableIsExhaustive(t *testing.T) {
+	for action := range gateway_ecs.Actions {
+		assert.True(t, gateway_ecs.HasScope(action),
+			"ecs action %q has no resource scope entry: add one to ecsScopes in gateway/ecs/authz.go", action)
+	}
+	for _, action := range gateway_ecs.ScopedActions() {
+		_, served := gateway_ecs.Actions[action]
+		assert.True(t, served,
+			"ecsScopes has an entry for %q, which the dispatch table does not serve: remove it from gateway/ecs/authz.go", action)
+	}
+}
+
+// The detail that decides whether a fence on the default cluster fires at all:
+// the handler resolves an omitted cluster to "default", so the gate must too.
+func TestResourceARNs_OmittedClusterResolvesToDefault(t *testing.T) {
+	assert.Equal(t, []string{ecsARN("cluster/default")}, resolve(t, "DeleteCluster", `{}`))
+	assert.Equal(t, []string{ecsARN("cluster/default")}, resolve(t, "CreateCluster", `{}`))
+	assert.Equal(t, []string{ecsARN("service/default/web")},
+		resolve(t, "DeleteService", `{"service":"web"}`))
+}
+
+// A cluster ARN and a bare name name the same cluster, because the handler
+// normalizes both the same way.
+func TestResourceARNs_ClusterARNAndNameResolveIdentically(t *testing.T) {
+	byName := resolve(t, "DeleteCluster", `{"cluster":"prod"}`)
+	byARN := resolve(t, "DeleteCluster", `{"cluster":"`+ecsARN("cluster/prod")+`"}`)
+	assert.Equal(t, byName, byARN)
+	assert.Equal(t, []string{ecsARN("cluster/prod")}, byName)
+}
+
+func TestResourceARNs_ShortIDsAreExtractedFromARNs(t *testing.T) {
+	assert.Equal(t, []string{ecsARN("task/prod/t-1")},
+		resolve(t, "StopTask", `{"cluster":"prod","task":"`+ecsARN("task/prod/t-1")+`"}`))
+	assert.Equal(t, []string{ecsARN("container-instance/prod/ci-1")},
+		resolve(t, "DeregisterContainerInstance",
+			`{"cluster":"prod","containerInstance":"`+ecsARN("container-instance/prod/ci-1")+`"}`))
+	assert.Equal(t, []string{ecsARN("capacity-provider/cp")},
+		resolve(t, "DeleteCapacityProvider", `{"capacityProvider":"`+ecsARN("capacity-provider/cp")+`"}`))
+}
+
+// A reference without a revision means latest, which the gate cannot resolve.
+// The trailing "*" is the AWS-documented spelling, and is a value, not a widening.
+func TestResourceARNs_TaskDefinitionWithoutRevisionWildcardsIt(t *testing.T) {
+	assert.Equal(t, []string{ecsARN("task-definition/app:*")},
+		resolve(t, "RunTask", `{"taskDefinition":"app"}`))
+	assert.Equal(t, []string{ecsARN("task-definition/app:3")},
+		resolve(t, "RunTask", `{"taskDefinition":"app:3"}`))
+	assert.Equal(t, []string{ecsARN("task-definition/app:3")},
+		resolve(t, "StartTask", `{"taskDefinition":"`+ecsARN("task-definition/app:3")+`"}`))
+}
+
+// A list action names every resource it asks about, and each is evaluated.
+func TestResourceARNs_ListFieldsResolveEveryMember(t *testing.T) {
+	assert.Equal(t, []string{ecsARN("cluster/prod"), ecsARN("cluster/dev")},
+		resolve(t, "DescribeClusters", `{"clusters":["prod","dev"]}`))
+	assert.Equal(t, []string{ecsARN("service/prod/web"), ecsARN("service/prod/api")},
+		resolve(t, "DescribeServices", `{"cluster":"prod","services":["web","api"]}`))
+}
+
+// A tag request names its resource by ARN. The handler ignores that ARN's
+// region and account and works in the caller's, so the gate must too.
+func TestResourceARNs_TagARNIsReanchored(t *testing.T) {
+	foreign := `{"resourceArn":"arn:aws:ecs:us-east-1:999999999999:cluster/prod"}`
+	assert.Equal(t, []string{ecsARN("cluster/prod")}, resolve(t, "TagResource", foreign))
+	assert.Equal(t, []string{ecsARN("service/prod/web")},
+		resolve(t, "ListTagsForResource", `{"resourceArn":"`+ecsARN("service/prod/web")+`"}`))
+	// An ARN the tag handler rejects stays its own validation fault.
+	assert.Equal(t, []string{"*"}, resolve(t, "UntagResource", `{"resourceArn":"arn:aws:ecs:::not-a-resource"}`))
+}
+
+// A body the gate cannot parse authorizes account-wide: it is the handler that
+// rejects a malformed request.
+func TestResourceARNs_UnparseableBodyAuthorizesAccountWide(t *testing.T) {
+	assert.Equal(t, []string{"*"}, resolve(t, "DescribeServices", "{not json"))
+	assert.Equal(t, []string{"*"}, resolve(t, "DescribeTasks", `{"cluster":"prod"}`))
+}
+
+func TestResourceARNs_AccountWideActionsStayAccountWide(t *testing.T) {
+	for _, action := range []string{
+		"ListClusters", "ListServices", "ListTasks", "ListTaskDefinitions",
+		"ListTaskDefinitionFamilies", "ListContainerInstances", "ListServicesByNamespace",
+		"RegisterTaskDefinition", "DescribeTaskDefinition", "RegisterContainerInstance",
+		"SubmitTaskStateChange", "PutAccountSetting", "ListAccountSettings",
+	} {
+		assert.Equal(t, []string{"*"}, resolve(t, action, `{"cluster":"prod"}`), "action %q", action)
+	}
+}
+
+// An action that is served but has no entry fails closed rather than defaulting
+// to an account-wide grant.
+func TestResourceARNs_UnknownActionIsRejected(t *testing.T) {
+	_, err := gateway_ecs.ResourceARNs("MadeUpAction", testRegion, testAccountID, nil)
+	require.Error(t, err)
+}

--- a/spinifex/gateway/ecs_authz_test.go
+++ b/spinifex/gateway/ecs_authz_test.go
@@ -92,6 +92,36 @@ func TestECSRequest_UnparseableBodyStaysTheHandlersFault(t *testing.T) {
 	assert.Equal(t, awserrors.ErrorNotImplemented, err.Error())
 }
 
+// A body spelling one field two ways is the bypass a case-folded lookup opens:
+// the handler reads the last spelling in document order, the gate's map cannot,
+// so the request is rejected rather than authorized against the wrong cluster.
+func TestECSRequest_FieldSpelledTwoWaysIsRejected(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecs:*", "*"),
+		statement("Deny", "ecs:DeleteCluster", ecsResourceARN("cluster/prod")),
+	)
+
+	// Repeated: the fold's disagreement is random, the rejection must not be.
+	for range 50 {
+		err := dispatchECS(t, gw, "DeleteCluster", `{"cluster":"dev","Cluster":"prod"}`)
+		require.Error(t, err)
+		assert.Equal(t, awserrors.ErrorInvalidParameterValue, err.Error())
+	}
+}
+
+// A describe naming no cluster describes the default one in the handler, so a
+// fence on the default cluster fires against an empty list too.
+func TestECSRequest_OmittedClusterListIsFencedAsDefault(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecs:*", "*"),
+		statement("Deny", "ecs:DescribeClusters", ecsResourceARN("cluster/default")),
+	)
+
+	assertDenied(t, dispatchECS(t, gw, "DescribeClusters", `{}`))
+	assertDenied(t, dispatchECS(t, gw, "DescribeClusters", `{"clusters":[]}`))
+	assertReachedHandler(t, dispatchECS(t, gw, "DescribeClusters", `{"clusters":["prod"]}`))
+}
+
 // A body past the signed path's cap cannot be used to bypass the gate or to
 // exhaust memory: it is rejected before either the gate or the handler.
 func TestECSRequest_OversizedBodyIsRejected(t *testing.T) {

--- a/spinifex/gateway/ecs_authz_test.go
+++ b/spinifex/gateway/ecs_authz_test.go
@@ -1,0 +1,136 @@
+//test:in-package — drives ECS_Request through the gateway's unexported test
+// helpers (setupECSRequest, policyMockIAMService) and auth context keys.
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_ecs "github.com/mulgadc/spinifex/spinifex/gateway/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dispatchECS drives the gateway with no NATS connection. A permitted request
+// therefore reaches the handler and fails there, which is what proves the policy
+// check ran ahead of the resource existing at all.
+func dispatchECS(t *testing.T, gw *GatewayConfig, action, body string) error {
+	t.Helper()
+	req := setupECSRequest(gateway_ecs.TargetPrefix+"."+action, body)
+	return gw.ECS_Request(httptest.NewRecorder(), req)
+}
+
+// assertReachedHandler asserts the policy gate passed. The request then fails on
+// the absent NATS connection or on its 501 stub rather than on authorization, so
+// a denial cannot hide behind a not-found.
+func assertReachedHandler(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	assert.NotEqual(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+func ecsResourceARN(resource string) string {
+	return "arn:aws:ecs:" + authzRegion + ":" + authzAccountID + ":" + resource
+}
+
+// TestECSRequest_ScopedDenyFires is the bypass this work closes. An operator
+// fences a production service; before the resolver the fence was inert and
+// DeleteService against it was permitted with nothing logged.
+func TestECSRequest_ScopedDenyFires(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecs:*", "*"),
+		statement("Deny", "ecs:DeleteService", "arn:aws:ecs:*:*:service/prod/web"),
+	)
+
+	assertDenied(t, dispatchECS(t, gw, "DeleteService", `{"cluster":"prod","service":"web"}`))
+	assertReachedHandler(t, dispatchECS(t, gw, "DeleteService", `{"cluster":"prod","service":"api"}`))
+	assertReachedHandler(t, dispatchECS(t, gw, "DeleteService", `{"cluster":"dev","service":"web"}`))
+}
+
+// TestECSRequest_ScopedAllowGrants is the other half: a least-privilege policy
+// used to deny everything, so the only working policy shape was Resource "*".
+func TestECSRequest_ScopedAllowGrants(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecs:UpdateCluster", "arn:aws:ecs:*:*:cluster/dev"),
+	)
+
+	err := dispatchECS(t, gw, "UpdateCluster", `{"cluster":"dev"}`)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorNotImplemented, err.Error())
+	assertDenied(t, dispatchECS(t, gw, "UpdateCluster", `{"cluster":"prod"}`))
+}
+
+// An omitted cluster is the default cluster, both at the gate and in the
+// handler, so a fence on it fires.
+func TestECSRequest_OmittedClusterIsFencedAsDefault(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecs:*", "*"),
+		statement("Deny", "ecs:UpdateCluster", ecsResourceARN("cluster/default")),
+	)
+
+	assertDenied(t, dispatchECS(t, gw, "UpdateCluster", `{}`))
+	assertDenied(t, dispatchECS(t, gw, "UpdateCluster", `{"cluster":"default"}`))
+	assertReachedHandler(t, dispatchECS(t, gw, "UpdateCluster", `{"cluster":"prod"}`))
+}
+
+// A body the gate cannot parse authorizes account-wide, and the handler still
+// reports its own validation fault.
+func TestECSRequest_UnparseableBodyStaysTheHandlersFault(t *testing.T) {
+	gw := scopedPolicyGateway(
+		statement("Allow", "ecs:*", "*"),
+		statement("Deny", "ecs:UpdateCluster", ecsResourceARN("cluster/prod")),
+	)
+
+	err := dispatchECS(t, gw, "UpdateCluster", "{not json")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorNotImplemented, err.Error())
+}
+
+// A body past the signed path's cap cannot be used to bypass the gate or to
+// exhaust memory: it is rejected before either the gate or the handler.
+func TestECSRequest_OversizedBodyIsRejected(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "ecs:*", "*"))
+	body := `{"cluster":"` + strings.Repeat("a", sigv4.MaxPayloadLen) + `"}`
+
+	err := dispatchECS(t, gw, "UpdateCluster", body)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorRequestEntityTooLarge, err.Error())
+}
+
+// The property the per-service rollout rests on: passing a real ARN where "*"
+// was passed before cannot withdraw access a working policy already grants.
+func TestECSRequest_AccountWideGrantStillPermitsEveryAction(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "ecs:*", "*"))
+	req := withTestIdentity(httptest.NewRequest(http.MethodPost, "/", nil).
+		WithContext(context.WithValue(context.Background(), ctxAccountID, authzAccountID)))
+	body := []byte(`{"cluster":"prod","service":"web","serviceName":"web","task":"t-1",` +
+		`"containerInstance":"ci-1","taskDefinition":"app:1","name":"cp","capacityProvider":"cp",` +
+		`"clusterName":"prod","resourceArn":"` + ecsResourceARN("cluster/prod") + `"}`)
+
+	for _, action := range gateway_ecs.ScopedActions() {
+		t.Run(action, func(t *testing.T) {
+			resources, err := gateway_ecs.ResourceARNs(action, authzRegion, authzAccountID, body)
+			require.NoError(t, err)
+			assert.NoError(t, gw.checkPolicyResources(req, "ecs", action, resources))
+		})
+	}
+}
+
+// The account-ID read moved above the gate, which used to reject a missing
+// account itself. InternalError is the code the caller has always seen.
+func TestECSRequest_MissingAccountIDReturnsInternalError(t *testing.T) {
+	gw := scopedPolicyGateway(statement("Allow", "ecs:*", "*"))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
+	req.Header.Set("X-Amz-Target", gateway_ecs.TargetPrefix+".ListClusters")
+	req = withTestIdentity(req.WithContext(context.WithValue(req.Context(), ctxService, "ecs")))
+
+	err := gw.ECS_Request(httptest.NewRecorder(), req)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
+}

--- a/spinifex/gateway/eks.go
+++ b/spinifex/gateway/eks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -266,10 +265,10 @@ func (gw *GatewayConfig) EKS_Request(w http.ResponseWriter, r *http.Request) err
 		return errors.New(awserrors.ErrorInternalError)
 	}
 
-	body, err := io.ReadAll(r.Body)
+	body, err := readBoundedBody(r)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "EKS_Request: failed to read body", "err", err)
-		return errors.New(awserrors.ErrorInvalidParameterValue)
+		return err
 	}
 
 	// Some REST-JSON actions carry their non-path inputs as query params with

--- a/spinifex/gateway/eks/authz.go
+++ b/spinifex/gateway/eks/authz.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/mulgadc/spinifex/spinifex/arn"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/gateway/bodyscope"
 	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
 )
 
@@ -33,6 +34,7 @@ const (
 	sourceCluster
 	sourceClusterFromBody
 	sourceInternalCluster
+	sourceBodyAccountCluster
 	sourceNodegroup
 	sourceNodegroupFromBody
 	sourceAddon
@@ -59,9 +61,10 @@ var eksScopes = map[string][]resourceSource{
 	// system caller's, because that is the account the handler reads.
 	"ListInternalAddons":   {sourceInternalCluster},
 	"GetRecoveryDirective": {sourceInternalCluster},
-	// The owning account arrives in the body, which the handler parses.
-	"PublishInternal":    {sourceAny},
-	"WebhookTokenReview": {sourceAny},
+	// The owning account arrives in the body on these two, and the ARN names
+	// that account for the same reason: it is the account the handler acts in.
+	"PublishInternal":    {sourceBodyAccountCluster},
+	"WebhookTokenReview": {sourceBodyAccountCluster},
 
 	// Nodegroups. Create evaluates the cluster and the nodegroup it is about
 	// to create, matching AWS.
@@ -169,6 +172,9 @@ func resolve(source resourceSource, action, region, accountID string, params []s
 
 	case sourceInternalCluster:
 		return clusterARN(region, param(params, 1), param(params, 0)), nil
+
+	case sourceBodyAccountCluster:
+		return clusterARN(region, bodyscope.Parse(action, body).String("accountId"), param(params, 0)), nil
 
 	case sourceNodegroup:
 		return nodegroupARN(region, accountID, param(params, 0), param(params, 1)), nil

--- a/spinifex/gateway/eks/authz.go
+++ b/spinifex/gateway/eks/authz.go
@@ -174,7 +174,11 @@ func resolve(source resourceSource, action, region, accountID string, params []s
 		return clusterARN(region, param(params, 1), param(params, 0)), nil
 
 	case sourceBodyAccountCluster:
-		return clusterARN(region, bodyscope.Parse(action, body).String("accountId"), param(params, 0)), nil
+		scope, err := bodyscope.Parse(action, body)
+		if err != nil {
+			return "", errors.New(awserrors.ErrorInvalidParameterValue)
+		}
+		return clusterARN(region, scope.String("accountId"), param(params, 0)), nil
 
 	case sourceNodegroup:
 		return nodegroupARN(region, accountID, param(params, 0), param(params, 1)), nil

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -515,10 +515,27 @@ func isNATSTransient(err error) bool {
 		errors.Is(err, nats.ErrNoStreamResponse))
 }
 
+// readBoundedBody reads a request body under the same cap the signed path
+// applies, so a body read ahead of the policy gate can neither be used to
+// bypass the gate nor to exhaust memory. On the signed path sigv4.Parse has
+// already buffered and rewound these bytes, so this re-reads a buffer.
+func readBoundedBody(r *http.Request) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, sigv4.MaxPayloadLen+1))
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	if int64(len(body)) > sigv4.MaxPayloadLen {
+		return nil, errors.New(awserrors.ErrorRequestEntityTooLarge)
+	}
+	return body, nil
+}
+
 // checkPolicy evaluates IAM policies against the literal resource "*", so it
 // grants account-wide: a caller's resource-scoped statements do not participate
 // at all, neither a Deny that fences a resource nor an Allow that names one.
-// Prefer checkPolicyResources with the request's real ARNs.
+// Prefer checkPolicyResources with the request's real ARNs: where the
+// identifier arrives in a JSON body, read the body ahead of the gate and
+// resolve it there rather than settling for "*".
 func (gw *GatewayConfig) checkPolicy(r *http.Request, service, action string) error {
 	return gw.checkPolicyResources(r, service, action, []string{"*"})
 }

--- a/spinifex/handlers/ecs/capacity.go
+++ b/spinifex/handlers/ecs/capacity.go
@@ -114,7 +114,7 @@ func (s *Service) ProvisionCapacity(ctx context.Context, input *ProvisionCapacit
 		return nil, err
 	}
 
-	cluster := clusterShortName(input.Cluster)
+	cluster := ClusterShortName(input.Cluster)
 	userData := buildContainerInstanceUserData(containerInstanceUserDataInput{
 		GatewayURL:    s.deps.GatewayBaseURL,
 		GatewayCACert: s.deps.GatewayCACert,

--- a/spinifex/handlers/ecs/capacity_providers.go
+++ b/spinifex/handlers/ecs/capacity_providers.go
@@ -17,7 +17,7 @@ func (s *Service) PutClusterCapacityProviders(ctx context.Context, input *ecs.Pu
 	if input == nil {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func (s *Service) DescribeCapacityProviders(ctx context.Context, input *ecs.Desc
 	}
 
 	for _, ref := range names {
-		name := capacityProviderShortName(ref)
+		name := CapacityProviderShortName(ref)
 		var rec CapacityProviderRecord
 		ok, gerr := getJSON(ctx, kv, CapacityProviderKey(name), &rec)
 		if gerr != nil {
@@ -126,7 +126,7 @@ func (s *Service) DeleteCapacityProvider(ctx context.Context, input *ecs.DeleteC
 	if input == nil || aws.StringValue(input.CapacityProvider) == "" {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
-	name := capacityProviderShortName(aws.StringValue(input.CapacityProvider))
+	name := CapacityProviderShortName(aws.StringValue(input.CapacityProvider))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err

--- a/spinifex/handlers/ecs/cluster_teardown.go
+++ b/spinifex/handlers/ecs/cluster_teardown.go
@@ -22,7 +22,7 @@ func clusterKeyPrefix(cluster string) string {
 // is marked INACTIVE, then the whole clusters/{name}/ prefix is deleted. Returns
 // the cluster with Status INACTIVE.
 func (s *Service) DeleteCluster(ctx context.Context, input *ecs.DeleteClusterInput, accountID string) (*ecs.DeleteClusterOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -58,8 +58,8 @@ func (s *Service) DeleteCluster(ctx context.Context, input *ecs.DeleteClusterInp
 // record and its assignment inbox are deleted; the response carries Status
 // INACTIVE.
 func (s *Service) DeregisterContainerInstance(ctx context.Context, input *ecs.DeregisterContainerInstanceInput, accountID string) (*ecs.DeregisterContainerInstanceOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
-	id := containerInstanceShortID(aws.StringValue(input.ContainerInstance))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
+	id := ContainerInstanceShortID(aws.StringValue(input.ContainerInstance))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (s *Service) DeregisterContainerInstance(ctx context.Context, input *ecs.De
 // relaunches them elsewhere; standalone (non-service) tasks are left running,
 // matching AWS. Unknown instances surface as Failures.
 func (s *Service) UpdateContainerInstancesState(ctx context.Context, input *ecs.UpdateContainerInstancesStateInput, accountID string) (*ecs.UpdateContainerInstancesStateOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	status := aws.StringValue(input.Status)
 	if status != InstanceStatusActive && status != InstanceStatusDraining {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
@@ -110,7 +110,7 @@ func (s *Service) UpdateContainerInstancesState(ctx context.Context, input *ecs.
 	}
 	out := &ecs.UpdateContainerInstancesStateOutput{}
 	for _, ref := range awsStringSlice(input.ContainerInstances) {
-		id := containerInstanceShortID(ref)
+		id := ContainerInstanceShortID(ref)
 		var rec InstanceRecord
 		found, gerr := getJSON(ctx, kv, InstanceKey(cluster, id), &rec)
 		if gerr != nil {

--- a/spinifex/handlers/ecs/conv.go
+++ b/spinifex/handlers/ecs/conv.go
@@ -21,8 +21,10 @@ func awsStringSlice(in []*string) []string {
 	return out
 }
 
-// clusterShortName extracts the cluster name from a name or a cluster ARN.
-func clusterShortName(ref string) string {
+// ClusterShortName extracts the cluster name from a name or a cluster ARN, and
+// resolves an omitted reference to the default cluster. Exported so the policy
+// gate names the same cluster the handler acts on.
+func ClusterShortName(ref string) string {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return defaultCluster
@@ -33,26 +35,26 @@ func clusterShortName(ref string) string {
 	return ref
 }
 
-// containerInstanceShortID extracts the container-instance UUID from an ID or ARN.
-func containerInstanceShortID(ref string) string {
+// ContainerInstanceShortID extracts the container-instance UUID from an ID or ARN.
+func ContainerInstanceShortID(ref string) string {
 	if i := strings.LastIndexByte(ref, '/'); i >= 0 {
 		return ref[i+1:]
 	}
 	return ref
 }
 
-// taskShortID extracts the task UUID from a bare id or a task ARN
+// TaskShortID extracts the task UUID from a bare id or a task ARN
 // (arn:...:task/{cluster}/{taskID}); the final path segment is the task id.
-func taskShortID(ref string) string {
+func TaskShortID(ref string) string {
 	if i := strings.LastIndexByte(ref, '/'); i >= 0 {
 		return ref[i+1:]
 	}
 	return ref
 }
 
-// capacityProviderShortName extracts the capacity-provider name from a name
+// CapacityProviderShortName extracts the capacity-provider name from a name
 // or a capacity-provider ARN.
-func capacityProviderShortName(ref string) string {
+func CapacityProviderShortName(ref string) string {
 	ref = strings.TrimSpace(ref)
 	if i := strings.LastIndex(ref, "capacity-provider/"); i >= 0 {
 		return ref[i+len("capacity-provider/"):]

--- a/spinifex/handlers/ecs/conv_test.go
+++ b/spinifex/handlers/ecs/conv_test.go
@@ -30,14 +30,14 @@ func TestTaskDefReservedSums(t *testing.T) {
 }
 
 func TestClusterShortName(t *testing.T) {
-	assert.Equal(t, defaultCluster, clusterShortName(""))
-	assert.Equal(t, "web", clusterShortName("web"))
-	assert.Equal(t, "web", clusterShortName("arn:aws:ecs:r:a:cluster/web"))
+	assert.Equal(t, defaultCluster, ClusterShortName(""))
+	assert.Equal(t, "web", ClusterShortName("web"))
+	assert.Equal(t, "web", ClusterShortName("arn:aws:ecs:r:a:cluster/web"))
 }
 
 func TestContainerInstanceShortID(t *testing.T) {
-	assert.Equal(t, "i-1", containerInstanceShortID("i-1"))
-	assert.Equal(t, "i-1", containerInstanceShortID("arn:aws:ecs:r:a:container-instance/web/i-1"))
+	assert.Equal(t, "i-1", ContainerInstanceShortID("i-1"))
+	assert.Equal(t, "i-1", ContainerInstanceShortID("arn:aws:ecs:r:a:container-instance/web/i-1"))
 }
 
 func TestAWSStringSlice(t *testing.T) {

--- a/spinifex/handlers/ecs/deployments.go
+++ b/spinifex/handlers/ecs/deployments.go
@@ -218,7 +218,7 @@ func tripCircuitBreaker(svc *ServiceRecord, primary *Deployment) bool {
 // rollbackToLastGood demotes the failed PRIMARY and starts a fresh PRIMARY from
 // the last-good task definition ARN.
 func (r *ServiceRecord) rollbackToLastGood() {
-	family, rev := parseTaskDefRef(r.LastGoodTaskDefARN)
+	family, rev := ParseTaskDefRef(r.LastGoodTaskDefARN)
 	r.demotePrimary()
 	now := time.Now().UTC()
 	r.DeploymentID = uuid.NewV4().String()

--- a/spinifex/handlers/ecs/eni_test.go
+++ b/spinifex/handlers/ecs/eni_test.go
@@ -183,7 +183,7 @@ func TestRecordTaskState_Awsvpc_ReleasesENIOnStopOnce(t *testing.T) {
 	registerInstance(t, svc, "web", "i-1", 1024, 2048)
 	out, err := svc.RunTask(context.Background(), awsvpcRunInput(), testAccountID)
 	require.NoError(t, err)
-	taskID := containerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
+	taskID := ContainerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
 
 	stop := &bus.TaskState{
 		AccountID: testAccountID, ClusterName: "web", InstanceID: "i-1", TaskID: taskID,

--- a/spinifex/handlers/ecs/gpu_report.go
+++ b/spinifex/handlers/ecs/gpu_report.go
@@ -29,8 +29,8 @@ type ReportTaskGPUOutput struct {
 // task or container is a silent no-op — the state-report path already owns
 // the task's lifecycle; this only enriches it.
 func (s *Service) ReportTaskGPU(ctx context.Context, input *ReportTaskGPUInput, accountID string) (*ReportTaskGPUOutput, error) {
-	cluster := clusterShortName(input.Cluster)
-	taskID := taskShortID(input.Task)
+	cluster := ClusterShortName(input.Cluster)
+	taskID := TaskShortID(input.Task)
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err

--- a/spinifex/handlers/ecs/instance_recovery_test.go
+++ b/spinifex/handlers/ecs/instance_recovery_test.go
@@ -76,7 +76,7 @@ func TestReaper_ReleasesCapacityAndRecoversClean(t *testing.T) {
 	}, testAccountID)
 	require.NoError(t, err)
 	require.Len(t, out.Tasks, 1)
-	taskID := containerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
+	taskID := ContainerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
 
 	seeded := instanceStatus(t, svc, "web", "i-1")
 	require.Equal(t, 128, seeded.ReservedCPU)

--- a/spinifex/handlers/ecs/instances.go
+++ b/spinifex/handlers/ecs/instances.go
@@ -37,7 +37,7 @@ func (s *Service) listInstanceRecords(ctx context.Context, kv jetstream.KeyValue
 // normally registers over the Layer-2 bus; this keeps API parity by writing the
 // same record shape from an explicit call.
 func (s *Service) RegisterContainerInstance(ctx context.Context, input *ecs.RegisterContainerInstanceInput, accountID string) (*ecs.RegisterContainerInstanceOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	instanceID := aws.StringValue(input.InstanceIdentityDocument)
 	if instanceID == "" {
 		instanceID = "ci-" + time.Now().UTC().Format("20060102150405")
@@ -80,14 +80,14 @@ func (s *Service) RegisterContainerInstance(ctx context.Context, input *ecs.Regi
 
 // DescribeContainerInstances returns records for the named container instances.
 func (s *Service) DescribeContainerInstances(ctx context.Context, input *ecs.DescribeContainerInstancesInput, accountID string) (*ecs.DescribeContainerInstancesOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
 	}
 	out := &ecs.DescribeContainerInstancesOutput{}
 	for _, ref := range awsStringSlice(input.ContainerInstances) {
-		id := containerInstanceShortID(ref)
+		id := ContainerInstanceShortID(ref)
 		var rec InstanceRecord
 		found, err := getJSON(ctx, kv, InstanceKey(cluster, id), &rec)
 		if err != nil {
@@ -104,7 +104,7 @@ func (s *Service) DescribeContainerInstances(ctx context.Context, input *ecs.Des
 
 // ListContainerInstances returns the ARNs of all container instances in a cluster.
 func (s *Service) ListContainerInstances(ctx context.Context, input *ecs.ListContainerInstancesInput, accountID string) (*ecs.ListContainerInstancesOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -305,8 +305,8 @@ func (s *Service) recordTaskState(ctx context.Context, msg *bus.TaskState) error
 func (s *Service) SubmitTaskStateChange(ctx context.Context, input *ecs.SubmitTaskStateChangeInput, accountID string) (*ecs.SubmitTaskStateChangeOutput, error) {
 	msg := bus.TaskState{
 		AccountID:   accountID,
-		ClusterName: clusterShortName(aws.StringValue(input.Cluster)),
-		TaskID:      taskShortID(aws.StringValue(input.Task)),
+		ClusterName: ClusterShortName(aws.StringValue(input.Cluster)),
+		TaskID:      TaskShortID(aws.StringValue(input.Task)),
 		LastStatus:  aws.StringValue(input.Status),
 		Reason:      aws.StringValue(input.Reason),
 		ReportedAt:  time.Now().UTC(),

--- a/spinifex/handlers/ecs/poll.go
+++ b/spinifex/handlers/ecs/poll.go
@@ -35,8 +35,8 @@ type PollAssignmentsOutput struct {
 // authoritative from accountID (SigV4 caller), so an instance cannot drain
 // another account's inbox.
 func (s *Service) PollAssignments(ctx context.Context, input *PollAssignmentsInput, accountID string) (*PollAssignmentsOutput, error) {
-	cluster := clusterShortName(input.Cluster)
-	instanceID := containerInstanceShortID(input.ContainerInstance)
+	cluster := ClusterShortName(input.Cluster)
+	instanceID := ContainerInstanceShortID(input.ContainerInstance)
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -46,13 +46,13 @@ func (s *Service) PollAssignments(ctx context.Context, input *PollAssignmentsInp
 		if taskID == "" {
 			continue
 		}
-		_ = kv.Delete(ctx, AssignmentKey(cluster, instanceID, taskShortID(taskID)))
+		_ = kv.Delete(ctx, AssignmentKey(cluster, instanceID, TaskShortID(taskID)))
 	}
 	for _, taskID := range input.AckStopIDs {
 		if taskID == "" {
 			continue
 		}
-		_ = kv.Delete(ctx, StopKey(cluster, instanceID, taskShortID(taskID)))
+		_ = kv.Delete(ctx, StopKey(cluster, instanceID, TaskShortID(taskID)))
 	}
 
 	keys, err := keysWithPrefix(ctx, kv, AssignmentsPrefix(cluster, instanceID))

--- a/spinifex/handlers/ecs/records.go
+++ b/spinifex/handlers/ecs/records.go
@@ -2,6 +2,7 @@ package handlers_ecs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -82,7 +83,13 @@ func ClusterARN(region, accountID, name string) string {
 }
 
 func TaskDefARN(region, accountID, family string, rev int) string {
-	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:%d", region, accountID, family, rev)
+	return TaskDefRefARN(region, accountID, family, strconv.Itoa(rev))
+}
+
+// TaskDefRefARN spells the revision verbatim, so a reference whose revision is
+// not yet resolved can render it as a wildcard.
+func TaskDefRefARN(region, accountID, family, revision string) string {
+	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:%s", region, accountID, family, revision)
 }
 
 func TaskARN(region, accountID, cluster, taskID string) string {

--- a/spinifex/handlers/ecs/service.go
+++ b/spinifex/handlers/ecs/service.go
@@ -284,7 +284,7 @@ func (s *Service) DescribeClusters(ctx context.Context, input *ecs.DescribeClust
 	}
 	out := &ecs.DescribeClustersOutput{}
 	for _, name := range names {
-		name = clusterShortName(name)
+		name = ClusterShortName(name)
 		var rec ClusterRecord
 		found, err := getJSON(ctx, kv, ClusterMetaKey(name), &rec)
 		if err != nil {
@@ -466,7 +466,7 @@ func (s *Service) nextRevision(ctx context.Context, kv jetstream.KeyValue, famil
 // AWS requires an explicit family:revision (a bare family is rejected); the
 // revision stays describable, matching AWS. Idempotent.
 func (s *Service) DeregisterTaskDefinition(ctx context.Context, input *ecs.DeregisterTaskDefinitionInput, accountID string) (*ecs.DeregisterTaskDefinitionOutput, error) {
-	family, rev := parseTaskDefRef(aws.StringValue(input.TaskDefinition))
+	family, rev := ParseTaskDefRef(aws.StringValue(input.TaskDefinition))
 	if family == "" || rev == 0 {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
@@ -542,7 +542,7 @@ func (s *Service) ListTaskDefinitions(ctx context.Context, input *ecs.ListTaskDe
 // resolveTaskDef loads the TaskDefRecord named by ref ("family", "family:rev",
 // or a task-definition ARN). A bare family resolves to its latest revision.
 func (s *Service) resolveTaskDef(ctx context.Context, kv jetstream.KeyValue, ref string) (*TaskDefRecord, error) {
-	family, rev := parseTaskDefRef(ref)
+	family, rev := ParseTaskDefRef(ref)
 	if family == "" {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
@@ -568,9 +568,9 @@ func (s *Service) resolveTaskDef(ctx context.Context, kv jetstream.KeyValue, ref
 	return &rec, nil
 }
 
-// parseTaskDefRef splits "family", "family:rev" or an ARN into (family, rev).
+// ParseTaskDefRef splits "family", "family:rev" or an ARN into (family, rev).
 // rev is 0 when unspecified (caller resolves to latest).
-func parseTaskDefRef(ref string) (string, int) {
+func ParseTaskDefRef(ref string) (string, int) {
 	ref = strings.TrimSpace(ref)
 	if i := strings.LastIndex(ref, "task-definition/"); i >= 0 {
 		ref = ref[i+len("task-definition/"):]

--- a/spinifex/handlers/ecs/service_test.go
+++ b/spinifex/handlers/ecs/service_test.go
@@ -220,7 +220,7 @@ func TestService_RunTask_PlacesAndAssigns(t *testing.T) {
 	lt, err := svc.ListTasks(context.Background(), &ecs.ListTasksInput{Cluster: aws.String("web")}, testAccountID)
 	require.NoError(t, err)
 	assert.Len(t, lt.TaskArns, 1)
-	assert.Equal(t, as.TaskID, containerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn)))
+	assert.Equal(t, as.TaskID, ContainerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn)))
 }
 
 func TestService_RunTask_AssignCarriesTaskRole(t *testing.T) {
@@ -265,7 +265,7 @@ func TestService_PollAssignments_AckAndReclaim(t *testing.T) {
 	registerInstance(t, svc, "web", "i-1", 1024, 2048)
 	out, err := svc.RunTask(context.Background(), &ecs.RunTaskInput{Cluster: aws.String("web"), TaskDefinition: aws.String("app")}, testAccountID)
 	require.NoError(t, err)
-	taskID := containerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
+	taskID := ContainerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
 
 	// Unacked re-poll re-delivers.
 	p1, err := svc.PollAssignments(context.Background(), &PollAssignmentsInput{Cluster: "web", ContainerInstance: "i-1"}, testAccountID)
@@ -285,7 +285,7 @@ func TestService_PollAssignments_AckAndReclaim(t *testing.T) {
 	// A fresh RunTask + STOPPED reclaims its inbox entry without an explicit ack.
 	out2, err := svc.RunTask(context.Background(), &ecs.RunTaskInput{Cluster: aws.String("web"), TaskDefinition: aws.String("app")}, testAccountID)
 	require.NoError(t, err)
-	task2 := containerInstanceShortID(aws.StringValue(out2.Tasks[0].TaskArn))
+	task2 := ContainerInstanceShortID(aws.StringValue(out2.Tasks[0].TaskArn))
 	require.NoError(t, svc.recordTaskState(context.Background(), &bus.TaskState{
 		AccountID: testAccountID, ClusterName: "web", InstanceID: "i-1", TaskID: task2,
 		LastStatus: bus.TaskStatusStopped,
@@ -326,7 +326,7 @@ func TestService_RecordTaskState_ReleasesCapacityOnStop(t *testing.T) {
 	registerInstance(t, svc, "web", "i-1", 1024, 2048)
 	out, err := svc.RunTask(context.Background(), &ecs.RunTaskInput{Cluster: aws.String("web"), TaskDefinition: aws.String("app")}, testAccountID)
 	require.NoError(t, err)
-	taskID := containerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
+	taskID := ContainerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
 
 	require.NoError(t, svc.recordTaskState(context.Background(), &bus.TaskState{
 		AccountID: testAccountID, ClusterName: "web", InstanceID: "i-1", TaskID: taskID,
@@ -370,7 +370,7 @@ func TestService_SubmitTaskStateChange_StopsTask(t *testing.T) {
 	registerInstance(t, svc, "web", "i-1", 1024, 2048)
 	out, err := svc.RunTask(context.Background(), &ecs.RunTaskInput{Cluster: aws.String("web"), TaskDefinition: aws.String("app")}, testAccountID)
 	require.NoError(t, err)
-	taskARN := aws.StringValue(out.Tasks[0].TaskArn) // full ARN exercises taskShortID
+	taskARN := aws.StringValue(out.Tasks[0].TaskArn) // full ARN exercises TaskShortID
 
 	exit := int64(0)
 	ack, err := svc.SubmitTaskStateChange(context.Background(), &ecs.SubmitTaskStateChangeInput{
@@ -420,7 +420,7 @@ func TestScheduler_ReapBucket_StopsStaleInstanceTasks(t *testing.T) {
 	registerInstance(t, svc, "web", "i-1", 1024, 2048)
 	out, err := svc.RunTask(context.Background(), &ecs.RunTaskInput{Cluster: aws.String("web"), TaskDefinition: aws.String("app")}, testAccountID)
 	require.NoError(t, err)
-	taskID := containerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
+	taskID := ContainerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
 
 	// Backdate LastSeen beyond the heartbeat timeout.
 	kv, err := svc.bucket(t.Context(), testAccountID)
@@ -557,7 +557,7 @@ func TestService_RunTask_GPU_ReservesOnPlacement(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out.Tasks, 1)
 	assert.Empty(t, out.Failures)
-	taskID := containerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
+	taskID := ContainerInstanceShortID(aws.StringValue(out.Tasks[0].TaskArn))
 
 	di, err := svc.DescribeContainerInstances(context.Background(), &ecs.DescribeContainerInstancesInput{
 		Cluster: aws.String("web"), ContainerInstances: []*string{aws.String("i-1")},

--- a/spinifex/handlers/ecs/services.go
+++ b/spinifex/handlers/ecs/services.go
@@ -136,7 +136,7 @@ func (s *Service) CreateService(ctx context.Context, input *ecs.CreateServiceInp
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
 
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -203,8 +203,8 @@ func (s *Service) CreateService(ctx context.Context, input *ecs.CreateServiceInp
 
 // UpdateService mutates desiredCount and/or the task definition, then reconciles.
 func (s *Service) UpdateService(ctx context.Context, input *ecs.UpdateServiceInput, accountID string) (*ecs.UpdateServiceOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
-	name := serviceShortName(aws.StringValue(input.Service))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
+	name := ServiceShortName(aws.StringValue(input.Service))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -249,8 +249,8 @@ func (s *Service) UpdateService(ctx context.Context, input *ecs.UpdateServiceInp
 // DeleteService drains the service to zero, force-stops its tasks, and marks it
 // INACTIVE (kept describable, AWS parity).
 func (s *Service) DeleteService(ctx context.Context, input *ecs.DeleteServiceInput, accountID string) (*ecs.DeleteServiceOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
-	name := serviceShortName(aws.StringValue(input.Service))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
+	name := ServiceShortName(aws.StringValue(input.Service))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -284,14 +284,14 @@ func (s *Service) DeleteService(ctx context.Context, input *ecs.DeleteServiceInp
 
 // DescribeServices returns the named services; unknown names surface as failures.
 func (s *Service) DescribeServices(ctx context.Context, input *ecs.DescribeServicesInput, accountID string) (*ecs.DescribeServicesOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
 	}
 	out := &ecs.DescribeServicesOutput{}
 	for _, ref := range awsStringSlice(input.Services) {
-		name := serviceShortName(ref)
+		name := ServiceShortName(ref)
 		var rec ServiceRecord
 		found, gerr := getJSON(ctx, kv, ServiceKey(cluster, name), &rec)
 		if gerr != nil {
@@ -308,7 +308,7 @@ func (s *Service) DescribeServices(ctx context.Context, input *ecs.DescribeServi
 
 // ListServices returns the ARNs of every service in a cluster.
 func (s *Service) ListServices(ctx context.Context, input *ecs.ListServicesInput, accountID string) (*ecs.ListServicesOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -585,8 +585,8 @@ func (s *Service) allServiceRecords(ctx context.Context, kv jetstream.KeyValue) 
 	return out, nil
 }
 
-// serviceShortName extracts the service name from a name or a service ARN.
-func serviceShortName(ref string) string {
+// ServiceShortName extracts the service name from a name or a service ARN.
+func ServiceShortName(ref string) string {
 	ref = strings.TrimSpace(ref)
 	if i := strings.LastIndexByte(ref, '/'); i >= 0 {
 		return ref[i+1:]

--- a/spinifex/handlers/ecs/tags.go
+++ b/spinifex/handlers/ecs/tags.go
@@ -77,7 +77,7 @@ func (s *Service) resourceTags(ctx context.Context, kv jetstream.KeyValue, kind 
 		}
 		return rec.Tags, nil
 	case ecsResourceTaskDefinition:
-		family, rev := parseTaskDefRef(id)
+		family, rev := ParseTaskDefRef(id)
 		if family == "" || rev == 0 {
 			return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 		}
@@ -142,7 +142,7 @@ func (s *Service) mutateResourceTags(ctx context.Context, kv jetstream.KeyValue,
 		rec.Tags = mutate(rec.Tags)
 		return putJSON(ctx, kv, ClusterMetaKey(id), &rec)
 	case ecsResourceTaskDefinition:
-		family, rev := parseTaskDefRef(id)
+		family, rev := ParseTaskDefRef(id)
 		if family == "" || rev == 0 {
 			return errors.New(awserrors.ErrorECSInvalidParameter)
 		}

--- a/spinifex/handlers/ecs/tags.go
+++ b/spinifex/handlers/ecs/tags.go
@@ -23,43 +23,51 @@ const (
 	ecsResourceContainerInstance
 )
 
+// ResourceARNSegment validates an ECS resource ARN with the same parser the tag
+// handler uses and returns the "<type>/<path>" segment it addresses. Exported
+// so the policy gate authorizes exactly the ARNs the handler acts on.
+func ResourceARNSegment(resourceARN string) (string, error) {
+	_, _, _, segment, err := parseResourceARN(resourceARN)
+	return segment, err
+}
+
 // parseResourceARN splits an ECS resource ARN into its kind, owning cluster
-// (empty for cluster/task-definition, which are flat), and short id/name.
-// Cluster and task-definition ARNs are flat (.../cluster/{name},
-// .../task-definition/{family}:{rev}); service/task/container-instance ARNs
-// embed the owning cluster (.../service/{cluster}/{name}).
-func parseResourceARN(resourceARN string) (kind ecsResourceKind, cluster, id string, err error) {
+// (empty for cluster/task-definition, which are flat), short id/name, and the
+// resource segment verbatim. Cluster and task-definition ARNs are flat
+// (.../cluster/{name}, .../task-definition/{family}:{rev});
+// service/task/container-instance ARNs embed the owning cluster.
+func parseResourceARN(resourceARN string) (kind ecsResourceKind, cluster, id, segment string, err error) {
 	// SplitN(..., 6) keeps the resource segment intact even though a
 	// task-definition id ("family:1") itself contains a colon.
 	parts := strings.SplitN(resourceARN, ":", 6)
-	if len(parts) != 6 || parts[0] != "arn" {
-		return 0, "", "", errors.New(awserrors.ErrorECSInvalidParameter)
+	if len(parts) != 6 || parts[0] != "arn" || parts[2] != "ecs" {
+		return 0, "", "", "", errors.New(awserrors.ErrorECSInvalidParameter)
 	}
 	rtype, rest, ok := strings.Cut(parts[5], "/")
 	if !ok || rtype == "" || rest == "" {
-		return 0, "", "", errors.New(awserrors.ErrorECSInvalidParameter)
+		return 0, "", "", "", errors.New(awserrors.ErrorECSInvalidParameter)
 	}
 
 	switch rtype {
 	case "cluster":
-		return ecsResourceCluster, rest, rest, nil
+		return ecsResourceCluster, rest, rest, parts[5], nil
 	case "task-definition":
-		return ecsResourceTaskDefinition, "", rest, nil
+		return ecsResourceTaskDefinition, "", rest, parts[5], nil
 	case "service", "task", "container-instance":
 		clusterName, name, ok := strings.Cut(rest, "/")
 		if !ok || clusterName == "" || name == "" {
-			return 0, "", "", errors.New(awserrors.ErrorECSInvalidParameter)
+			return 0, "", "", "", errors.New(awserrors.ErrorECSInvalidParameter)
 		}
 		switch rtype {
 		case "service":
-			return ecsResourceService, clusterName, name, nil
+			return ecsResourceService, clusterName, name, parts[5], nil
 		case "task":
-			return ecsResourceTask, clusterName, name, nil
+			return ecsResourceTask, clusterName, name, parts[5], nil
 		default:
-			return ecsResourceContainerInstance, clusterName, name, nil
+			return ecsResourceContainerInstance, clusterName, name, parts[5], nil
 		}
 	default:
-		return 0, "", "", errors.New(awserrors.ErrorECSInvalidParameter)
+		return 0, "", "", "", errors.New(awserrors.ErrorECSInvalidParameter)
 	}
 }
 
@@ -199,7 +207,7 @@ func (s *Service) ListTagsForResource(ctx context.Context, input *ecs.ListTagsFo
 	if input == nil || aws.StringValue(input.ResourceArn) == "" {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
-	kind, cluster, id, err := parseResourceARN(aws.StringValue(input.ResourceArn))
+	kind, cluster, id, _, err := parseResourceARN(aws.StringValue(input.ResourceArn))
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +227,7 @@ func (s *Service) TagResource(ctx context.Context, input *ecs.TagResourceInput, 
 	if input == nil || aws.StringValue(input.ResourceArn) == "" {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
-	kind, cluster, id, err := parseResourceARN(aws.StringValue(input.ResourceArn))
+	kind, cluster, id, _, err := parseResourceARN(aws.StringValue(input.ResourceArn))
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +254,7 @@ func (s *Service) UntagResource(ctx context.Context, input *ecs.UntagResourceInp
 	if input == nil || aws.StringValue(input.ResourceArn) == "" {
 		return nil, errors.New(awserrors.ErrorECSInvalidParameter)
 	}
-	kind, cluster, id, err := parseResourceARN(aws.StringValue(input.ResourceArn))
+	kind, cluster, id, _, err := parseResourceARN(aws.StringValue(input.ResourceArn))
 	if err != nil {
 		return nil, err
 	}

--- a/spinifex/handlers/ecs/tags_test.go
+++ b/spinifex/handlers/ecs/tags_test.go
@@ -26,7 +26,7 @@ func TestParseResourceARN(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			kind, cluster, id, err := parseResourceARN(tc.arn)
+			kind, cluster, id, _, err := parseResourceARN(tc.arn)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantKind, kind)
 			assert.Equal(t, tc.wantCluster, cluster)
@@ -42,10 +42,14 @@ func TestParseResourceARN_Invalid(t *testing.T) {
 		"arn:aws:ecs:r:a:cluster",         // no "/" after resource type
 		"arn:aws:ecs:r:a:service/onlyone", // service missing embedded name
 		"arn:aws:ecs:r:a:unknown/x",       // unrecognized resource type
+		// A foreign service segment would otherwise be tagged as an ECS
+		// resource in the caller's own bucket, out from under a fence on it.
+		"arn:aws:ecsx:r:a:cluster/prod",
+		"arn:aws:ec2:r:a:cluster/prod",
 	}
 	for _, arnStr := range cases {
 		t.Run(arnStr, func(t *testing.T) {
-			_, _, _, err := parseResourceARN(arnStr)
+			_, _, _, _, err := parseResourceARN(arnStr)
 			assert.EqualError(t, err, "InvalidParameterException")
 		})
 	}

--- a/spinifex/handlers/ecs/task_stop.go
+++ b/spinifex/handlers/ecs/task_stop.go
@@ -26,8 +26,8 @@ const defaultStopReason = "Task stopped by user"
 // so a freed port is never rebound while the old container still holds it
 // (ecs-v1.md:165).
 func (s *Service) StopTask(ctx context.Context, input *ecs.StopTaskInput, accountID string) (*ecs.StopTaskOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
-	taskID := taskShortID(aws.StringValue(input.Task))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
+	taskID := TaskShortID(aws.StringValue(input.Task))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (s *Service) StopTask(ctx context.Context, input *ecs.StopTaskInput, accoun
 // StartTask places one task per named container instance (explicit placement, no
 // scheduler bin-pack). Mirrors RunTask's reserve → record → ENI → assign flow.
 func (s *Service) StartTask(ctx context.Context, input *ecs.StartTaskInput, accountID string) (*ecs.StartTaskOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func (s *Service) StartTask(ctx context.Context, input *ecs.StartTaskInput, acco
 
 	out := &ecs.StartTaskOutput{}
 	for _, ref := range awsStringSlice(input.ContainerInstances) {
-		instanceID := containerInstanceShortID(ref)
+		instanceID := ContainerInstanceShortID(ref)
 		taskID := uuid.NewV4().String()
 		inst, rerr := s.reserveOnInstance(ctx, kv, cluster, instanceID, taskID, cpu, mem, gpu)
 		if rerr != nil {

--- a/spinifex/handlers/ecs/taskdef_validation_test.go
+++ b/spinifex/handlers/ecs/taskdef_validation_test.go
@@ -153,7 +153,7 @@ func TestRunTask_AssignCarriesGPU(t *testing.T) {
 	assert.Equal(t, 1, poll.Assignments[0].Containers[0].GPU)
 	assert.Zero(t, poll.Assignments[0].Containers[1].GPU)
 
-	taskID := taskShortID(aws.StringValue(out.Tasks[0].TaskArn))
+	taskID := TaskShortID(aws.StringValue(out.Tasks[0].TaskArn))
 	kv, err := svc.bucket(t.Context(), testAccountID)
 	require.NoError(t, err)
 	var rec TaskRecord

--- a/spinifex/handlers/ecs/tasks.go
+++ b/spinifex/handlers/ecs/tasks.go
@@ -25,7 +25,7 @@ const reservePlacementRetries = 5
 // publishes an assign on the Layer-2 bus for each. Placement failures for a task
 // are returned as RunTask failures; already-placed tasks in the same call stay.
 func (s *Service) RunTask(ctx context.Context, input *ecs.RunTaskInput, accountID string) (*ecs.RunTaskOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -219,14 +219,14 @@ func (s *Service) publishAssign(ctx context.Context, kv jetstream.KeyValue, acco
 
 // DescribeTasks returns task records for the named tasks in a cluster.
 func (s *Service) DescribeTasks(ctx context.Context, input *ecs.DescribeTasksInput, accountID string) (*ecs.DescribeTasksOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err
 	}
 	out := &ecs.DescribeTasksOutput{}
 	for _, ref := range awsStringSlice(input.Tasks) {
-		taskID := containerInstanceShortID(ref)
+		taskID := ContainerInstanceShortID(ref)
 		var rec TaskRecord
 		found, err := getJSON(ctx, kv, TaskKey(cluster, taskID), &rec)
 		if err != nil {
@@ -243,7 +243,7 @@ func (s *Service) DescribeTasks(ctx context.Context, input *ecs.DescribeTasksInp
 
 // ListTasks returns the ARNs of all tasks in a cluster.
 func (s *Service) ListTasks(ctx context.Context, input *ecs.ListTasksInput, accountID string) (*ecs.ListTasksOutput, error) {
-	cluster := clusterShortName(aws.StringValue(input.Cluster))
+	cluster := ClusterShortName(aws.StringValue(input.Cluster))
 	kv, err := s.bucket(ctx, accountID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

`checkPolicy` evaluates against the literal resource `"*"`, so a statement scoped to a real ARN never matches: a scoped Deny fails open and a scoped Allow fails closed. Six dispatchers still called it, covering the ECS control plane (39 actions), the ECR control plane (39), and the four Bedrock services (16 + 5 + 11 + 2), plus the two EKS internal routes whose owning account arrives in the body.

## Mechanism

One mechanism for all six, extending the shape EKS already ships for `CreateCluster`: read the account ID and the body ahead of the gate, resolve the action's resources from the same bytes the handler will parse, then call `checkPolicyResources`. The check stays at the single choke point `recordResolvedAction` and the audit line depend on.

`gateway/bodyscope` parses a body once into `map[string]json.RawMessage` and offers case-insensitive `String`/`Strings`/`Object` lookups. Two reasons over a shared struct of every identifier field: a type mismatch on an unrelated field cannot poison the parse and silently widen the request to `"*"`, and AWS JSON 1.1 spells fields lower-camel while the SDK structs are upper-camel.

Three properties preserved throughout:

- A body the gate cannot parse authorizes account-wide, so the caller keeps a validation fault rather than a denial.
- The gate still runs ahead of existence: a denial is `AccessDenied`, never a not-found.
- The read is bounded by `sigv4.MaxPayloadLen`, returning `RequestEntityTooLarge` past the cap, so an oversized body cannot be used to bypass the gate or exhaust memory.

`ECR_Request`'s twelve inline handlers read `r.Body` themselves, so the dispatcher rewinds it after the gate-time read.

## Scoping

Each service gets an exhaustive scope table and a two-way completeness test against its dispatch table, so a new action cannot be added with a silent account-wide grant. Account-wide actions carry explicit entries naming the reason.

- **ECS** — cluster/service/task/container-instance/task-definition/capacity-provider ARNs, built with the handler's own builders and normalizers (exported for this), so an omitted `cluster` resolves to `cluster/default` at the gate exactly as it does in the handler. A task-definition reference without a revision wildcards it.
- **ECR** — `repository/<repositoryName>` from the body; `registryId` is ignored, since a caller-supplied account would let a request slide out from under a Deny scoped to the real one. The registry-level surface is `"*"`, which is what AWS evaluates it against.
- **bedrock / bedrock-runtime / bedrock-agent / bedrock-agent-runtime** — guardrail, provisioned-model, foundation-model and knowledge-base ARNs, accepting the id-or-ARN spelling each surface allows and re-anchoring through the existing `Parse*ARN` validators. `FormatKnowledgeBaseARN` moved into `gateway/bedrock` so the authz table can reach it.
- **EKS** — `PublishInternal` and `WebhookTokenReview` now resolve `cluster/<path name>` under the `accountId` their body names.

## Out of scope

The five EC2 association-id actions. Their identifier is already parsed before the gate; what is missing is a mapping from an association id to the resource behind it, which needs a gate-time store lookup over NATS — a different mechanism, tracked as its own bead. They keep today's behaviour.

## Testing

`make preflight` passes. New coverage: scoped Deny fires and scoped Allow grants per service, two-way completeness for all six dispatch tables, ARN fidelity asserted against the handler's own normalizers, unparseable bodies staying the handler's validation fault, oversized bodies returning `RequestEntityTooLarge`, `registryId` being ignored, non-regression across every scoped action under an account-wide grant, and `InternalError` for a missing account ID.