### PR TITLE
refactor: change EKS casUpdateMeta to use kvutil

### DIFF
--- a/spinifex/handlers/eks/cluster_state.go
+++ b/spinifex/handlers/eks/cluster_state.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -209,41 +210,20 @@ func GetClusterMeta(ctx context.Context, kv jetstream.KeyValue, name string) (*C
 }
 
 // casUpdateMeta does a revision-checked read-modify-write of the cluster meta.
-// mutate returns true when a field changed. Retries on CAS conflict up to
-// maxClusterStateCASRetries. Returns ErrClusterNotFound if deleted concurrently.
+// mutate returns true when a field changed. Returns ErrClusterNotFound if the
+// cluster is deleted concurrently.
 func casUpdateMeta(ctx context.Context, kv jetstream.KeyValue, name string, mutate func(*ClusterMeta) bool) error {
 	if name == "" {
 		return errors.New("eks: casUpdateMeta empty name")
 	}
-	for range maxClusterStateCASRetries {
-		entry, err := kv.Get(ctx, ClusterMetaKey(name))
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				return ErrClusterNotFound
-			}
-			return fmt.Errorf("kv get %s: %w", ClusterMetaKey(name), err)
-		}
-		var meta ClusterMeta
-		if err := json.Unmarshal(entry.Value(), &meta); err != nil {
-			return fmt.Errorf("unmarshal cluster meta %s: %w", name, err)
-		}
-		if !mutate(&meta) {
-			return nil
-		}
-		data, err := json.Marshal(&meta)
-		if err != nil {
-			return fmt.Errorf("marshal cluster meta %s: %w", name, err)
-		}
-		_, err = kv.Update(ctx, ClusterMetaKey(name), data, entry.Revision())
-		if err == nil {
-			return nil
-		}
-		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
-			continue
-		}
-		return fmt.Errorf("kv update %s: %w", ClusterMetaKey(name), err)
-	}
-	return fmt.Errorf("eks: casUpdateMeta %s exhausted CAS retries", name)
+	_, err := kvutil.Update(ctx, kv, ClusterMetaKey(name), kvutil.CASConfig{
+		Attempts: maxClusterStateCASRetries,
+		NotFound: ErrClusterNotFound,
+		Exhausted: func(string, int) error {
+			return fmt.Errorf("eks: casUpdateMeta %s exhausted CAS retries", name)
+		},
+	}, func(m *ClusterMeta) (bool, error) { return mutate(m), nil })
+	return err
 }
 
 // SetClusterStatus does a CAS update of meta.Status. Returns ErrClusterNotFound if deleted concurrently.


### PR DESCRIPTION
Fourth caller converted to the shared `kvutil` CAS helper, after `daemon` (#878), `iam` (#879) and `acm` (#880).

`casUpdateMeta` is the single read-modify-write path for EKS cluster metadata, backing every state transition in `cluster_state.go`. Its hand-rolled retry loop is replaced by `kvutil.Update`.

## Behaviour

One real change. The old loop retried a CAS conflict with a bare `continue` and no delay, so contending writers re-collided on the same revision immediately. `kvutil` applies its jittered backoff instead. That is a fix rather than a regression, but it is a behaviour change and worth calling out: under contention this now spreads writers apart instead of spinning them against each other.

Everything else is preserved. The attempt budget stays at `maxClusterStateCASRetries`, the empty-name guard is unchanged, and the exhaustion message is identical.

`kvutil.Update` returns `CASConfig.NotFound` directly rather than wrapping it, so `errors.Is(err, ErrClusterNotFound)` at the call sites keeps working. Nothing in the tree compares that sentinel with `==`.

The error text for infrastructure failures changes from `kv get %s: %w`, `kv update %s: %w` and `unmarshal cluster meta %s: %w` to the `kvutil` equivalents. No test asserts on them.

## Changes

- `handlers/eks/cluster_state.go`: `casUpdateMeta` rewritten over `kvutil.Update`, 31 lines down to 11.
- `kvutil` import added; nothing removed, since `encoding/json` is still used by `GetClusterMeta`.

All ten call sites are untouched. The `mutate func(*ClusterMeta) bool` signature is kept, and a one-line closure adapts it to `kvutil`'s `func(*T) (bool, error)`.

## Testing

- `go test ./spinifex/handlers/eks/ -race`, including `cluster_reconciler_recovery_test.go` which calls `casUpdateMeta` directly.
- `make preflight`.
