### PR TITLE
refactor: move the IAM role and instance-profile CAS loops onto kvutil

### DIFF
--- a/spinifex/handlers/iam/instance_profiles.go
+++ b/spinifex/handlers/iam/instance_profiles.go
@@ -373,47 +373,16 @@ func (s *IAMServiceImpl) getInstanceProfile(ctx context.Context, accountID, prof
 // re-reading and re-running mutate when a concurrent writer wins the race.
 // mutate reports whether it changed the record; a false return commits nothing.
 func (s *IAMServiceImpl) updateInstanceProfileCAS(ctx context.Context, accountID, profileName string, mutate func(*InstanceProfile) (bool, error)) error {
-	key := accountID + "." + profileName
-	for range instanceProfileCASMaxRetries {
-		entry, err := s.instanceProfilesBucket.Get(ctx, key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				return errors.New(awserrors.ErrorIAMNoSuchEntity)
-			}
-			return fmt.Errorf("get instance profile: %w", err)
-		}
-
-		var profile InstanceProfile
-		if err := json.Unmarshal(entry.Value(), &profile); err != nil {
-			return fmt.Errorf("unmarshal instance profile: %w", err)
-		}
-
-		changed, err := mutate(&profile)
-		if err != nil {
-			return err
-		}
-		if !changed {
-			return nil
-		}
-
-		data, err := json.Marshal(&profile)
-		if err != nil {
-			return fmt.Errorf("marshal instance profile: %w", err)
-		}
-		// ErrKeyRevisionMismatch is the only conflict signal that holds on both
-		// replicated and single-replica buckets; ErrKeyExists misses R>1.
-		if _, err := s.instanceProfilesBucket.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
-				continue // CAS conflict — another writer won, re-read and retry.
-			}
-			return fmt.Errorf("update instance profile: %w", err)
-		}
-		return nil
-	}
-
-	slog.Warn("IAM instance profile CAS exhausted retries",
-		"accountID", accountID, "instanceProfileName", profileName, "attempts", instanceProfileCASMaxRetries)
-	return errors.New(awserrors.ErrorServerInternal)
+	_, err := kvutil.Update(ctx, s.instanceProfilesBucket, accountID+"."+profileName, kvutil.CASConfig{
+		Attempts: instanceProfileCASMaxRetries,
+		NotFound: errors.New(awserrors.ErrorIAMNoSuchEntity),
+		Exhausted: func(string, int) error {
+			slog.Warn("IAM instance profile CAS exhausted retries",
+				"accountID", accountID, "instanceProfileName", profileName, "attempts", instanceProfileCASMaxRetries)
+			return errors.New(awserrors.ErrorServerInternal)
+		},
+	}, mutate)
+	return err
 }
 
 // profileToSDK converts the internal InstanceProfile to the AWS SDK shape.

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -572,46 +572,18 @@ func (s *IAMServiceImpl) getRole(ctx context.Context, accountID, roleName string
 // to one role at once) write the same record concurrently. mutate reports
 // whether it changed the record; a false return commits nothing.
 func (s *IAMServiceImpl) updateRoleCAS(ctx context.Context, accountID, roleName string, mutate func(*Role) (bool, error)) error {
-	key := accountID + "." + roleName
-	for range roleCASMaxRetries {
-		entry, err := s.rolesBucket.Get(ctx, key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				return errors.New(awserrors.ErrorIAMNoSuchEntity)
-			}
-			return fmt.Errorf("get role: %w", err)
-		}
-
-		var role Role
-		if err := json.Unmarshal(entry.Value(), &role); err != nil {
-			return fmt.Errorf("unmarshal role: %w", err)
-		}
-
-		changed, err := mutate(&role)
-		if err != nil {
-			return err
-		}
-		if !changed {
-			return nil
-		}
-
-		data, err := json.Marshal(&role)
-		if err != nil {
-			return fmt.Errorf("marshal role: %w", err)
-		}
-		if _, err := s.rolesBucket.Update(ctx, key, data, entry.Revision()); err != nil {
-			if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
-				continue // CAS conflict — another writer won, re-read and retry.
-			}
-			return fmt.Errorf("update role: %w", err)
-		}
-		return nil
-	}
-	// Only a CAS conflict reaches here, so the role is contended rather than
-	// broken; say so, or the caller's InternalError has no cause anywhere.
-	slog.Error("IAM role CAS retries exhausted under contention",
-		"accountID", accountID, "roleName", roleName, "attempts", roleCASMaxRetries)
-	return errors.New(awserrors.ErrorServerInternal)
+	_, err := kvutil.Update(ctx, s.rolesBucket, accountID+"."+roleName, kvutil.CASConfig{
+		Attempts: roleCASMaxRetries,
+		NotFound: errors.New(awserrors.ErrorIAMNoSuchEntity),
+		Exhausted: func(string, int) error {
+			// Only a CAS conflict reaches here, so the role is contended rather than
+			// broken; say so, or the caller's InternalError has no cause anywhere.
+			slog.Error("IAM role CAS retries exhausted under contention",
+				"accountID", accountID, "roleName", roleName, "attempts", roleCASMaxRetries)
+			return errors.New(awserrors.ErrorServerInternal)
+		},
+	}, mutate)
+	return err
 }
 
 // findInstanceProfilesForRole scans the instance-profiles bucket for any

--- a/spinifex/kvutil/cas.go
+++ b/spinifex/kvutil/cas.go
@@ -21,6 +21,14 @@ const casBackoffBase = 2 * time.Millisecond
 type CASConfig struct {
 	Attempts       int  // 0 selects casAttempts
 	CreateIfAbsent bool // start from a zero value when the key is missing
+
+	// NotFounc replaces the raw jetstream error when the key is absent and
+	// CreateIfAbsent is unset, so a caller can map it to its own API error.
+	NotFound error
+
+	// Exhausted builds the error returned when the attempt budget is spent, for callers that log the contention
+	// or return a specific API error.
+	Exhausted func(key string, attempts int) error
 }
 
 // isConflict reports a lost CAS race. Create reports one as ErrKeyExists and Update as ErrKeyRevisionMismatch.
@@ -54,6 +62,9 @@ func retryCAS(ctx context.Context, cfg CASConfig, op, key string, attempt func()
 			return ctx.Err()
 		}
 	}
+	if cfg.Exhausted != nil {
+		return cfg.Exhausted(key, attempts)
+	}
 	return fmt.Errorf("CAS %s exhausted %d attempts for key %s: %w", op, attempts, key, lastErr)
 }
 
@@ -74,6 +85,8 @@ func Update[T any](ctx context.Context, kv jetstream.KeyValue, key string, cfg C
 			revision = entry.Revision()
 		case errors.Is(err, jetstream.ErrKeyNotFound) && cfg.CreateIfAbsent:
 			revision = 0
+		case errors.Is(err, jetstream.ErrKeyNotFound) && cfg.NotFound != nil:
+			return cfg.NotFound
 		default:
 			return err
 		}
@@ -118,6 +131,8 @@ func Put(ctx context.Context, kv jetstream.KeyValue, key string, cfg CASConfig, 
 			revision = entry.Revision()
 		case errors.Is(err, jetstream.ErrKeyNotFound) && cfg.CreateIfAbsent:
 			revision = 0
+		case errors.Is(err, jetstream.ErrKeyNotFound) && cfg.NotFound != nil:
+			return cfg.NotFound
 		default:
 			return err
 		}

--- a/spinifex/kvutil/cas_conflict_test.go
+++ b/spinifex/kvutil/cas_conflict_test.go
@@ -2,6 +2,7 @@ package kvutil_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -151,4 +152,30 @@ func TestCASClaim_RetriesRevisionConflict(t *testing.T) {
 
 func jetstreamCodeSuffix(code jetstream.ErrorCode) string {
 	return fmt.Sprintf("%d", code)
+}
+
+func TestUpdate_AbsentKeyReturnsCallerError(t *testing.T) {
+	kv := casTestBucket(t, "cas-notfound")
+
+	sentinel := errors.New("no such entity")
+	_, err := kvutil.Update(t.Context(), kv, "missing", kvutil.CASConfig{NotFound: sentinel},
+		func(*casRecord) (bool, error) { t.Fatal("mutate ran against an absent key"); return false, nil })
+
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestUpdate_ExhaustionUsesCallerError(t *testing.T) {
+	kv := casTestBucket(t, "cas-exhausted-hook")
+	_, err := kv.Put(t.Context(), "key", []byte(`{"counter":1}`))
+	require.NoError(t, err)
+
+	stub := &casConflictKV{KeyValue: kv, conflictCode: jetstream.JSErrCodeStreamWrongLastSequenceConstant,
+		updateFailures: casTestAttempts + 1}
+	sentinel := errors.New("contended")
+	_, err = kvutil.Update(t.Context(), stub, "key", kvutil.CASConfig{
+		Attempts:  casTestAttempts,
+		Exhausted: func(string, int) error { return sentinel },
+	}, bumpCounter)
+
+	assert.ErrorIs(t, err, sentinel)
 }


### PR DESCRIPTION
## What

Converts `updateRoleCAS` and `updateInstanceProfileCAS` to `kvutil.Update`, and
grows `CASConfig` with the two knobs those callers need: a caller-supplied
absent-key error and a caller-supplied exhaustion error.

## Why

Both functions were the same loop as the `daemon` primitives promoted in #878,
differing only in error mapping. `CASConfig.NotFound` and `CASConfig.Exhausted`
carry that mapping, so the mapping is preserved rather than flattened onto one
shared error.

Both also retried 16 times with no pause between attempts. Against a contended
key those 16 attempts complete in microseconds and are likely to all lose, which
is exactly the case the original comment describes — Terraform attaching several
managed policies to one role at once. They now inherit the shared jittered
backoff, spreading the same budget over roughly 270ms and succeeding where they
previously exhausted.

## Changes

- `kvutil/cas.go`: `CASConfig.NotFound` and `CASConfig.Exhausted`. `NotFound` is
  handled in both `Update` and `Put`, since a config field that silently does
  nothing on one of the two would be worse than the three duplicated lines.
- `handlers/iam/roles.go`, `handlers/iam/instance_profiles.go`: loop bodies
  replaced. Both wrappers keep their signatures, so none of their ten call sites
  change.

`CreateAccount` in `service_impl.go` is deliberately not converted. It looks like
a fourth CAS site but is not the same primitive: its value is a decimal string
rather than JSON, and its retry loop is unbounded, so routing it through `Update`
would silently impose an attempt budget and change behaviour under contention. It
is a counter, and there are at least two more in the fleet, so it argues for a
counter helper rather than for forcing this one through `Update`.

## Testing

`make preflight` passes. Two new `kvutil` tests cover the knobs: an absent key
returns the caller's error and short-circuits before `mutate` runs, and a spent
budget returns the caller's error rather than the default wrapped one.

`spinifex/handlers/iam` passes untouched.
`TestAttachRolePolicy_ConcurrentDistinctPolicies`,
`TestAddRoleToInstanceProfile_ConcurrentDistinctRoles`
`TestRemoveRoleFromInstanceProfile_ConcurrentDetach` and the two
`TestTagInstanceProfile_Concurrent*` tests drive both functions through their real
callers under the exact contention this change affects.

## Follow-up

`CreateAccount`'s unbounded retry loop can spin indefinitely on a contended
counter. Pre-existing, and bounding it is a behaviour change, so it needs its own
bead rather than riding in here.