### PR TITLE
fix: support '?' and backslash escapes in EC2 filter wildcard matching

### DIFF
--- a/spinifex/filterutil/filterutil.go
+++ b/spinifex/filterutil/filterutil.go
@@ -37,7 +37,8 @@ func ParseFilters(filters []*ec2.Filter, validNames map[string]bool) (map[string
 }
 
 // MatchesAny returns true if value matches any of the filter values.
-// Supports the AWS wildcard convention where * matches any substring.
+// Supports the AWS wildcard convention: * matches any substring, ? matches one
+// character, and \ escapes either.
 // Returns true if filterValues is empty.
 func MatchesAny(filterValues []string, value string) bool {
 	if len(filterValues) == 0 {
@@ -84,40 +85,60 @@ func EC2TagsToMap(tags []*ec2.Tag) map[string]string {
 	return m
 }
 
-// MatchWildcard matches value against a pattern where * matches zero or more characters.
+// MatchWildcard matches value against a pattern where * matches zero or more
+// characters, ? matches exactly one, and \ escapes the next byte so a literal
+// *, ? or \ can still be filtered for. A trailing \ matches itself.
 // Case-sensitive; callers needing case-insensitive matching should lower-case both inputs.
+//
+// Metacharacters are matched over bytes, not runes: EC2 filter values are
+// compared bytewise and ? on a multi-byte character has no behaviour to match.
 func MatchWildcard(pattern, value string) bool {
 	if pattern == "*" {
 		return true
 	}
-	if !strings.Contains(pattern, "*") {
+	if !strings.ContainsAny(pattern, `*?\`) {
 		return pattern == value
 	}
 
-	parts := strings.Split(pattern, "*")
-	last := len(parts) - 1
-
-	if !strings.HasPrefix(value, parts[0]) {
-		return false
-	}
-	if !strings.HasSuffix(value, parts[last]) {
-		return false
-	}
-
-	// Trim anchored ends before scanning middle parts.
-	remaining := value[len(parts[0]):]
-	if len(remaining) < len(parts[last]) {
-		return false
-	}
-	remaining = remaining[:len(remaining)-len(parts[last])]
-
-	// Walk through middle parts in order.
-	for i := 1; i < last; i++ {
-		idx := strings.Index(remaining, parts[i])
-		if idx < 0 {
+	// Greedy scan with a single backtrack point at the most recent "*", which
+	// keeps patterns like a*a*a*b linear rather than exponential.
+	var p, v int
+	star, starV := -1, 0
+	for v < len(value) {
+		switch {
+		case p < len(pattern) && pattern[p] == '*':
+			star, starV = p, v
+			p++
+		case p < len(pattern) && matchesByte(pattern, p, value[v]):
+			p += patternWidth(pattern, p)
+			v++
+		case star >= 0:
+			starV++
+			p, v = star+1, starV
+		default:
 			return false
 		}
-		remaining = remaining[idx+len(parts[i]):]
 	}
-	return true
+
+	for p < len(pattern) && pattern[p] == '*' {
+		p++
+	}
+	return p == len(pattern)
+}
+
+// patternWidth returns the byte length of the pattern token at p: 2 for an
+// escape pair, 1 otherwise.
+func patternWidth(pattern string, p int) int {
+	if pattern[p] == '\\' && p+1 < len(pattern) {
+		return 2
+	}
+	return 1
+}
+
+// matchesByte reports whether the single-character pattern token at p matches b.
+func matchesByte(pattern string, p int, b byte) bool {
+	if pattern[p] == '\\' && p+1 < len(pattern) {
+		return pattern[p+1] == b
+	}
+	return pattern[p] == '?' || pattern[p] == b
 }

--- a/spinifex/filterutil/filterutil_test.go
+++ b/spinifex/filterutil/filterutil_test.go
@@ -293,6 +293,74 @@ func TestMatchWildcard_OverlappingSuffixNotDoubled(t *testing.T) {
 	}
 }
 
+// TestMatchWildcard_SingleCharacterAndEscapes covers the EC2 filter grammar
+// beyond "*": "?" for exactly one character, and "\" escaping the next byte.
+func TestMatchWildcard_SingleCharacterAndEscapes(t *testing.T) {
+	tests := []struct {
+		pattern string
+		value   string
+		want    bool
+	}{
+		// "?" alone.
+		{"a?c", "abc", true},
+		{"a?c", "ac", false},
+		{"a?c", "abbc", false},
+
+		// "?" never matches the empty string.
+		{"abc?", "abc", false},
+		{"?", "", false},
+		{"?", "a", true},
+
+		// "?" at pattern start and end.
+		{"?bc", "abc", true},
+		{"?bc", "bc", false},
+		{"ab?", "abc", true},
+
+		// "?" combined with "*".
+		{"a?*c", "abxc", true},
+		{"a?*c", "ac", false},
+		{"web?-*", "web1-prod", true},
+		{"web?-*", "web-prod", false},
+
+		// Escaped metacharacters match themselves and nothing else.
+		{`a\*c`, "a*c", true},
+		{`a\*c`, "abc", false},
+		{`a\?c`, "a?c", true},
+		{`a\?c`, "abc", false},
+		{`a\\c`, `a\c`, true},
+		{`a\\c`, "abc", false},
+		{`ab\`, `ab\`, true},
+
+		// An unescaped "*" in the pattern stays a wildcard even when the value
+		// contains a literal "*" at the same offset.
+		{"a*", "a*c", true},
+		{"a*c", "a*c", true},
+
+		// Backtracking.
+		{"a*b?c", "axxbyc", true},
+		{"*?", "a", true},
+		{"a*a*a*b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false},
+	}
+
+	for _, tt := range tests {
+		if got := MatchWildcard(tt.pattern, tt.value); got != tt.want {
+			t.Errorf("MatchWildcard(%q, %q) = %v, want %v", tt.pattern, tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestMatchesTags_SingleCharacterWildcard confirms the fix reaches the tag
+// filter path callers actually use.
+func TestMatchesTags_SingleCharacterWildcard(t *testing.T) {
+	filters := map[string][]string{"tag:Name": {"web?"}}
+	if !MatchesTags(filters, map[string]string{"Name": "web1"}) {
+		t.Fatal("expected tag:Name=web? to match web1")
+	}
+	if MatchesTags(filters, map[string]string{"Name": "web"}) {
+		t.Fatal("expected tag:Name=web? to NOT match web")
+	}
+}
+
 func TestMatchWildcard_TwoPartPattern(t *testing.T) {
 	// Simple two-part: prefix + suffix, no middle parts.
 	if !MatchesAny([]string{"a*a"}, "aa") {


### PR DESCRIPTION
## Summary

`filterutil.MatchWildcard` implemented only `*`. The EC2 `DescribeX` filter grammar also defines `?` as matching exactly one character, and a backslash escape so a literal `*`, `?` or `\` can still be filtered for. Both were compared as literal bytes, so `--filters Name=tag:Name,Values=web?` returned nothing where AWS returns the instance tagged `web1`.

Unlike the IAM equivalent this is not a security boundary — filters narrow a result set the caller is already authorized to see, so the failure is a missing row, never an extra one.

## Changes

- Rewrote `MatchWildcard` as a single-pass glob matcher: `*` matches zero or more characters at any position, `?` matches exactly one and never the empty string, `\` escapes the next byte, every other byte is literal. A trailing `\` matches itself rather than erroring, since a filter value is caller input and a typo should not become an API error.
- Used a greedy scan with one backtrack point at the most recent `*`, so patterns like `a*a*a*b` stay linear instead of blowing up exponentially. Iterative and allocation-free, removing the previous `strings.Split` that ran once per candidate resource per filter value on every `DescribeX`.
- Kept the `pattern == "*"` fast path and widened the literal fast path to `strings.ContainsAny(pattern, "*?\\")`.
- Matching stays byte-wise and case-sensitive. `MatchesAny` and `MatchesTags` are unchanged apart from a corrected doc comment.
- Tests: `?` alone, at pattern start and end, combined with `*`, not matching empty; each escape including a trailing backslash; a backtracking guard; and a `tag:Name` case through `MatchesTags`. All existing cases pass unchanged.

This is deliberately a separate implementation from `iampolicy.MatchWildcard` rather than a shared one. The two grammars differ — EC2 filters have a backslash escape, IAM policy patterns have none — so sharing would need a mode flag and would let a change made for one surface alter the other.

## Testing

`make preflight` passes.