### PR TITLE
refactor: convert the acm certificate store to kvstore

### DIFF
--- a/spinifex/handlers/acm/getcertificate_test.go
+++ b/spinifex/handlers/acm/getcertificate_test.go
@@ -125,7 +125,7 @@ func putUndecryptableCert(t *testing.T, store *Store, arn, domain string) {
 		Status:         acm.CertificateStatusIssued,
 	})
 	require.NoError(t, err)
-	_, err = store.kv.Put(t.Context(), certKey(arn), data)
+	_, err = rawKV(t, store).Put(t.Context(), certKey(arn), data)
 	require.NoError(t, err)
 }
 

--- a/spinifex/handlers/acm/service_impl_test.go
+++ b/spinifex/handlers/acm/service_impl_test.go
@@ -278,7 +278,7 @@ func TestImportCertificate_PrivateKeyEncryptedAtRest(t *testing.T) {
 	}, testAccountID)
 	require.NoError(t, err)
 
-	entry, err := svc.store.kv.Get(context.Background(), certKey(aws.StringValue(out.CertificateArn)))
+	entry, err := rawKV(t, svc.store).Get(context.Background(), certKey(aws.StringValue(out.CertificateArn)))
 	require.NoError(t, err)
 
 	var raw CertRecord

--- a/spinifex/handlers/acm/store.go
+++ b/spinifex/handlers/acm/store.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/arn"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -154,7 +155,7 @@ type CertRecord struct {
 
 // Store provides CRUD for ACM certificate records backed by JetStream KV.
 type Store struct {
-	kv jetstream.KeyValue
+	store *kvstore.Store[CertRecord]
 	// masterKey encrypts/decrypts CertRecord.PrivateKey at rest (AES-256-GCM via
 	// handlers_iam.EncryptSecret/DecryptSecret). Every Store over the ACM bucket
 	// — the ACM service and ELBv2's independent read-only Store alike — must be
@@ -184,8 +185,16 @@ func NewStore(ctx context.Context, nc *nats.Conn, masterKey []byte) (*Store, err
 		return nil, err
 	}
 
-	slog.Info("ACM store initialized", "bucket", KVBucketACM)
-	return &Store{kv: kv, masterKey: masterKey}, nil
+	slog.Info("ACM store initialised", "bucket", KVBucketACM)
+	return &Store{
+		store: kvstore.Over[CertRecord](kv, kvstore.Config{
+			Attempts: maxInUseByCASAttempts,
+			Exhausted: func(key string, attempts int) error {
+				return fmt.Errorf("acm store: exceeded %d CAS attempts updating %s", attempts, key)
+			},
+		}),
+		masterKey: masterKey,
+	}, nil
 }
 
 // certKey derives the KV key from a certificate ARN, reading the id exactly as
@@ -215,16 +224,11 @@ func (s *Store) PutCert(ctx context.Context, rec *CertRecord) error {
 	// this call.
 	clone := *rec
 	clone.PrivateKey = ciphertext
-	data, err := json.Marshal(&clone)
-	if err != nil {
-		return fmt.Errorf("marshal cert: %w", err)
-	}
 	key := certKey(rec.CertificateArn)
 	if key == "" {
 		return fmt.Errorf("acm store: not a certificate ARN: %q", rec.CertificateArn)
 	}
-	_, err = s.kv.Put(ctx, key, data)
-	return err
+	return s.store.Set(ctx, key, &clone)
 }
 
 // GetCert retrieves a certificate by ARN with PrivateKey decrypted to
@@ -260,25 +264,21 @@ func (s *Store) getCert(ctx context.Context, certArn string, decrypt bool) (*Cer
 	if key == "" {
 		return nil, nil
 	}
-	entry, err := s.kv.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, nil
-		}
-		return nil, err
+	rec, _, err := s.store.Get(ctx, key)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return nil, nil
 	}
-	var rec CertRecord
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return nil, fmt.Errorf("unmarshal cert: %w", err)
+	if err != nil {
+		return nil, err
 	}
 	if !decrypt {
 		rec.PrivateKey = ""
-		return &rec, nil
+		return rec, nil
 	}
-	if err := s.decryptPrivateKey(&rec); err != nil {
+	if err := s.decryptPrivateKey(rec); err != nil {
 		return nil, err
 	}
-	return &rec, nil
+	return rec, nil
 }
 
 // legacyPrivateKeyPEMTypes are the PEM block types ImportCertificate accepts
@@ -333,13 +333,11 @@ func (s *Store) DeleteCert(ctx context.Context, certArn string) (bool, error) {
 	if key == "" {
 		return false, nil
 	}
-	if _, err := s.kv.Get(ctx, key); err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return false, nil
-		}
+	present, err := s.store.Exists(ctx, key)
+	if err != nil || !present {
 		return false, err
 	}
-	if err := s.kv.Delete(ctx, key); err != nil {
+	if err := s.store.Delete(ctx, key); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -386,7 +384,11 @@ func (s *Store) ListAllCertMetadata(ctx context.Context) ([]*CertRecord, error) 
 // ListAllCertMetadata — and an undecryptable key is not a reason to skip the
 // record, since nothing here reads it.
 func (s *Store) listCerts(ctx context.Context, keep func(*CertRecord) bool, decrypt bool) ([]*CertRecord, error) {
-	keys, err := s.kv.Keys(ctx)
+	kv, err := s.store.KV(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := kv.Keys(ctx)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return nil, nil
@@ -398,7 +400,7 @@ func (s *Store) listCerts(ctx context.Context, keep func(*CertRecord) bool, decr
 		if !strings.HasPrefix(key, KeyPrefixCert) {
 			continue
 		}
-		entry, err := s.kv.Get(ctx, key)
+		entry, err := kv.Get(ctx, key)
 		if err != nil {
 			continue
 		}
@@ -464,11 +466,6 @@ func (s *Store) RemoveInUseBy(ctx context.Context, certArn, resourceArn string) 
 	})
 }
 
-// errCertAbsent lets updateInUseByCAS tell an absent certificate apart from a
-// real failure. Both callers treat a missing certificate as a no-op, so it
-// never escapes this file.
-var errCertAbsent = errors.New("acm store: certificate not found")
-
 // updateInUseByCAS applies mutate to certArn's current InUseBy set and writes
 // the result back under CAS. mutate returns nil to mean "no change needed".
 // A certificate that does not exist is a no-op, not an error.
@@ -477,13 +474,7 @@ func (s *Store) updateInUseByCAS(ctx context.Context, certArn string, mutate fun
 	if key == "" {
 		return nil
 	}
-	_, err := kvutil.Update(ctx, s.kv, key, kvutil.CASConfig{
-		Attempts: maxInUseByCASAttempts,
-		NotFound: errCertAbsent,
-		Exhausted: func(string, int) error {
-			return fmt.Errorf("acm store: exceeded %d CAS attempts updating InUseBy for %s", maxInUseByCASAttempts, certArn)
-		},
-	}, func(rec *CertRecord) (bool, error) {
+	err := s.store.Mutate(ctx, key, func(rec *CertRecord) (bool, error) {
 		next := mutate(rec.InUseBy)
 		if next == nil {
 			return false, nil
@@ -491,7 +482,7 @@ func (s *Store) updateInUseByCAS(ctx context.Context, certArn string, mutate fun
 		rec.InUseBy = next
 		return true, nil
 	})
-	if errors.Is(err, errCertAbsent) {
+	if errors.Is(err, kvstore.ErrNotFound) {
 		return nil
 	}
 	return err
@@ -515,28 +506,20 @@ func (s *Store) AcquireLease(ctx context.Context, certArn, holderID string, ttl 
 	if key == "" {
 		return false, nil
 	}
-	entry, err := s.kv.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return false, nil
-		}
-		return false, err
+	rec, rev, err := s.store.Get(ctx, key)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return false, nil
 	}
-	var rec CertRecord
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return false, fmt.Errorf("unmarshal cert: %w", err)
+	if err != nil {
+		return false, err
 	}
 	if rec.LeaseHolder != "" && rec.LeaseHolder != holderID && rec.LeaseExpiresAt.After(now) {
 		return false, nil
 	}
 	rec.LeaseHolder = holderID
 	rec.LeaseExpiresAt = now.Add(ttl)
-	data, err := json.Marshal(&rec)
-	if err != nil {
-		return false, fmt.Errorf("marshal cert: %w", err)
-	}
-	if _, err := s.kv.Update(ctx, key, data, entry.Revision()); err != nil {
-		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
+	if err := s.store.CompareAndSet(ctx, key, rec, rev); err != nil {
+		if errors.Is(err, kvstore.ErrConflict) {
 			// Lost the race to a concurrent acquirer between Get and Update;
 			// the caller skips this tick rather than retrying immediately.
 			return false, nil
@@ -555,28 +538,20 @@ func (s *Store) ReleaseLease(ctx context.Context, certArn, holderID string) erro
 	if key == "" {
 		return nil
 	}
-	entry, err := s.kv.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil
-		}
-		return err
+	rec, rev, err := s.store.Get(ctx, key)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return nil
 	}
-	var rec CertRecord
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return fmt.Errorf("unmarshal cert: %w", err)
+	if err != nil {
+		return err
 	}
 	if rec.LeaseHolder != holderID {
 		return nil // already released, expired, or taken over by another holder
 	}
 	rec.LeaseHolder = ""
 	rec.LeaseExpiresAt = time.Time{}
-	data, err := json.Marshal(&rec)
-	if err != nil {
-		return fmt.Errorf("marshal cert: %w", err)
-	}
-	if _, err := s.kv.Update(ctx, key, data, entry.Revision()); err != nil {
-		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
+	if err := s.store.CompareAndSet(ctx, key, rec, rev); err != nil {
+		if errors.Is(err, kvstore.ErrConflict) {
 			return nil // record changed concurrently; nothing to clean up
 		}
 		return err

--- a/spinifex/handlers/acm/store_test.go
+++ b/spinifex/handlers/acm/store_test.go
@@ -9,6 +9,7 @@ import (
 
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,6 +25,16 @@ func setupACMStore(t *testing.T) *Store {
 	store, err := NewStore(t.Context(), nc, masterKey)
 	require.NoError(t, err)
 	return store
+}
+
+// rawKV returns the underlying bucket so a test can assert on the bytes as
+// stored. Reading through Store would decode them, which is the one thing
+// these tests must not do.
+func rawKV(t *testing.T, s *Store) jetstream.KeyValue {
+	t.Helper()
+	kv, err := s.store.KV(t.Context())
+	require.NoError(t, err)
+	return kv
 }
 
 func TestAddInUseBy_AddsAndDedupes(t *testing.T) {
@@ -142,7 +153,7 @@ func TestStore_PutCert_EncryptsPrivateKeyAtRest(t *testing.T) {
 	require.NoError(t, store.PutCert(t.Context(), rec))
 
 	// The raw bytes landed in KV must not contain the plaintext key.
-	entry, err := store.kv.Get(t.Context(), certKey(arn))
+	entry, err := rawKV(t, store).Get(t.Context(), certKey(arn))
 	require.NoError(t, err)
 	assert.NotContains(t, string(entry.Value()), "BEGIN EC PRIVATE KEY")
 
@@ -166,7 +177,7 @@ func TestStore_GetCert_LegacyPlaintextPassthroughAndReencrypt(t *testing.T) {
 	legacy := &CertRecord{CertificateArn: arn, AccountID: "000000000001", PrivateKey: plaintext}
 	data, err := json.Marshal(legacy)
 	require.NoError(t, err)
-	_, err = store.kv.Put(t.Context(), certKey(arn), data)
+	_, err = rawKV(t, store).Put(t.Context(), certKey(arn), data)
 	require.NoError(t, err)
 
 	got, err := store.GetCert(t.Context(), arn)
@@ -175,7 +186,7 @@ func TestStore_GetCert_LegacyPlaintextPassthroughAndReencrypt(t *testing.T) {
 
 	// The next write re-encrypts it — no operator action required.
 	require.NoError(t, store.PutCert(t.Context(), got))
-	entry, err := store.kv.Get(t.Context(), certKey(arn))
+	entry, err := rawKV(t, store).Get(t.Context(), certKey(arn))
 	require.NoError(t, err)
 	assert.NotContains(t, string(entry.Value()), "BEGIN RSA PRIVATE KEY", "record must be re-encrypted after the next PutCert")
 }
@@ -191,7 +202,7 @@ func TestStore_GetCert_RejectsGarbageAsLegacyPlaintext(t *testing.T) {
 	garbage := &CertRecord{CertificateArn: arn, AccountID: "000000000001", PrivateKey: "not-pem-and-not-ciphertext"}
 	data, err := json.Marshal(garbage)
 	require.NoError(t, err)
-	_, err = store.kv.Put(t.Context(), certKey(arn), data)
+	_, err = rawKV(t, store).Put(t.Context(), certKey(arn), data)
 	require.NoError(t, err)
 
 	_, err = store.GetCert(t.Context(), arn)
@@ -309,7 +320,7 @@ func TestAcquireLease_LeavesPrivateKeyEncrypted(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, acquired)
 
-	entry, err := store.kv.Get(t.Context(), certKey(arn))
+	entry, err := rawKV(t, store).Get(t.Context(), certKey(arn))
 	require.NoError(t, err)
 	assert.NotContains(t, string(entry.Value()), "BEGIN EC PRIVATE KEY",
 		"AcquireLease must not write the private key back in plaintext")
@@ -335,7 +346,7 @@ func TestReleaseLease_LeavesPrivateKeyEncrypted(t *testing.T) {
 
 	require.NoError(t, store.ReleaseLease(t.Context(), arn, "node-a"))
 
-	entry, err := store.kv.Get(t.Context(), certKey(arn))
+	entry, err := rawKV(t, store).Get(t.Context(), certKey(arn))
 	require.NoError(t, err)
 	assert.NotContains(t, string(entry.Value()), "BEGIN EC PRIVATE KEY",
 		"ReleaseLease must not write the private key back in plaintext")

--- a/spinifex/kvstore/bucket.go
+++ b/spinifex/kvstore/bucket.go
@@ -15,11 +15,13 @@ import (
 
 // Config describes the bucket that a Store or Bucket sits over.
 type Config struct {
-	Name     string
-	History  int
-	Replicas int
-	TTL      time.Duration
-	Missing  string
+	Name      string
+	History   int
+	Replicas  int
+	TTL       time.Duration
+	Missing   string
+	Attempts  int
+	Exhausted func(key string, attempts int) error
 }
 
 // Bucket memoises a lazily created KV bucket. Construct it with NewBucket.
@@ -37,15 +39,25 @@ func NewBucket(js jetstream.JetStream, cfg Config) *Bucket {
 	return &Bucket{js: js, cfg: cfg}
 }
 
+// NewOpenBucket returns a Bucket over an already-open handle, for callers that
+// resolve their bucket at construction so a bad connection fails at startup
+// rather than on first use.
+func NewOpenBucket(kv jetstream.KeyValue, cfg Config) *Bucket {
+	return &Bucket{kv: kv, cfg: cfg}
+}
+
 // KV opens the bucket on first use and returns the cached handle thereafter.
 func (b *Bucket) KV(ctx context.Context) (jetstream.KeyValue, error) {
-	if b.js == nil {
-		return nil, errors.New(b.cfg.Missing)
-	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.kv != nil {
 		return b.kv, nil
+	}
+	if b.js == nil {
+		if b.cfg.Missing == "" {
+			return nil, errors.New("kvstore: no JetStream client configured")
+		}
+		return nil, errors.New(b.cfg.Missing)
 	}
 	kv, err := b.open(ctx)
 	if err != nil {

--- a/spinifex/kvstore/store.go
+++ b/spinifex/kvstore/store.go
@@ -16,6 +16,7 @@ import (
 var (
 	ErrNotFound = errors.New("kvstore: key not found")
 	ErrExists   = errors.New("kvstore: key already exists")
+	ErrConflict = errors.New("kvstore: revision conflict")
 )
 
 // Store is a Bucket plus a JSON codec for T.
@@ -66,7 +67,9 @@ func (s *Store[T]) Mutate(ctx context.Context, key string, fn func(*T) (bool, er
 		return err
 	}
 	_, err = kvutil.Update(ctx, kv, key, kvutil.CASConfig{
-		NotFound: fmt.Errorf("%w: %s", ErrNotFound, key),
+		Attempts:  s.cfg.Attempts,
+		NotFound:  fmt.Errorf("%w: %s", ErrNotFound, key),
+		Exhausted: s.cfg.Exhausted,
 	}, fn)
 	return err
 }
@@ -122,6 +125,65 @@ func (s *Store[T]) DeletePrefix(ctx context.Context, prefix string) error {
 		if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 			return fmt.Errorf("kvstore: delete %s: %w", key, err)
 		}
+	}
+	return nil
+}
+
+// Over returns a Store for records of type T over an already-open bucket.
+func Over[T any](kv jetstream.KeyValue, cfg Config) *Store[T] {
+	return &Store[T]{Bucket: NewOpenBucket(kv, cfg)}
+}
+
+// Set writes a record whether or not the key exists, for callers whose write
+// is a replacement rather than a claim or a read-modify-write.
+func (s *Store[T]) Set(ctx context.Context, key string, v *T) error {
+	kv, err := s.KV(ctx)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("kvstore: encode %s: %w", key, err)
+	}
+	if _, err := kv.Put(ctx, key, data); err != nil {
+		return fmt.Errorf("kvstore: put %s: %w", key, err)
+	}
+	return nil
+}
+
+// Exists reports whether a key is present without decoding its value, so a
+// record that cannot be unmarshalled is still reported as present.
+func (s *Store[T]) Exists(ctx context.Context, key string) (bool, error) {
+	kv, err := s.KV(ctx)
+	if err != nil {
+		return false, err
+	}
+	if _, err := kv.Get(ctx, key); err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("kvstore: get %s: %w", key, err)
+	}
+	return true, nil
+}
+
+// CompareAndSet writes v only if key is still at rev, returning ErrConflict
+// when it is not. For callers whose lost race is a decision rather than a
+// failure; callers that should retry want Mutate.
+func (s *Store[T]) CompareAndSet(ctx context.Context, key string, v *T, rev uint64) error {
+	kv, err := s.KV(ctx)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("kvstore: encode %s: %w", key, err)
+	}
+	if _, err := kv.Update(ctx, key, data, rev); err != nil {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) || errors.Is(err, jetstream.ErrKeyExists) {
+			return fmt.Errorf("%w: %s", ErrConflict, key)
+		}
+		return fmt.Errorf("kvstore: update %s: %w", key, err)
 	}
 	return nil
 }

--- a/spinifex/kvstore/store_test.go
+++ b/spinifex/kvstore/store_test.go
@@ -2,10 +2,13 @@ package kvstore_test
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -183,4 +186,158 @@ func TestStore_NilJetStreamReportsTheConfiguredMessage(t *testing.T) {
 
 	_, err = store.List(t.Context(), "")
 	require.ErrorContains(t, err, "no JetStream client configured")
+}
+
+// TestStore_NilJetStreamWithNoMessageStillSaysSomething guards the fallback: a
+// Config that omits Missing must not produce an error with an empty string,
+// which reads as a passing call to anything logging err.Error().
+func TestStore_NilJetStreamWithNoMessageStillSaysSomething(t *testing.T) {
+	store := kvstore.New[record](nil, kvstore.Config{Name: "kvstore-test"})
+
+	_, _, err := store.Get(t.Context(), "acct-a/one")
+	require.Error(t, err)
+	assert.NotEmpty(t, err.Error(), "an error with no message is worse than a wrong one")
+	assert.ErrorContains(t, err, "no JetStream client configured")
+}
+
+// newOpenBucket starts an embedded JetStream server and returns an already-open
+// bucket handle, the shape an eager caller holds at construction.
+func newOpenBucket(t *testing.T) jetstream.KeyValue {
+	t.Helper()
+	_, nc, _ := testutil.StartTestJetStream(t)
+	kv, err := kvutil.GetOrCreateBucket(t.Context(), testutil.NewJetStream(t, nc), "kvstore-over-test", 1)
+	require.NoError(t, err)
+	return kv
+}
+
+// TestOver_ServesAPreOpenedBucket covers the eager-caller path end to end. It
+// also pins the order of the checks in Bucket.KV: a Store built by Over holds
+// no JetStream client, so a nil-client guard running before the memo check
+// would fail every one of these calls with an empty error string.
+func TestOver_ServesAPreOpenedBucket(t *testing.T) {
+	kv := newOpenBucket(t)
+
+	// A record written straight to the bucket, as a pre-existing one would be.
+	data, err := json.Marshal(record{Name: "one", Count: 7})
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), "acct-a/one", data)
+	require.NoError(t, err)
+
+	store := kvstore.Over[record](kv, kvstore.Config{})
+
+	got, _, err := store.Get(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.Equal(t, record{Name: "one", Count: 7}, *got)
+
+	require.NoError(t, store.Set(t.Context(), "acct-a/two", &record{Name: "two"}))
+	all, err := store.List(t.Context(), "acct-a/")
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+}
+
+func TestStore_SetOverwritesWhereCreateWouldConflict(t *testing.T) {
+	store := newStore(t)
+	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "first"}))
+	require.ErrorIs(t, store.Create(t.Context(), "acct-a/one", &record{Name: "second"}), kvstore.ErrExists)
+
+	require.NoError(t, store.Set(t.Context(), "acct-a/one", &record{Name: "second", Count: 9}))
+	got, _, err := store.Get(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.Equal(t, record{Name: "second", Count: 9}, *got, "Set replaces where Create refuses")
+
+	require.NoError(t, store.Set(t.Context(), "acct-a/new", &record{Name: "new"}))
+	got, _, err = store.Get(t.Context(), "acct-a/new")
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Name, "Set on an absent key creates it")
+}
+
+// TestStore_ExistsDoesNotDecode is the reason Exists is a method rather than a
+// Get in disguise: a record whose bytes will not unmarshal must still be
+// reported as present, or it becomes impossible to delete.
+func TestStore_ExistsDoesNotDecode(t *testing.T) {
+	store := newStore(t)
+	kv, err := store.KV(t.Context())
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), "acct-a/corrupt", []byte("{not json"))
+	require.NoError(t, err)
+
+	_, _, err = store.Get(t.Context(), "acct-a/corrupt")
+	require.Error(t, err, "Get cannot read it")
+
+	present, err := store.Exists(t.Context(), "acct-a/corrupt")
+	require.NoError(t, err)
+	assert.True(t, present, "a corrupt record is still present, and must stay deletable")
+
+	require.NoError(t, store.Delete(t.Context(), "acct-a/corrupt"))
+	present, err = store.Exists(t.Context(), "acct-a/corrupt")
+	require.NoError(t, err)
+	assert.False(t, present)
+}
+
+func TestStore_ExistsIsFalseForAnAbsentKey(t *testing.T) {
+	store := newStore(t)
+
+	present, err := store.Exists(t.Context(), "nobody")
+	require.NoError(t, err, "an absent key is not an error, unlike Get")
+	assert.False(t, present)
+}
+
+func TestStore_CompareAndSetRejectsAStaleRevision(t *testing.T) {
+	store := newStore(t)
+	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one", Count: 1}))
+	_, stale, err := store.Get(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+
+	// Another writer commits first, moving the revision on.
+	seedRaw(t, store, "acct-a/one", record{Name: "one", Count: 2})
+
+	err = store.CompareAndSet(t.Context(), "acct-a/one", &record{Name: "one", Count: 99}, stale)
+	require.ErrorIs(t, err, kvstore.ErrConflict)
+
+	got, fresh, err := store.Get(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.Equal(t, 2, got.Count, "a rejected write must leave the winner's value in place")
+
+	require.NoError(t, store.CompareAndSet(t.Context(), "acct-a/one", &record{Name: "one", Count: 3}, fresh))
+	got, _, err = store.Get(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.Equal(t, 3, got.Count, "the same call commits at the current revision")
+}
+
+// TestStore_ConfigAttemptsBoundsMutate pins both halves of the per-store budget:
+// the loop stops after Attempts tries, and the caller's Exhausted error is what
+// surfaces rather than kvutil's default message.
+func TestStore_ConfigAttemptsBoundsMutate(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	errBudgetSpent := errors.New("budget spent")
+	var gotKey string
+	var gotAttempts int
+
+	store := kvstore.New[record](testutil.NewJetStream(t, nc), kvstore.Config{
+		Name:     "kvstore-attempts-test",
+		History:  1,
+		Attempts: 2,
+		Exhausted: func(key string, attempts int) error {
+			gotKey, gotAttempts = key, attempts
+			return errBudgetSpent
+		},
+	})
+	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one"}))
+
+	calls := 0
+	err := store.Mutate(t.Context(), "acct-a/one", func(rec *record) (bool, error) {
+		calls++
+		// Move the revision on every attempt, so no commit can ever win.
+		seedRaw(t, store, "acct-a/one", record{Name: "one", Count: calls})
+		rec.Count = 100
+		return true, nil
+	})
+	require.ErrorIs(t, err, errBudgetSpent, "the configured error must surface, not kvutil's default")
+	assert.Equal(t, 2, calls, "Attempts bounds the loop")
+	assert.Equal(t, "acct-a/one", gotKey)
+	assert.Equal(t, 2, gotAttempts, "Exhausted is told the budget it spent")
+
+	got, _, err := store.Get(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.Equal(t, 2, got.Count, "an exhausted Mutate commits nothing of its own")
 }


### PR DESCRIPTION
Second of Phase 3. `acm` is deliberately not one of the thirteen files the phase was scoped around — it is the pilot that tests whether `kvstore` serves the rest of the tree or only the subsystem the duplication came from.

## Why acm

All thirteen lazy `bucket(ctx)` accessors are in `gateway/bedrock` (eight) and `ochrevector` (five). There are none anywhere else, because the memoised-lazy accessor is one of three patterns rather than the dominant one:

| Pattern | Bucket obtained | Where |
| --- | --- | --- |
| A, eager | opened at construction, struct holds a `jetstream.KeyValue` | `acm`, `iam`, `elbv2`, `sts`, `ecr`, `ec2/*` |
| B, lazy memoised | struct holds `js`, opens on first use | the thirteen |
| C, per-account | resolved per call, one bucket per tenant | `eks`, `ecs`, `rds` |

As an accessor deduplication this phase only ever helps pattern B. The value that generalises is the codec above it, and nothing had tested that against a pattern A caller. `acm` is small, eager, and has a transform layer over the codec — it encrypts `PrivateKey` on write and either decrypts or clears it on read. That last part is the real test of the seam.

## The answer

It fits. The transform composes cleanly: `acm` keeps its encryption, `kvstore` handles the bucket and the JSON, and neither leaks into the other.

Five additions were needed to get there. Each is named by a specific call site rather than speculated, and none changed what `Store[T]` is:

| Addition | Driven by |
| --- | --- |
| `Over[T](kv, cfg)` | Eager construction. `NewStore` returning an error is how `elbv2` and acm's own service detect broken JetStream at startup; lazy construction would move that to the first certificate operation |
| `Set` | `PutCert` writes unconditionally — no claim, no CAS. `guardrail`, `provisioned` and `logging` want it too |
| `Exists` | `DeleteCert` probes without decoding, and must keep doing so |
| `CompareAndSet` and `ErrConflict` | `AcquireLease` and `ReleaseLease` are single-shot CAS where a lost race is a decision, not a failure. `Mutate` retries, so it cannot express them |
| `Config.Attempts` and `Config.Exhausted` | `updateInUseByCAS` runs 50 attempts with its own exhaustion message |

`Exists` prevents a regression the obvious conversion would have introduced. `DeleteCert` returns whether the record was there, and routing that through `Get` would decode it — so a record whose JSON is corrupt would become permanently undeletable. `GetCertMetadata`'s comment forbids exactly that: "an unreadable key must not make a certificate undescribable or undeletable."

`CompareAndSet` matters beyond acm: it is the primitive the five remaining single-shot CAS sites in `ochrevector` and `gateway/bedrock` already need. It treats both `ErrKeyRevisionMismatch` and `ErrKeyExists` as a conflict, because a replicated bucket reports it as the latter — the defect #843 fixed across twenty files.

## One function does not convert

`listCerts` stays on the raw handle via `Store.KV`. It skips a record whose read or unmarshal fails and carries on, because one corrupt record must not stop the renewal worker renewing every other certificate. `Store.List` fails the whole listing instead, which is right for a tenant-facing `ListCertificates` where a silently short list is worse than an error.

Both policies are correct for their callers, so this is a real limit on `Store.List` rather than an oversight in either place. Papering over it with a flag would make one of the two callers silently wrong.

The useful shape of that result for the remaining conversions: expect one or two functions per file to stay on raw KV, and treat it as a normal outcome.

## Behaviour change

`Config.Exhausted` is per-store, so it cannot close over one call's ARN. The exhaustion message from `updateInUseByCAS` now names the KV key rather than the certificate ARN. The key is derived from the ARN, so nothing is lost, but the string differs.

## Also in this PR

`Bucket.KV` checked the nil-JetStream guard before the memo check. That is dead weight on the hot path and wrong for a pre-opened handle, so the two are swapped. `TestOver_ServesAPreOpenedBucket` pins the new order — with the old one it fails, and the failure message is empty, because `errors.New("")` is what a Store built by `Over` would have produced.

That empty string is worth not being reachable at all, so `KV` now falls back to a default message when `Config.Missing` is unset. An error that logs as nothing is worse than a wrong one.

Two pieces of the pre-conversion shape are gone because nothing reaches them any more. `errCertAbsent` was the sentinel `updateInUseByCAS` used to tell an absent certificate from a real failure, which `kvstore.ErrNotFound` now does. `AcquireLease` had an `if err != nil` that used to guard `json.Marshal(rec)`; the typed store marshals, so the branch was unreachable and the error it wrapped was provably nil. Both were caught by `unused` and `nilness` rather than by review.

## Testing

Seven new `kvstore` tests, seventeen in the package total. The two carrying the most weight:

`TestStore_ExistsDoesNotDecode` writes bytes that will not unmarshal, then asserts `Get` fails, `Exists` still reports the key as present, and `Delete` still removes it. That is the `DeleteCert` regression written as its own case.

`TestStore_ConfigAttemptsBoundsMutate` moves the revision on every attempt so no commit can win, then asserts the loop stops at the configured budget, the caller's error surfaces rather than `kvutil`'s default, `Exhausted` is told the budget it spent, and the record still holds the competing writer's value. Verified against `kvutil.retryCAS`, which passes the resolved budget.

Both new guards were checked red before green by reverting the production change and confirming the specific failure.

`acm` has 88 tests across seven files; `elbv2` builds its own `acm.Store` in `haproxy_certs_test.go`. All pass, and `NewStore`'s signature is unchanged so nothing outside the package sees this.

Eight acm test sites were repointed off the deleted `kv` field onto a `rawKV(t, store)` helper. Every one of them deliberately asserts on the bytes **as stored**, to prove a private key was never persisted in plaintext — so they must not go through the typed API, which would decode them. No assertion changed; only the way the handle is obtained.

`make preflight`.
