### PR TITLE
refactor: convert the ochrevector registry and kb stores to kvstore

### DIFF
--- a/spinifex/handlers/ochrevector/kbstore.go
+++ b/spinifex/handlers/ochrevector/kbstore.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-	"sync"
 	"time"
 
-	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -94,36 +92,18 @@ type DataSourceRecord struct {
 }
 
 // KBStore persists KBRecords in the ochre-kb JetStream KV bucket, mirroring
-// Registry's lazy get-or-create bucket, key "accountID/id", per-account
-// prefix-scan list.
+// Registry: key "accountID/id", per-account prefix-scan list.
 type KBStore struct {
-	js jetstream.JetStream
-
-	mu sync.Mutex
-	kv jetstream.KeyValue
+	store *kvstore.Store[KBRecord]
 }
 
 // NewKBStore constructs a KBStore over js.
 func NewKBStore(js jetstream.JetStream) *KBStore {
-	return &KBStore{js: js}
-}
-
-// bucket lazily opens (or creates) the KB KV bucket, caching the handle.
-func (s *KBStore) bucket(ctx context.Context) (jetstream.KeyValue, error) {
-	if s.js == nil {
-		return nil, errors.New("ochrevector: knowledge base store has no JetStream client configured")
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.kv != nil {
-		return s.kv, nil
-	}
-	kv, err := kvutil.GetOrCreateBucket(ctx, s.js, kbBucket, kbBucketHistory)
-	if err != nil {
-		return nil, err
-	}
-	s.kv = kv
-	return kv, nil
+	return &KBStore{store: kvstore.New[KBRecord](js, kvstore.Config{
+		Name:    kbBucket,
+		History: kbBucketHistory,
+		Missing: "ochrevector: knowledge base store has no JetStream client configured",
+	})}
 }
 
 // kbKey scopes every record to its owning account, so a foreign account's raw
@@ -137,17 +117,9 @@ func kbKey(accountID, id string) string {
 // creates of the same id race safely and exactly one wins. rec.AccountID is
 // stamped from accountID, overriding whatever the caller set.
 func (s *KBStore) Create(ctx context.Context, accountID string, rec KBRecord) error {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return err
-	}
 	rec.AccountID = accountID
-	data, err := json.Marshal(rec)
-	if err != nil {
-		return fmt.Errorf("ochrevector: encode knowledge base %s: %w", rec.ID, err)
-	}
-	if _, err := kv.Create(ctx, kbKey(accountID, rec.ID), data); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+	if err := s.store.Create(ctx, kbKey(accountID, rec.ID), &rec); err != nil {
+		if errors.Is(err, kvstore.ErrExists) {
 			return ErrKBExists
 		}
 		return fmt.Errorf("ochrevector: reserve knowledge base %s: %w", rec.ID, err)
@@ -155,71 +127,29 @@ func (s *KBStore) Create(ctx context.Context, accountID string, rec KBRecord) er
 	return nil
 }
 
-// Get reads accountID's record for id, returning (nil, nil) when absent.
+// Get reads accountID's record for id, returning (nil, nil) when absent, which
+// is how every caller distinguishes a missing knowledge base from a failure.
 func (s *KBStore) Get(ctx context.Context, accountID, id string) (*KBRecord, error) {
-	kv, err := s.bucket(ctx)
+	rec, _, err := s.store.Get(ctx, kbKey(accountID, id))
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
-	entry, err := kv.Get(ctx, kbKey(accountID, id))
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("ochrevector: kv get %s: %w", kbKey(accountID, id), err)
-	}
-	var rec KBRecord
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return nil, fmt.Errorf("ochrevector: decode %s: %w", kbKey(accountID, id), err)
-	}
-	return &rec, nil
+	return rec, nil
 }
 
 // List returns every knowledge base owned by accountID, so one tenant's
 // listing never surfaces another's.
 func (s *KBStore) List(ctx context.Context, accountID string) ([]KBRecord, error) {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	keys, err := kv.Keys(ctx)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("ochrevector: list keys: %w", err)
-	}
-	prefix := accountID + "/"
-	var out []KBRecord
-	for _, key := range keys {
-		if !strings.HasPrefix(key, prefix) {
-			continue
-		}
-		entry, err := kv.Get(ctx, key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				continue
-			}
-			return nil, fmt.Errorf("ochrevector: kv get %s: %w", key, err)
-		}
-		var rec KBRecord
-		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-			return nil, fmt.Errorf("ochrevector: decode %s: %w", key, err)
-		}
-		out = append(out, rec)
-	}
-	return out, nil
+	return s.store.List(ctx, accountID+"/")
 }
 
 // Delete removes accountID's id record. Idempotent: deleting an
 // already-absent record is a no-op success.
 func (s *KBStore) Delete(ctx context.Context, accountID, id string) error {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	key := kbKey(accountID, id)
-	if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+	if err := s.store.Delete(ctx, kbKey(accountID, id)); err != nil {
 		return fmt.Errorf("ochrevector: delete knowledge base %s: %w", id, err)
 	}
 	return nil
@@ -228,56 +158,22 @@ func (s *KBStore) Delete(ctx context.Context, accountID, id string) error {
 // PurgeAll deletes every knowledge base record across every account.
 // Idempotent: an empty bucket is a no-op success.
 func (s *KBStore) PurgeAll(ctx context.Context) error {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	keys, err := kv.Keys(ctx)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil
-		}
-		return fmt.Errorf("ochrevector: list keys: %w", err)
-	}
-	for _, key := range keys {
-		if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-			return fmt.Errorf("ochrevector: purge knowledge base %s: %w", key, err)
-		}
-	}
-	return nil
+	return s.store.DeletePrefix(ctx, "")
 }
 
 // DataSourceStore persists DataSourceRecords in the ochre-kb-datasource
 // JetStream KV bucket, mirroring KBStore.
 type DataSourceStore struct {
-	js jetstream.JetStream
-
-	mu sync.Mutex
-	kv jetstream.KeyValue
+	store *kvstore.Store[DataSourceRecord]
 }
 
 // NewDataSourceStore constructs a DataSourceStore over js.
 func NewDataSourceStore(js jetstream.JetStream) *DataSourceStore {
-	return &DataSourceStore{js: js}
-}
-
-// bucket lazily opens (or creates) the data-source KV bucket, caching the
-// handle.
-func (s *DataSourceStore) bucket(ctx context.Context) (jetstream.KeyValue, error) {
-	if s.js == nil {
-		return nil, errors.New("ochrevector: data source store has no JetStream client configured")
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.kv != nil {
-		return s.kv, nil
-	}
-	kv, err := kvutil.GetOrCreateBucket(ctx, s.js, dataSourceBucket, dataSourceBucketHistory)
-	if err != nil {
-		return nil, err
-	}
-	s.kv = kv
-	return kv, nil
+	return &DataSourceStore{store: kvstore.New[DataSourceRecord](js, kvstore.Config{
+		Name:    dataSourceBucket,
+		History: dataSourceBucketHistory,
+		Missing: "ochrevector: data source store has no JetStream client configured",
+	})}
 }
 
 // dataSourceKey scopes every record to its owning account, so a foreign
@@ -288,17 +184,9 @@ func dataSourceKey(accountID, id string) string {
 
 // Create atomically claims rec.ID for accountID, mirroring KBStore.Create.
 func (s *DataSourceStore) Create(ctx context.Context, accountID string, rec DataSourceRecord) error {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return err
-	}
 	rec.AccountID = accountID
-	data, err := json.Marshal(rec)
-	if err != nil {
-		return fmt.Errorf("ochrevector: encode data source %s: %w", rec.ID, err)
-	}
-	if _, err := kv.Create(ctx, dataSourceKey(accountID, rec.ID), data); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+	if err := s.store.Create(ctx, dataSourceKey(accountID, rec.ID), &rec); err != nil {
+		if errors.Is(err, kvstore.ErrExists) {
 			return ErrDataSourceExists
 		}
 		return fmt.Errorf("ochrevector: reserve data source %s: %w", rec.ID, err)
@@ -306,60 +194,23 @@ func (s *DataSourceStore) Create(ctx context.Context, accountID string, rec Data
 	return nil
 }
 
-// Get reads accountID's record for id, returning (nil, nil) when absent.
+// Get reads accountID's record for id, returning (nil, nil) when absent, which
+// is how every caller distinguishes a missing data source from a failure.
 func (s *DataSourceStore) Get(ctx context.Context, accountID, id string) (*DataSourceRecord, error) {
-	kv, err := s.bucket(ctx)
+	rec, _, err := s.store.Get(ctx, dataSourceKey(accountID, id))
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
-	entry, err := kv.Get(ctx, dataSourceKey(accountID, id))
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("ochrevector: kv get %s: %w", dataSourceKey(accountID, id), err)
-	}
-	var rec DataSourceRecord
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return nil, fmt.Errorf("ochrevector: decode %s: %w", dataSourceKey(accountID, id), err)
-	}
-	return &rec, nil
+	return rec, nil
 }
 
 // List returns every data source owned by accountID, across every knowledge
 // base, so one tenant's listing never surfaces another's.
 func (s *DataSourceStore) List(ctx context.Context, accountID string) ([]DataSourceRecord, error) {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	keys, err := kv.Keys(ctx)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("ochrevector: list keys: %w", err)
-	}
-	prefix := accountID + "/"
-	var out []DataSourceRecord
-	for _, key := range keys {
-		if !strings.HasPrefix(key, prefix) {
-			continue
-		}
-		entry, err := kv.Get(ctx, key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				continue
-			}
-			return nil, fmt.Errorf("ochrevector: kv get %s: %w", key, err)
-		}
-		var rec DataSourceRecord
-		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-			return nil, fmt.Errorf("ochrevector: decode %s: %w", key, err)
-		}
-		out = append(out, rec)
-	}
-	return out, nil
+	return s.store.List(ctx, accountID+"/")
 }
 
 // ListByKnowledgeBase returns accountID's data sources scoped to
@@ -381,12 +232,7 @@ func (s *DataSourceStore) ListByKnowledgeBase(ctx context.Context, accountID, kn
 // Delete removes accountID's id record. Idempotent: deleting an
 // already-absent record is a no-op success.
 func (s *DataSourceStore) Delete(ctx context.Context, accountID, id string) error {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	key := dataSourceKey(accountID, id)
-	if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+	if err := s.store.Delete(ctx, dataSourceKey(accountID, id)); err != nil {
 		return fmt.Errorf("ochrevector: delete data source %s: %w", id, err)
 	}
 	return nil
@@ -395,21 +241,5 @@ func (s *DataSourceStore) Delete(ctx context.Context, accountID, id string) erro
 // PurgeAll deletes every data source record across every account. Idempotent:
 // an empty bucket is a no-op success.
 func (s *DataSourceStore) PurgeAll(ctx context.Context) error {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	keys, err := kv.Keys(ctx)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil
-		}
-		return fmt.Errorf("ochrevector: list keys: %w", err)
-	}
-	for _, key := range keys {
-		if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-			return fmt.Errorf("ochrevector: purge data source %s: %w", key, err)
-		}
-	}
-	return nil
+	return s.store.DeletePrefix(ctx, "")
 }

--- a/spinifex/handlers/ochrevector/registry.go
+++ b/spinifex/handlers/ochrevector/registry.go
@@ -2,16 +2,13 @@ package handlers_ochrevector
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
-	"sync"
 	"time"
 
-	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -85,37 +82,18 @@ type Record struct {
 }
 
 // Registry persists index Records in the ochre-vector-indexes JetStream KV
-// bucket, mirroring GuardrailStore's gateway-direct-KV pattern (lazy
-// get-or-create bucket, key "accountID/id", per-account prefix-scan list).
+// bucket, keyed "accountID/id" with a per-account prefix-scan list.
 type Registry struct {
-	js jetstream.JetStream
-
-	mu sync.Mutex
-	kv jetstream.KeyValue
+	store *kvstore.Store[Record]
 }
 
 // NewRegistry constructs a Registry over js.
 func NewRegistry(js jetstream.JetStream) *Registry {
-	return &Registry{js: js}
-}
-
-// bucket lazily opens (or creates) the registry KV bucket, caching the
-// handle.
-func (reg *Registry) bucket(ctx context.Context) (jetstream.KeyValue, error) {
-	if reg.js == nil {
-		return nil, errors.New("ochrevector: registry has no JetStream client configured")
-	}
-	reg.mu.Lock()
-	defer reg.mu.Unlock()
-	if reg.kv != nil {
-		return reg.kv, nil
-	}
-	kv, err := kvutil.GetOrCreateBucket(ctx, reg.js, registryBucket, registryBucketHistory)
-	if err != nil {
-		return nil, err
-	}
-	reg.kv = kv
-	return kv, nil
+	return &Registry{store: kvstore.New[Record](js, kvstore.Config{
+		Name:    registryBucket,
+		History: registryBucketHistory,
+		Missing: "ochrevector: registry has no JetStream client configured",
+	})}
 }
 
 // registryKey scopes every record to its owning account, so a foreign
@@ -125,22 +103,13 @@ func registryKey(accountID, indexID string) string {
 }
 
 // Reserve atomically claims rec.ID for accountID: the create-only KV write is
-// the single-writer mutex (mirrors handlers/rds's identifier claim via
-// jetstream.ErrKeyExists), so two concurrent creates of the same id race
-// safely and exactly one wins. rec.AccountID is stamped from accountID,
-// overriding whatever the caller set.
+// the single-writer mutex (mirrors handlers/rds's identifier claim), so two
+// concurrent creates of the same id race safely and exactly one wins.
+// rec.AccountID is stamped from accountID, overriding whatever the caller set.
 func (reg *Registry) Reserve(ctx context.Context, accountID string, rec Record) error {
-	kv, err := reg.bucket(ctx)
-	if err != nil {
-		return err
-	}
 	rec.AccountID = accountID
-	data, err := json.Marshal(rec)
-	if err != nil {
-		return fmt.Errorf("ochrevector: encode index record %s: %w", rec.ID, err)
-	}
-	if _, err := kv.Create(ctx, registryKey(accountID, rec.ID), data); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+	if err := reg.store.Create(ctx, registryKey(accountID, rec.ID), &rec); err != nil {
+		if errors.Is(err, kvstore.ErrExists) {
 			return ErrIndexExists
 		}
 		return fmt.Errorf("ochrevector: reserve index %s: %w", rec.ID, err)
@@ -148,104 +117,43 @@ func (reg *Registry) Reserve(ctx context.Context, accountID string, rec Record) 
 	return nil
 }
 
-// Get reads accountID's record for indexID, returning (nil, nil) when absent.
+// Get reads accountID's record for indexID, returning (nil, nil) when absent,
+// which is how every caller distinguishes a missing index from a failure.
 func (reg *Registry) Get(ctx context.Context, accountID, indexID string) (*Record, error) {
-	kv, err := reg.bucket(ctx)
+	rec, _, err := reg.store.Get(ctx, registryKey(accountID, indexID))
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
-	return getRecord(ctx, kv, registryKey(accountID, indexID))
-}
-
-// getRecord reads and decodes one record, returning (nil, nil) when absent.
-func getRecord(ctx context.Context, kv jetstream.KeyValue, key string) (*Record, error) {
-	entry, err := kv.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("ochrevector: kv get %s: %w", key, err)
-	}
-	var rec Record
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return nil, fmt.Errorf("ochrevector: decode %s: %w", key, err)
-	}
-	return &rec, nil
+	return rec, nil
 }
 
 // List returns every index record owned by accountID, so one tenant's
 // listing never surfaces another's.
 func (reg *Registry) List(ctx context.Context, accountID string) ([]Record, error) {
-	kv, err := reg.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return listRecords(ctx, kv, accountID+"/")
+	return reg.store.List(ctx, accountID+"/")
 }
 
 // ListAll returns every index record across every account, for the
 // reconciler's crash-recovery sweep.
 func (reg *Registry) ListAll(ctx context.Context) ([]Record, error) {
-	kv, err := reg.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return listRecords(ctx, kv, "")
-}
-
-// listRecords walks every key with the given prefix ("" matches everything)
-// and decodes each into a Record, skipping any key that disappears between
-// the key listing and the read.
-func listRecords(ctx context.Context, kv jetstream.KeyValue, prefix string) ([]Record, error) {
-	keys, err := kv.Keys(ctx)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("ochrevector: list keys: %w", err)
-	}
-	var out []Record
-	for _, key := range keys {
-		if !strings.HasPrefix(key, prefix) {
-			continue
-		}
-		rec, err := getRecord(ctx, kv, key)
-		if err != nil {
-			return nil, err
-		}
-		if rec != nil {
-			out = append(out, *rec)
-		}
-	}
-	return out, nil
+	return reg.store.List(ctx, "")
 }
 
 // SetState updates accountID's indexID record's State in place, returning
 // ErrIndexNotFound if no such record exists.
 func (reg *Registry) SetState(ctx context.Context, accountID, indexID, state string) error {
-	kv, err := reg.bucket(ctx)
+	err := reg.store.Mutate(ctx, registryKey(accountID, indexID), func(rec *Record) (bool, error) {
+		rec.State = state
+		rec.UpdatedAt = time.Now().UTC()
+		return true, nil
+	})
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return ErrIndexNotFound
+	}
 	if err != nil {
-		return err
-	}
-	key := registryKey(accountID, indexID)
-	entry, err := kv.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return ErrIndexNotFound
-		}
-		return fmt.Errorf("ochrevector: kv get %s: %w", key, err)
-	}
-	var rec Record
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return fmt.Errorf("ochrevector: decode %s: %w", key, err)
-	}
-	rec.State = state
-	rec.UpdatedAt = time.Now().UTC()
-	data, err := json.Marshal(rec)
-	if err != nil {
-		return fmt.Errorf("ochrevector: encode index record %s: %w", rec.ID, err)
-	}
-	if _, err := kv.Update(ctx, key, data, entry.Revision()); err != nil {
 		return fmt.Errorf("ochrevector: update state for index %s: %w", indexID, err)
 	}
 	return nil
@@ -256,32 +164,18 @@ func (reg *Registry) SetState(ctx context.Context, accountID, indexID, state str
 // an unchanged source never accumulates duplicate entries (D4: the stored
 // source-spec set drives auto-repopulation after a Postgres rebuild).
 func (reg *Registry) AppendSourceSpec(ctx context.Context, accountID, indexID string, spec SourceSpec) error {
-	kv, err := reg.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	key := registryKey(accountID, indexID)
-	entry, err := kv.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return ErrIndexNotFound
+	err := reg.store.Mutate(ctx, registryKey(accountID, indexID), func(rec *Record) (bool, error) {
+		if slices.ContainsFunc(rec.SourceSpecs, func(s SourceSpec) bool { return sourceSpecEqual(s, spec) }) {
+			return false, nil
 		}
-		return fmt.Errorf("ochrevector: kv get %s: %w", key, err)
+		rec.SourceSpecs = append(rec.SourceSpecs, spec)
+		rec.UpdatedAt = time.Now().UTC()
+		return true, nil
+	})
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return ErrIndexNotFound
 	}
-	var rec Record
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return fmt.Errorf("ochrevector: decode %s: %w", key, err)
-	}
-	if slices.ContainsFunc(rec.SourceSpecs, func(s SourceSpec) bool { return sourceSpecEqual(s, spec) }) {
-		return nil
-	}
-	rec.SourceSpecs = append(rec.SourceSpecs, spec)
-	rec.UpdatedAt = time.Now().UTC()
-	data, err := json.Marshal(rec)
 	if err != nil {
-		return fmt.Errorf("ochrevector: encode index record %s: %w", rec.ID, err)
-	}
-	if _, err := kv.Update(ctx, key, data, entry.Revision()); err != nil {
 		return fmt.Errorf("ochrevector: append source spec for index %s: %w", indexID, err)
 	}
 	return nil
@@ -291,34 +185,13 @@ func (reg *Registry) AppendSourceSpec(ctx context.Context, accountID, indexID st
 // appliance's registry never advertises a table that no longer exists.
 // Idempotent: an empty bucket is a no-op success.
 func (reg *Registry) PurgeAll(ctx context.Context) error {
-	kv, err := reg.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	keys, err := kv.Keys(ctx)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil
-		}
-		return fmt.Errorf("ochrevector: list keys: %w", err)
-	}
-	for _, key := range keys {
-		if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-			return fmt.Errorf("ochrevector: purge index %s: %w", key, err)
-		}
-	}
-	return nil
+	return reg.store.DeletePrefix(ctx, "")
 }
 
 // Delete removes accountID's indexID record. Idempotent: deleting an
 // already-absent record is a no-op success.
 func (reg *Registry) Delete(ctx context.Context, accountID, indexID string) error {
-	kv, err := reg.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	key := registryKey(accountID, indexID)
-	if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+	if err := reg.store.Delete(ctx, registryKey(accountID, indexID)); err != nil {
 		return fmt.Errorf("ochrevector: delete index %s: %w", indexID, err)
 	}
 	return nil

--- a/spinifex/handlers/ochrevector/registry_test.go
+++ b/spinifex/handlers/ochrevector/registry_test.go
@@ -6,6 +6,8 @@ package handlers_ochrevector
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -186,6 +188,75 @@ func TestRegistry_AppendSourceSpecNotFound(t *testing.T) {
 	err := reg.AppendSourceSpec(ctx, regAccountA, "does-not-exist", SourceSpec{Bucket: "docs"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrIndexNotFound)
+}
+
+// TestRegistry_AppendSourceSpecConcurrentAppendsAllLand is the case that can
+// lose data: the read-check-append is not atomic, so two ingests racing on one
+// index must not drop a spec. Every distinct spec has to survive.
+func TestRegistry_AppendSourceSpecConcurrentAppendsAllLand(t *testing.T) {
+	reg := newRegistryTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	require.NoError(t, reg.Reserve(ctx, regAccountA, Record{ID: "idx-one", CreatedAt: now, UpdatedAt: now}))
+
+	const writers = 4
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := range writers {
+		wg.Go(func() {
+			spec := SourceSpec{Bucket: "docs", Prefix: fmt.Sprintf("kb%d/", i), ChunkSize: 512, Dimension: 768}
+			errs[i] = reg.AppendSourceSpec(ctx, regAccountA, "idx-one", spec)
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "appender %d", i)
+	}
+
+	got, err := reg.Get(ctx, regAccountA, "idx-one")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Len(t, got.SourceSpecs, writers, "a spec was dropped by a lost CAS race")
+
+	prefixes := make(map[string]bool, writers)
+	for _, spec := range got.SourceSpecs {
+		prefixes[spec.Prefix] = true
+	}
+	for i := range writers {
+		assert.Truef(t, prefixes[fmt.Sprintf("kb%d/", i)], "appender %d's spec is missing", i)
+	}
+}
+
+// TestRegistry_SetStateConcurrentWritersAllSucceed pins the retry: before the
+// conversion this was a single-shot update at the read revision, so a caller
+// that lost the race got a raw revision mismatch back.
+func TestRegistry_SetStateConcurrentWritersAllSucceed(t *testing.T) {
+	reg := newRegistryTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	require.NoError(t, reg.Reserve(ctx, regAccountA, Record{ID: "idx-one", State: StateCreating, CreatedAt: now, UpdatedAt: now}))
+
+	states := []string{StateReady, StateStale, StateReady, StateDeleting}
+	var wg sync.WaitGroup
+	errs := make([]error, len(states))
+	for i, state := range states {
+		wg.Go(func() {
+			errs[i] = reg.SetState(ctx, regAccountA, "idx-one", state)
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "writer %d lost its race instead of retrying", i)
+	}
+
+	got, err := reg.Get(ctx, regAccountA, "idx-one")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Contains(t, states, got.State, "the surviving state must be one a writer actually set")
 }
 
 func TestRegistry_ListAll(t *testing.T) {


### PR DESCRIPTION
Third of Phase 3. Converts the index registry and the two bedrock-agent stores onto `kvstore`. This is the first conversion that consumes the package exactly as it stands — no additions, no signature changes — which is what the acm pilot was for.

740 lines to 443.

| Store | File | Record |
| --- | --- | --- |
| `Registry` | `registry.go` | `Record` |
| `KBStore` | `kbstore.go` | `KBRecord` |
| `DataSourceStore` | `kbstore.go` | `DataSourceRecord` |

All three were the same shape: a `js` field, a `sync.Mutex`, a memoised `kv`, and a `bucket(ctx)` accessor, followed by hand-rolled marshal/unmarshal in every method. `KBStore.List` and `DataSourceStore.List` were byte-for-byte identical apart from the record type; both are now one line.

## A defect fixed on the way

`Registry.SetState` and `Registry.AppendSourceSpec` were read-modify-write against a **single-shot** `kv.Update` at the read revision, with no conflict handling at all. A caller that lost the race got a raw revision mismatch wrapped as `"update state for index X"`. `registry.go:248` is one of the five single-shot CAS sites the plan doc tracks.

`AppendSourceSpec` is the one that could lose data rather than just fail. It reads the record, checks whether the spec is already present, appends, and writes. It runs on every ingest. Two ingests racing on one index means one spec is silently dropped — the write that lost simply never lands, and the caller sees an error that reads like a transient KV problem rather than "your source spec is gone".

Both now go through `kvstore.Mutate`, which retries the whole read-modify-write under the CAS budget. The idempotence check becomes `return false, nil` — commit no write — which is also strictly cheaper than the old early return, since that had already paid for the read.

## The trap this conversion sets

All three `Get` methods return **`(nil, nil)` when the record is absent**, and every caller is written as:

```go
rec, err := ds.Get(ctx, accountID, id)
if err != nil {
    return nil, err
}
if rec == nil {
    return nil, errDataSourceNotFound(id)
}
```

`kvstore.Store.Get` returns `ErrNotFound` instead. Letting that leak would turn every absent index and knowledge base into a 500 rather than a NotFound, at five call sites at once — `api.go:245`, `api.go:296`, and `gateway/bedrockagent.go:629`, `:686`, `:753`, the last three across a package boundary. Each converted `Get` maps `kvstore.ErrNotFound` back to `(nil, nil)`.

This is the mirror image of the trap in #888: there, an `errors.Is` against a jetstream sentinel went stale once the call went through `kvstore` and had to be deleted. Here a new `errors.Is` against a `kvstore` sentinel has to be added. Both fail quietly — the fall-through still produces a plausible wrapped error.

## Testing

No test file touches `registry.kv`, either `KBStore`/`DataSourceStore` internal, or those `bucket()` methods, so all existing tests compile and pass **unchanged**. That is the behaviour-preservation check, and it covers the `(nil, nil)` contract from both sides: `handlers/ochrevector` and `gateway` (which builds these stores in `bedrockagent_test.go`).

Two new tests cover what actually changed, since neither method had a concurrent case:

`TestRegistry_AppendSourceSpecConcurrentAppendsAllLand` runs four appenders with distinct specs against one index and asserts all four survive. Checked red against the old single-shot path — it fails on the first appender.

`TestRegistry_SetStateConcurrentWritersAllSucceed` runs four concurrent state writers and asserts none of them is handed a lost-race error, and that the surviving state is one a writer actually set.

`make preflight`.

## Not in this PR

`appliance.go` is the fourth and last lazy accessor in the package, and it is not a mechanical port:

- `Ensure` needs the revision `kv.Create` returns (`appliance.go:353`) to hand to `promote`'s CAS. `Store.Create` returns no revision.
- It threads one `kv` handle through five private methods so the whole state machine shares an open bucket.
- `Appliance.mu` also guards `hostPortDeps`, `eniID`, `registry`, `jobs`, `kb` and `ds`, so the mutex stays either way.
- 15 test sites call `appliance.bucket(ctx)` directly.

Converting it means deciding whether `Store.Create` should return a revision, which changes every existing caller. That question deserves its own PR rather than riding along with three mechanical conversions.
