### PR TITLE
feat(firewall): scope ssh to an operator allowlist in custom.nft

### DIFF
--- a/scripts/node-reset.sh
+++ b/scripts/node-reset.sh
@@ -70,9 +70,14 @@ $KEEP_DATA || WIPE_DIRS+=("$DATA_DIR")
 # keep_args adds the regular files worth keeping: the service helper scripts
 # and the env files the units load, at the top level of $1 only. A *.sh deeper
 # in the tree is cluster state, not an installed helper.
+#
+# firewall/custom.nft is kept too, one level down: it is an operator's SSH
+# allowlist, and losing it silently returns the node to accepting ssh from
+# every source. Parenthesised so the -o groups against the whole top-level arm.
 KEEP_TOP=()
 keep_args() {
-    KEEP_TOP=(-path "$1/*" ! -path "$1/*/*" '(' -name '*.sh' -o -name '*.env' ')')
+    KEEP_TOP=('(' -path "$1/*" ! -path "$1/*/*" '(' -name '*.sh' -o -name '*.env' ')' ')' \
+              -o -path "$1/firewall/custom.nft")
 }
 
 # Report what is at stake in figures rather than adjectives. An operator who
@@ -148,6 +153,12 @@ run sudo rm -f /etc/openvswitch/system-id.conf
 FIREWALL_MODE=""
 if [ -r "$ETC_DIR/firewall/mode" ]; then
     FIREWALL_MODE=$(sudo cat "$ETC_DIR/firewall/mode" 2>/dev/null | tr -d '[:space:]')
+fi
+
+# Named in the transcript because the risk runs the other way too: an allowlist
+# naming the old cluster's management network locks an operator out of the new one.
+if [ -e "$ETC_DIR/firewall/custom.nft" ]; then
+    log "keeping the operator ssh allowlist in $ETC_DIR/firewall/custom.nft"
 fi
 
 log "removing OVN databases"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,6 +36,7 @@ FIREWALL_RULES="${FIREWALL_DIR}/spinifex.nft"
 FIREWALL_PEERS="${FIREWALL_DIR}/peers.nft"
 FIREWALL_LOCAL="${FIREWALL_DIR}/local.nft"
 FIREWALL_OPEN="${FIREWALL_DIR}/open-ports.nft"
+FIREWALL_CUSTOM="${FIREWALL_DIR}/custom.nft"
 FIREWALL_MODE_FILE="${FIREWALL_DIR}/mode"
 FIREWALL_APPLY="/usr/local/lib/spinifex/spinifex-firewall-apply"
 
@@ -349,6 +350,7 @@ install_firewall() {
 include "/etc/spinifex/firewall/local.nft"
 include "/etc/spinifex/firewall/open-ports.nft"
 include "/etc/spinifex/firewall/peers.nft"
+include "/etc/spinifex/firewall/custom.nft"
 
 # Create-then-delete so the replace is atomic and the delete cannot fail on a
 # first run. nft applies the whole file as one transaction or none of it.
@@ -379,12 +381,16 @@ table inet spinifex_filter {
         # conntrack entry, so the uplink and external-pool leases need this.
         udp sport 67 udp dport 68 accept
 
+        # Scoped by $trusted_ssh_peers from custom.nft, which the installer
+        # creates once and never rewrites. That default accepts every source,
+        # so a node is no less reachable than before until an operator narrows it.
+        ip saddr $trusted_ssh_peers tcp dport $spinifex_ssh_ports accept
+
         # Public plane. 9999 is also how every guest agent (lb, eks, ecs, rds)
         # reaches its control plane over br-mgmt: they speak SigV4 to the AWS
         # gateway, never NATS, so no cluster port needs to face the guests.
         # 443 has no listener yet and is held for the nginx TLS edge, so the
         # rollout does not need a firewall change on every node.
-        tcp dport $spinifex_ssh_ports accept
         tcp dport { 443, 3000, 8443, 9999 } accept
 
         # Transiently open to any source, for cluster formation. A node dialling
@@ -445,6 +451,31 @@ define spinifex_open_ports = { 0 }
 OPENPORTS
     $SUDO chmod 0644 "$FIREWALL_OPEN"
     info "  $FIREWALL_OPEN (closed)"
+
+    # Operator-owned, so it is created once and never rewritten: an upgrade, a
+    # re-install and a node reset all leave an edited file alone. Never write it
+    # empty — an undefined variable fails the whole ruleset, not just its rule.
+    if [ ! -e "$FIREWALL_CUSTOM" ]; then
+        $SUDO tee "$FIREWALL_CUSTOM" > /dev/null << 'CUSTOM'
+# Operator-owned host firewall settings. setup.sh creates this file once and
+# never overwrites it, so edits here survive upgrades, re-installs and resets.
+#
+# Check a change without applying it, then apply it:
+#   sudo nft -c -f /etc/spinifex/firewall/spinifex.nft
+#   sudo nft -f  /etc/spinifex/firewall/spinifex.nft
+#
+# Check spinifex.nft, not this file: on its own this parses as a bare define
+# and proves nothing, because the rule that uses the variable lives there.
+#
+# Sources allowed to reach SSH. 0.0.0.0/0 accepts from anywhere; narrow it to
+# your management networks. IPv4 only — sshd reached over IPv6 is not matched.
+define trusted_ssh_peers = { 0.0.0.0/0 }
+CUSTOM
+        $SUDO chmod 0644 "$FIREWALL_CUSTOM"
+        info "  $FIREWALL_CUSTOM (created — ssh open to every source)"
+    else
+        info "  $FIREWALL_CUSTOM (already present, left unchanged)"
+    fi
 
     # Armed or merely installed. The daemon reads this when the config carries no
     # explicit firewall_enabled, which is the normal case on both install paths.
@@ -582,6 +613,14 @@ APPLY
     $SUDO chown root:root "$FIREWALL_APPLY"
     $SUDO chmod 0755 "$FIREWALL_APPLY"
     info "  $FIREWALL_APPLY"
+
+    # Say which state ssh is in either way. A node whose allowlist was never
+    # narrowed reads as configured otherwise, and that is the whole risk here.
+    _ssh_srcs="$(grep -o '{[^}]*}' "$FIREWALL_CUSTOM" 2>/dev/null | tr -d '{}' | tr -s ' ')"
+    case "$_ssh_srcs" in
+        *0.0.0.0/0*) info "  ssh (${_ssh_ports}) accepted from ANY source — narrow \$trusted_ssh_peers in $FIREWALL_CUSTOM" ;;
+        ?*) info "  ssh (${_ssh_ports}) accepted from:${_ssh_srcs}" ;;
+    esac
 
     if [ "$INSTALL_SPINIFEX_FIREWALL" = "on" ]; then
         info "Host firewall installed and armed (applied by spinifex-daemon once peers resolve)"


### PR DESCRIPTION
The generated host firewall accepted ssh from any source, and `setup.sh` rewrites `spinifex.nft` from a heredoc on every run of the firewall stage — so there was nowhere to record an allowlist that survived an upgrade or a node reset.

## Approach

`/etc/spinifex/firewall/custom.nft` is operator-owned: created once with a permissive default, never rewritten. It holds a `define`, not rules, so an operator supplies a value and cannot write a rule that lands in the wrong place or fails the ruleset.

```nft
define trusted_ssh_peers = { 192.168.90.0/24, 202.53.48.222 }
```

The shipped rule consumes it, keeping `$spinifex_ssh_ports` rather than hardcoding 22 so a node with a non-default sshd port stays reachable:

```nft
ip saddr $trusted_ssh_peers tcp dport $spinifex_ssh_ports accept
```

The default is `{ 0.0.0.0/0 }`, which is exactly what the policy did before, so this is not a behaviour change until an operator narrows it.

## Why the default is never a blank file

An undefined variable fails the **whole** `nft -f` transaction, not just its rule. At boot that fails `spinifex-firewall.service` (`Type=oneshot`) and the node comes up with no firewall at all. Verified on a node:

```
spinifex.nft:51:19-35: Error: unknown identifier 'trusted_ssh_peers'
        ip saddr $trusted_ssh_peers tcp dport $spinifex_ssh_ports accept
                  ^^^^^^^^^^^^^^^^^
```

## node-reset.sh

`WIPE_DIRS` takes all of `/etc/spinifex` and `keep_args()` spared only top-level `*.sh`/`*.env`, so a reset silently returned the node to accepting ssh from everywhere. `custom.nft` is now kept. The existing expression is parenthesised so the added `-o` groups against the whole top-level arm rather than binding to the last `-name`.

## Testing

`make preflight` passes; no new shellcheck warnings (the pre-existing `FIREWALL_PEERS` SC2034 is unchanged).

Validated on all four nodes of the test-prod cluster by running `SETUP_STAGES=firewall` with the new script:

- `custom.nft` sha256 identical before and after on every node, and the installer reports `already present, left unchanged`
- regenerated `spinifex.nft` carries the include and the scoped rule; `nft -c -f` exits 0; applied with `nft -f`; a **fresh** ssh connection succeeds, so the rule itself accepts rather than an established conntrack entry
- with the file removed, the installer creates the permissive default and the policy still validates
- with the file empty, `nft -c` correctly exits 1

## Follow-ups, deliberately not in scope

A hand-broken `custom.nft` still fails the whole load, and at boot that yields an unfirewalled node. That hole is pre-existing (`peers.nft` sits on the same path), but this change puts a file operators are invited to edit onto it. A `base.nft` fallback and a `check` verb are written up in `docs/development/feature/nft-custom-fw-rules.md` under "Optional hardening".

IPv6 is not covered: `ip saddr` is v4-only, so if sshd is ever bound to v6 it would need an `ip6 saddr` companion. sshd currently listens on `0.0.0.0:22` only.