### PR TITLE
fix: stop reporting a placement group read failure as a successful removal

### DIFF
--- a/spinifex/handlers/ec2/placementgroup/service_impl.go
+++ b/spinifex/handlers/ec2/placementgroup/service_impl.go
@@ -314,12 +314,17 @@ func pgMatchesAnyTag(tags map[string]string, values []string, field func(k, v st
 }
 
 // GetPlacementGroupRecord reads a placement group record from KV with its revision for CAS operations.
-// Returns the record and the KV entry (for revision). Exported for use by gateway spread routing.
+// Returns the record and the KV entry (for revision).
 func (s *PlacementGroupServiceImpl) GetPlacementGroupRecord(ctx context.Context, accountID, groupName string) (*PlacementGroupRecord, jetstream.KeyValueEntry, error) {
 	key := utils.AccountKey(accountID, groupName)
 	entry, err := s.kv.Get(ctx, key)
 	if err != nil {
-		return nil, nil, errors.New(awserrors.ErrorInvalidPlacementGroupUnknown)
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, nil, errors.New(awserrors.ErrorInvalidPlacementGroupUnknown)
+		}
+		slog.ErrorContext(ctx, "Failed to read placement group from KV",
+			"groupName", groupName, "accountID", accountID, "err", err)
+		return nil, nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
 	var record PlacementGroupRecord
@@ -486,9 +491,12 @@ func (s *PlacementGroupServiceImpl) RemoveInstance(ctx context.Context, input *R
 	for attempt := range maxCASRetries {
 		record, entry, lookupErr := s.GetPlacementGroupRecord(ctx, accountID, input.GroupName)
 		if lookupErr != nil {
+			if !awserrors.IsErrorCode(lookupErr, awserrors.ErrorInvalidPlacementGroupUnknown) {
+				return nil, lookupErr
+			}
 			// Group may have been deleted already — treat as success
 			slog.DebugContext(ctx, "RemoveInstance: group not found, treating as success", "groupName", input.GroupName)
-			return &RemoveInstanceOutput{}, nil //nolint:nilerr // intentional: deleted group = success
+			return &RemoveInstanceOutput{}, nil
 		}
 
 		instances, exists := record.NodeInstances[input.NodeName]

--- a/spinifex/handlers/ec2/placementgroup/service_impl_test.go
+++ b/spinifex/handlers/ec2/placementgroup/service_impl_test.go
@@ -867,3 +867,22 @@ func TestSpreadLifecycle_ReserveFinalizeDelete(t *testing.T) {
 	}, testAccountID)
 	require.NoError(t, err)
 }
+
+func TestRemoveInstance_ReadFailureIsNotSuccess(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	svc, err := NewPlacementGroupServiceImplWithNATS(t.Context(), nil, nc)
+	require.NoError(t, err)
+
+	createTestGroup(t, svc, "pg-readfail", "spread")
+
+	// A closed connection fails the read for a reason other than a missing key.
+	nc.Close()
+
+	_, err = svc.RemoveInstance(context.Background(), &RemoveInstanceInput{
+		GroupName:  "pg-readfail",
+		InstanceID: "i-readfail01",
+		NodeName:   "node-1",
+	}, testAccountID)
+	require.Error(t, err)
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorServerInternal), "got %v", err)
+}


### PR DESCRIPTION
`RemoveInstance` reported success when it had removed nothing, and the effect outlived the failure that caused it.

## The bug

`GetPlacementGroupRecord` mapped every `kv.Get` error to `awserrors.ErrorInvalidPlacementGroupUnknown`, not just `jetstream.ErrKeyNotFound`. A transient NATS failure was therefore indistinguishable from a group that genuinely did not exist.

`RemoveInstance` then treated any lookup error as a deleted group and returned success:

    record, entry, lookupErr := s.GetPlacementGroupRecord(ctx, accountID, input.GroupName)
    if lookupErr != nil {
        // Group may have been deleted already — treat as success
        return &RemoveInstanceOutput{}, nil //nolint:nilerr
    }

So a NATS blip during instance removal returned success while leaving the instance in `NodeInstances`, and nothing retried because the caller had been told it worked.

The consequence is not transient. `ReserveSpreadNodes` treats any node present in `NodeInstances` as occupied, so the stale entry permanently removes that node from spread eligibility for the group. Capacity shrinks silently and stays shrunk, with no error logged anywhere to trace it back to.

## The fix

`GetPlacementGroupRecord` now separates the two cases. A genuine `ErrKeyNotFound` still returns `InvalidPlacementGroupUnknown`, unchanged. Any other read failure is logged and returns `ErrorServerInternal`.

`RemoveInstance` narrows its success shortcut to that one error code, so a deleted group is still success and a broken read is now an error.

The other five callers of `GetPlacementGroupRecord` return the lookup error unchanged, so a missing group still produces exactly the same AWS error it did before. Only the previously mislabelled read failure behaves differently, and it now tells the truth. No other call site needed touching.

## Testing

`TestRemoveInstance_ReadFailureIsNotSuccess` closes the NATS connection after setup so the read fails for a reason other than a missing key, then asserts an error is returned. Verified red before the fix, with `An error is expected but got nil`, and green after.

`TestRemoveInstance_GroupNotFound` already covered the other half and still passes. Together the pair pins both directions: a deleted group succeeds, a failed read does not.

`make preflight`.

## Follow-up

The six CAS retry loops in this file are still hand-rolled and are the last item in the `kvutil` consolidation. Converting them also fixes a second defect, where a non-conflict write error is retried as though it were contention and then reported as exhausted retries. That is a separate PR, planned in `docs/development/josh/improvements/placementgroup-cas-consolidation.md`.
