### PR TITLE
refactor: convert the ochrevector appliance to kvstore

### DIFF
--- a/spinifex/handlers/ochrevector/appliance.go
+++ b/spinifex/handlers/ochrevector/appliance.go
@@ -3,7 +3,6 @@ package handlers_ochrevector
 import (
 	"context"
 	"crypto/rand"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -13,7 +12,7 @@ import (
 	"time"
 
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
-	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -130,12 +129,13 @@ type ApplianceLauncher interface {
 // Appliance owns the singleton platform Postgres appliance: its encrypted
 // credential store and the re-entrant Ensure state machine over it (D2).
 type Appliance struct {
-	js        jetstream.JetStream
+	store     *kvstore.Store[ApplianceRecord]
 	masterKey []byte
 	launcher  ApplianceLauncher
 
+	// mu guards the optional collaborators below, which WithHostPort,
+	// WithStores and WithKBStores attach after construction.
 	mu sync.Mutex
-	kv jetstream.KeyValue
 
 	// hostPortDeps and eniID back this daemon's routed presence in the
 	// appliance's VPC. A nil hostPortDeps.HostPort (WithHostPort never called)
@@ -167,7 +167,15 @@ func NewAppliance(js jetstream.JetStream, masterKey []byte, launcher ApplianceLa
 	if launcher == nil {
 		return nil, errors.New("ochrevector: appliance requires an ApplianceLauncher")
 	}
-	return &Appliance{js: js, masterKey: masterKey, launcher: launcher}, nil
+	return &Appliance{
+		store: kvstore.New[ApplianceRecord](js, kvstore.Config{
+			Name:    applianceBucket,
+			History: applianceBucketHistory,
+			Missing: "ochrevector: appliance has no JetStream client configured",
+		}),
+		masterKey: masterKey,
+		launcher:  launcher,
+	}, nil
 }
 
 // WithHostPort attaches this daemon's VPC host-port collaborators, so every
@@ -276,12 +284,7 @@ func (a *Appliance) Teardown(ctx context.Context, purgeMetadata bool) error {
 		}
 	}
 
-	kv, err := a.bucket(ctx)
-	if err != nil {
-		errs = append(errs, err)
-		return errors.Join(errs...)
-	}
-	if err := kv.Delete(ctx, appliancePostgresKey); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+	if err := a.store.Delete(ctx, appliancePostgresKey); err != nil {
 		errs = append(errs, fmt.Errorf("ochrevector: delete appliance record: %w", err))
 	}
 
@@ -311,33 +314,15 @@ func (a *Appliance) ensureHostPort(ctx context.Context, rec *ApplianceRecord) (s
 	return dialIP, nil
 }
 
-// bucket lazily opens (or creates) the appliance KV bucket, caching the
-// handle, mirroring Registry.bucket.
-func (a *Appliance) bucket(ctx context.Context) (jetstream.KeyValue, error) {
-	if a.js == nil {
-		return nil, errors.New("ochrevector: appliance has no JetStream client configured")
-	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.kv != nil {
-		return a.kv, nil
-	}
-	kv, err := kvutil.GetOrCreateBucket(ctx, a.js, applianceBucket, applianceBucketHistory)
-	if err != nil {
-		return nil, err
-	}
-	a.kv = kv
-	return kv, nil
-}
-
 // Ensure is the re-entrant singleton-appliance orchestrator (D2): exactly one
 // caller across a multi-node control plane wins the atomic KV claim and
 // drives the launch; every other caller, concurrent or later, either waits
 // for that launch or resumes a crashed one, and no caller ever generates a
 // second password or identifier for the appliance.
 func (a *Appliance) Ensure(ctx context.Context) (ApplianceConnInfo, error) {
-	kv, err := a.bucket(ctx)
-	if err != nil {
+	// Resolve the bucket before minting a password, so an unreachable KV
+	// fails without generating credential material it would then discard.
+	if _, err := a.store.KV(ctx); err != nil {
 		return ApplianceConnInfo{}, err
 	}
 
@@ -345,19 +330,15 @@ func (a *Appliance) Ensure(ctx context.Context) (ApplianceConnInfo, error) {
 	if err != nil {
 		return ApplianceConnInfo{}, err
 	}
-	data, err := json.Marshal(rec)
-	if err != nil {
-		return ApplianceConnInfo{}, fmt.Errorf("ochrevector: encode appliance record: %w", err)
-	}
 
-	rev, err := kv.Create(ctx, appliancePostgresKey, data)
+	rev, err := a.store.Create(ctx, appliancePostgresKey, &rec)
 	switch {
 	case err == nil:
 		// Winner: the single-writer claim succeeded, so this caller alone
 		// drives the launch and the promotion to AVAILABLE.
-		return a.launchAndPromote(ctx, kv, rec, rev, plaintext)
-	case errors.Is(err, jetstream.ErrKeyExists):
-		return a.waitOrResume(ctx, kv)
+		return a.launchAndPromote(ctx, rec, rev, plaintext)
+	case errors.Is(err, kvstore.ErrExists):
+		return a.waitOrResume(ctx)
 	default:
 		return ApplianceConnInfo{}, fmt.Errorf("ochrevector: claim appliance: %w", err)
 	}
@@ -369,29 +350,25 @@ func (a *Appliance) Ensure(ctx context.Context) (ApplianceConnInfo, error) {
 // fresh claim would mint a second password for the same singleton appliance,
 // which Ensure must never do; the staleness-triggered resume path is the
 // only recovery.
-func (a *Appliance) launchAndPromote(ctx context.Context, kv jetstream.KeyValue, rec ApplianceRecord, rev uint64, plaintext string) (ApplianceConnInfo, error) {
+func (a *Appliance) launchAndPromote(ctx context.Context, rec ApplianceRecord, rev uint64, plaintext string) (ApplianceConnInfo, error) {
 	endpoint, port, err := a.launcher.Launch(ctx, rec.Identifier, rec.MasterUsername, plaintext)
 	if err != nil {
 		return ApplianceConnInfo{}, fmt.Errorf("ochrevector: launch appliance: %w", err)
 	}
-	return a.promote(ctx, kv, rec, rev, endpoint, port)
+	return a.promote(ctx, rec, rev, endpoint, port)
 }
 
 // promote flips rec to AVAILABLE via a revision-guarded (CAS) update. If the
 // update loses a race to a concurrent resume of the same stale record, a
 // record that has already reached AVAILABLE is this caller's success too,
 // not a conflict to surface.
-func (a *Appliance) promote(ctx context.Context, kv jetstream.KeyValue, rec ApplianceRecord, rev uint64, endpoint string, port int) (ApplianceConnInfo, error) {
+func (a *Appliance) promote(ctx context.Context, rec ApplianceRecord, rev uint64, endpoint string, port int) (ApplianceConnInfo, error) {
 	rec.State = ApplianceStateAvailable
 	rec.Endpoint = endpoint
 	rec.Port = port
 	rec.UpdatedAt = time.Now().UTC()
-	data, err := json.Marshal(rec)
-	if err != nil {
-		return ApplianceConnInfo{}, fmt.Errorf("ochrevector: encode appliance record: %w", err)
-	}
-	if _, err := kv.Update(ctx, appliancePostgresKey, data, rev); err != nil {
-		if current, _, getErr := a.getRecord(ctx, kv); getErr == nil && current != nil && current.State == ApplianceStateAvailable {
+	if err := a.store.CompareAndSet(ctx, appliancePostgresKey, &rec, rev); err != nil {
+		if current, _, getErr := a.getRecord(ctx); getErr == nil && current != nil && current.State == ApplianceStateAvailable {
 			return connInfo(*current), nil
 		}
 		return ApplianceConnInfo{}, fmt.Errorf("ochrevector: promote appliance to available: %w", err)
@@ -402,9 +379,9 @@ func (a *Appliance) promote(ctx context.Context, kv jetstream.KeyValue, rec Appl
 // waitOrResume is the losing caller's path: read the winner's record and
 // either return its endpoint once AVAILABLE, resume a stale crashed
 // provision, or wait and re-check, bounded by ctx.
-func (a *Appliance) waitOrResume(ctx context.Context, kv jetstream.KeyValue) (ApplianceConnInfo, error) {
+func (a *Appliance) waitOrResume(ctx context.Context) (ApplianceConnInfo, error) {
 	for {
-		rec, entry, err := a.getRecord(ctx, kv)
+		rec, rev, err := a.getRecord(ctx)
 		if err != nil {
 			return ApplianceConnInfo{}, err
 		}
@@ -418,7 +395,7 @@ func (a *Appliance) waitOrResume(ctx context.Context, kv jetstream.KeyValue) (Ap
 			return connInfo(*rec), nil
 		case ApplianceStateProvisioning:
 			if time.Since(rec.UpdatedAt) > applianceStaleAfter {
-				return a.resume(ctx, kv, *rec, entry.Revision())
+				return a.resume(ctx, *rec, rev)
 			}
 		default:
 			return ApplianceConnInfo{}, fmt.Errorf("ochrevector: appliance record in unexpected state %q", rec.State)
@@ -434,7 +411,7 @@ func (a *Appliance) waitOrResume(ctx context.Context, kv jetstream.KeyValue) (Ap
 // resume re-drives the launch for a stale PROVISIONING record left by a
 // crashed winner, reusing rec's existing identifier and stored password
 // rather than generating either anew (D2), then promotes it.
-func (a *Appliance) resume(ctx context.Context, kv jetstream.KeyValue, rec ApplianceRecord, rev uint64) (ApplianceConnInfo, error) {
+func (a *Appliance) resume(ctx context.Context, rec ApplianceRecord, rev uint64) (ApplianceConnInfo, error) {
 	password, err := a.decryptPassword(&rec)
 	if err != nil {
 		return ApplianceConnInfo{}, err
@@ -443,7 +420,7 @@ func (a *Appliance) resume(ctx context.Context, kv jetstream.KeyValue, rec Appli
 	if err != nil {
 		return ApplianceConnInfo{}, fmt.Errorf("ochrevector: resume stale appliance provisioning: %w", err)
 	}
-	return a.promote(ctx, kv, rec, rev, endpoint, port)
+	return a.promote(ctx, rec, rev, endpoint, port)
 }
 
 // Connect builds a ready *pgxBackend for the current AVAILABLE appliance
@@ -472,11 +449,7 @@ func (a *Appliance) Connect(ctx context.Context) (*pgxBackend, error) {
 // pgx pool. Backup/Restore shell out to pg_dump/psql instead of dialing
 // through pgx, but still need this exact dial host/port and password.
 func (a *Appliance) dsn(ctx context.Context) (string, error) {
-	kv, err := a.bucket(ctx)
-	if err != nil {
-		return "", err
-	}
-	rec, _, err := a.getRecord(ctx, kv)
+	rec, _, err := a.getRecord(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -506,21 +479,17 @@ func (a *Appliance) dsn(ctx context.Context) (string, error) {
 	return buildDSN(dialHost, rec.Port, rec.MasterUsername, password), nil
 }
 
-// getRecord reads and decodes the appliance record, returning (nil, nil, nil)
-// when absent.
-func (a *Appliance) getRecord(ctx context.Context, kv jetstream.KeyValue) (*ApplianceRecord, jetstream.KeyValueEntry, error) {
-	entry, err := kv.Get(ctx, appliancePostgresKey)
+// getRecord reads and decodes the appliance record, returning (nil, 0, nil)
+// when absent. The revision is the CAS precondition promote and resume need.
+func (a *Appliance) getRecord(ctx context.Context) (*ApplianceRecord, uint64, error) {
+	rec, rev, err := a.store.Get(ctx, appliancePostgresKey)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return nil, 0, nil
+	}
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return nil, nil, nil
-		}
-		return nil, nil, fmt.Errorf("ochrevector: get appliance record: %w", err)
+		return nil, 0, err
 	}
-	var rec ApplianceRecord
-	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-		return nil, nil, fmt.Errorf("ochrevector: decode appliance record: %w", err)
-	}
-	return &rec, entry, nil
+	return rec, rev, nil
 }
 
 // decryptPassword resolves rec's encrypted master password to plaintext. The

--- a/spinifex/handlers/ochrevector/appliance_test.go
+++ b/spinifex/handlers/ochrevector/appliance_test.go
@@ -16,6 +16,7 @@ import (
 
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -211,8 +212,7 @@ func TestEnsure_StaleProvisioningIsResumed(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	_, err = kv.Create(ctx, appliancePostgresKey, data)
 	require.NoError(t, err)
 
@@ -252,8 +252,7 @@ func TestEnsure_FreshProvisioningIsWaitedNotResumed(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	_, err = kv.Create(ctx, appliancePostgresKey, data)
 	require.NoError(t, err)
 
@@ -281,8 +280,7 @@ func TestEnsure_PlaintextPasswordNeverPersisted(t *testing.T) {
 	password := launcher.lastPassword()
 	require.NotEmpty(t, password)
 
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	entry, err := kv.Get(ctx, appliancePostgresKey)
 	require.NoError(t, err)
 	assert.NotContains(t, string(entry.Value()), password)
@@ -305,9 +303,7 @@ func TestEnsure_LaunchFailureLeavesRecordProvisioning(t *testing.T) {
 	require.Equal(t, 1, launcher.callCount())
 	firstPassword := launcher.lastPassword()
 
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
-	rec, _, err := appliance.getRecord(ctx, kv)
+	rec, _, err := appliance.getRecord(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 	assert.Equal(t, ApplianceStateProvisioning, rec.State)
@@ -348,8 +344,7 @@ func TestResume_LaunchFailureLeavesRecordProvisioning(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	_, err = kv.Create(ctx, appliancePostgresKey, data)
 	require.NoError(t, err)
 
@@ -358,7 +353,7 @@ func TestResume_LaunchFailureLeavesRecordProvisioning(t *testing.T) {
 	assert.Equal(t, 1, launcher.callCount())
 	assert.Equal(t, seedPassword, launcher.lastPassword())
 
-	rec, _, err := appliance.getRecord(ctx, kv)
+	rec, _, err := appliance.getRecord(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 	assert.Equal(t, ApplianceStateProvisioning, rec.State)
@@ -400,13 +395,21 @@ func TestConnect_NotAvailable(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	_, err = kv.Create(ctx, appliancePostgresKey, data)
 	require.NoError(t, err)
 
 	_, err = appliance.Connect(ctx)
 	assert.Error(t, err)
+}
+
+// applianceRawKV returns the appliance's underlying bucket, for the tests that
+// seed or inspect the stored bytes directly rather than through the record API.
+func applianceRawKV(t *testing.T, appliance *Appliance) jetstream.KeyValue {
+	t.Helper()
+	kv, err := appliance.store.KV(t.Context())
+	require.NoError(t, err)
+	return kv
 }
 
 // seedAvailableAppliance seeds an AVAILABLE record so Connect gets past its
@@ -433,8 +436,7 @@ func seedAvailableAppliance(t *testing.T, appliance *Appliance, masterKey []byte
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	_, err = kv.Create(ctx, appliancePostgresKey, data)
 	require.NoError(t, err)
 }
@@ -524,9 +526,7 @@ func TestTeardown_DeletesRecordLauncherAndHostPort(t *testing.T) {
 	assert.Equal(t, []string{ApplianceIdentifier}, launcher.deleteCalls)
 	assert.Equal(t, []string{"eni-installed"}, h.hostPort.removals())
 
-	kv, err := appliance.bucket(context.Background())
-	require.NoError(t, err)
-	rec, _, err := appliance.getRecord(context.Background(), kv)
+	rec, _, err := appliance.getRecord(context.Background())
 	require.NoError(t, err)
 	assert.Nil(t, rec, "the KV record must be gone after teardown")
 }
@@ -569,9 +569,7 @@ func TestTeardown_StillDeletesRecordWhenHostPortRemovalFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ovs-vsctl exploded")
 
-	kv, err := appliance.bucket(context.Background())
-	require.NoError(t, err)
-	rec, _, err := appliance.getRecord(context.Background(), kv)
+	rec, _, err := appliance.getRecord(context.Background())
 	require.NoError(t, err)
 	assert.Nil(t, rec, "the KV record must still be deleted despite the host-port failure")
 }
@@ -591,9 +589,7 @@ func TestTeardown_JoinsLauncherAndRecordErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rds unreachable")
 
-	kv, err := appliance.bucket(context.Background())
-	require.NoError(t, err)
-	rec, _, err := appliance.getRecord(context.Background(), kv)
+	rec, _, err := appliance.getRecord(context.Background())
 	require.NoError(t, err)
 	assert.Nil(t, rec, "the KV record must still be deleted despite the launcher failure")
 }
@@ -768,12 +764,16 @@ func TestTeardown_WithoutStoresStillWorks(t *testing.T) {
 	require.NoError(t, appliance.Teardown(context.Background(), false))
 }
 
-// TestBucket_RequiresJetStream proves bucket fails fast on a zero-value
-// Appliance rather than panicking on a nil JetStream client.
+// TestBucket_RequiresJetStream proves an Appliance built with no JetStream
+// client fails fast, and says which client is missing, rather than panicking
+// on first use.
 func TestBucket_RequiresJetStream(t *testing.T) {
-	appliance := &Appliance{}
-	_, err := appliance.bucket(context.Background())
-	assert.Error(t, err)
+	appliance, err := NewAppliance(nil, testMasterKey(t), &fakeLauncher{})
+	require.NoError(t, err)
+
+	_, err = appliance.store.KV(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "appliance has no JetStream client configured")
 }
 
 // TestBuildDSN proves the DSN round-trips endpoint/port/username/password,
@@ -824,12 +824,11 @@ func TestGetRecord_MalformedJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	_, err = kv.Put(ctx, appliancePostgresKey, []byte("not json"))
 	require.NoError(t, err)
 
-	_, _, err = appliance.getRecord(ctx, kv)
+	_, _, err = appliance.getRecord(ctx)
 	assert.Error(t, err)
 }
 
@@ -854,12 +853,11 @@ func TestWaitOrResume_UnexpectedStateErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	_, err = kv.Create(ctx, appliancePostgresKey, data)
 	require.NoError(t, err)
 
-	_, err = appliance.waitOrResume(ctx, kv)
+	_, err = appliance.waitOrResume(ctx)
 	assert.Error(t, err)
 }
 
@@ -873,10 +871,8 @@ func TestWaitOrResume_VanishedRecordRetriesClaim(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
 
-	info, err := appliance.waitOrResume(ctx, kv)
+	info, err := appliance.waitOrResume(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.10", info.Endpoint)
 	assert.Equal(t, 1, launcher.callCount())
@@ -896,8 +892,7 @@ func TestPromote_ConflictFallsBackToCurrentAvailable(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	kv, err := appliance.bucket(ctx)
-	require.NoError(t, err)
+	kv := applianceRawKV(t, appliance)
 	rev, err := kv.Create(ctx, appliancePostgresKey, data)
 	require.NoError(t, err)
 
@@ -910,7 +905,7 @@ func TestPromote_ConflictFallsBackToCurrentAvailable(t *testing.T) {
 	_, err = kv.Update(ctx, appliancePostgresKey, alreadyData, rev)
 	require.NoError(t, err)
 
-	info, err := appliance.promote(ctx, kv, rec, rev, "10.0.0.21", 5432)
+	info, err := appliance.promote(ctx, rec, rev, "10.0.0.21", 5432)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.20", info.Endpoint)
 }

--- a/spinifex/handlers/ochrevector/jobs.go
+++ b/spinifex/handlers/ochrevector/jobs.go
@@ -89,7 +89,7 @@ func jobKey(accountID, jobID string) string {
 // is stamped from accountID, overriding whatever the caller set.
 func (s *JobStore) Reserve(ctx context.Context, accountID string, rec JobRecord) error {
 	rec.AccountID = accountID
-	if err := s.store.Create(ctx, jobKey(accountID, rec.ID), &rec); err != nil {
+	if _, err := s.store.Create(ctx, jobKey(accountID, rec.ID), &rec); err != nil {
 		if errors.Is(err, kvstore.ErrExists) {
 			return ErrJobExists
 		}

--- a/spinifex/handlers/ochrevector/kbstore.go
+++ b/spinifex/handlers/ochrevector/kbstore.go
@@ -118,7 +118,7 @@ func kbKey(accountID, id string) string {
 // stamped from accountID, overriding whatever the caller set.
 func (s *KBStore) Create(ctx context.Context, accountID string, rec KBRecord) error {
 	rec.AccountID = accountID
-	if err := s.store.Create(ctx, kbKey(accountID, rec.ID), &rec); err != nil {
+	if _, err := s.store.Create(ctx, kbKey(accountID, rec.ID), &rec); err != nil {
 		if errors.Is(err, kvstore.ErrExists) {
 			return ErrKBExists
 		}
@@ -185,7 +185,7 @@ func dataSourceKey(accountID, id string) string {
 // Create atomically claims rec.ID for accountID, mirroring KBStore.Create.
 func (s *DataSourceStore) Create(ctx context.Context, accountID string, rec DataSourceRecord) error {
 	rec.AccountID = accountID
-	if err := s.store.Create(ctx, dataSourceKey(accountID, rec.ID), &rec); err != nil {
+	if _, err := s.store.Create(ctx, dataSourceKey(accountID, rec.ID), &rec); err != nil {
 		if errors.Is(err, kvstore.ErrExists) {
 			return ErrDataSourceExists
 		}

--- a/spinifex/handlers/ochrevector/registry.go
+++ b/spinifex/handlers/ochrevector/registry.go
@@ -108,7 +108,7 @@ func registryKey(accountID, indexID string) string {
 // rec.AccountID is stamped from accountID, overriding whatever the caller set.
 func (reg *Registry) Reserve(ctx context.Context, accountID string, rec Record) error {
 	rec.AccountID = accountID
-	if err := reg.store.Create(ctx, registryKey(accountID, rec.ID), &rec); err != nil {
+	if _, err := reg.store.Create(ctx, registryKey(accountID, rec.ID), &rec); err != nil {
 		if errors.Is(err, kvstore.ErrExists) {
 			return ErrIndexExists
 		}

--- a/spinifex/kvstore/store.go
+++ b/spinifex/kvstore/store.go
@@ -40,23 +40,25 @@ func (s *Store[T]) Get(ctx context.Context, key string) (*T, uint64, error) {
 }
 
 // Create writes a record only if the key is absent, returning ErrExists when
-// it is not. The create-only write is the single-writer claim.
-func (s *Store[T]) Create(ctx context.Context, key string, v *T) error {
+// it is not. The create-only write is the single-writer claim, and the
+// returned revision is the CAS precondition for the claim's own first update.
+func (s *Store[T]) Create(ctx context.Context, key string, v *T) (uint64, error) {
 	kv, err := s.KV(ctx)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	data, err := json.Marshal(v)
 	if err != nil {
-		return fmt.Errorf("kvstore: encode %s: %w", key, err)
+		return 0, fmt.Errorf("kvstore: encode %s: %w", key, err)
 	}
-	if _, err := kv.Create(ctx, key, data); err != nil {
+	rev, err := kv.Create(ctx, key, data)
+	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyExists) {
-			return fmt.Errorf("%w: %s", ErrExists, key)
+			return 0, fmt.Errorf("%w: %s", ErrExists, key)
 		}
-		return fmt.Errorf("kvstore: create %s: %w", key, err)
+		return 0, fmt.Errorf("kvstore: create %s: %w", key, err)
 	}
-	return nil
+	return rev, nil
 }
 
 // Mutate applies fn under a revision-guarded retry loop. fn reports whether it

--- a/spinifex/kvstore/store_test.go
+++ b/spinifex/kvstore/store_test.go
@@ -31,6 +31,15 @@ func newStore(t *testing.T) *kvstore.Store[record] {
 	})
 }
 
+// mustCreate claims key for rec and returns the claim's revision, for the tests
+// that need a record in place rather than a create to assert on.
+func mustCreate(t *testing.T, store *kvstore.Store[record], key string, rec record) uint64 {
+	t.Helper()
+	rev, err := store.Create(t.Context(), key, &rec)
+	require.NoError(t, err)
+	return rev
+}
+
 // seedRaw writes a record straight to the bucket, bypassing Store, so a test
 // can move the revision underneath an in-flight Mutate.
 func seedRaw(t *testing.T, store *kvstore.Store[record], key string, rec record) {
@@ -54,14 +63,14 @@ func TestStore_GetAbsentKeyIsNotFound(t *testing.T) {
 func TestStore_CreateRoundTripsAndRejectsDuplicate(t *testing.T) {
 	store := newStore(t)
 
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one", Count: 3}))
+	mustCreate(t, store, "acct-a/one", record{Name: "one", Count: 3})
 
 	got, rev, err := store.Get(t.Context(), "acct-a/one")
 	require.NoError(t, err)
 	assert.Equal(t, record{Name: "one", Count: 3}, *got)
 	assert.NotZero(t, rev, "a committed record has a revision")
 
-	err = store.Create(t.Context(), "acct-a/one", &record{Name: "impostor"})
+	_, err = store.Create(t.Context(), "acct-a/one", &record{Name: "impostor"})
 	require.ErrorIs(t, err, kvstore.ErrExists)
 
 	// The loser of the create must not have overwritten the winner.
@@ -72,7 +81,7 @@ func TestStore_CreateRoundTripsAndRejectsDuplicate(t *testing.T) {
 
 func TestStore_DeleteIsIdempotent(t *testing.T) {
 	store := newStore(t)
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one"}))
+	mustCreate(t, store, "acct-a/one", record{Name: "one"})
 
 	require.NoError(t, store.Delete(t.Context(), "acct-a/one"))
 	require.NoError(t, store.Delete(t.Context(), "acct-a/one"), "deleting an absent key is success")
@@ -92,9 +101,9 @@ func TestStore_ListOnEmptyBucketIsNotAnError(t *testing.T) {
 
 func TestStore_ListFiltersByPrefix(t *testing.T) {
 	store := newStore(t)
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one"}))
-	require.NoError(t, store.Create(t.Context(), "acct-a/two", &record{Name: "two"}))
-	require.NoError(t, store.Create(t.Context(), "acct-b/three", &record{Name: "three"}))
+	mustCreate(t, store, "acct-a/one", record{Name: "one"})
+	mustCreate(t, store, "acct-a/two", record{Name: "two"})
+	mustCreate(t, store, "acct-b/three", record{Name: "three"})
 
 	mine, err := store.List(t.Context(), "acct-a/")
 	require.NoError(t, err)
@@ -110,7 +119,7 @@ func TestStore_ListFiltersByPrefix(t *testing.T) {
 // value out of band, so the commit that follows it must lose and re-read.
 func TestStore_MutateRetriesARevisionConflict(t *testing.T) {
 	store := newStore(t)
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one", Count: 1}))
+	mustCreate(t, store, "acct-a/one", record{Name: "one", Count: 1})
 
 	attempts := 0
 	err := store.Mutate(t.Context(), "acct-a/one", func(rec *record) (bool, error) {
@@ -131,7 +140,7 @@ func TestStore_MutateRetriesARevisionConflict(t *testing.T) {
 
 func TestStore_MutateReportingNoChangeCommitsNoWrite(t *testing.T) {
 	store := newStore(t)
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one", Count: 1}))
+	mustCreate(t, store, "acct-a/one", record{Name: "one", Count: 1})
 	_, before, err := store.Get(t.Context(), "acct-a/one")
 	require.NoError(t, err)
 
@@ -159,8 +168,8 @@ func TestStore_MutateOnAbsentKeyIsNotFound(t *testing.T) {
 
 func TestStore_DeletePrefixLeavesOtherPrefixes(t *testing.T) {
 	store := newStore(t)
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one"}))
-	require.NoError(t, store.Create(t.Context(), "acct-b/two", &record{Name: "two"}))
+	mustCreate(t, store, "acct-a/one", record{Name: "one"})
+	mustCreate(t, store, "acct-b/two", record{Name: "two"})
 
 	require.NoError(t, store.DeletePrefix(t.Context(), "acct-a/"))
 
@@ -181,7 +190,7 @@ func TestStore_NilJetStreamReportsTheConfiguredMessage(t *testing.T) {
 	_, _, err := store.Get(t.Context(), "acct-a/one")
 	require.ErrorContains(t, err, "no JetStream client configured")
 
-	err = store.Create(t.Context(), "acct-a/one", &record{Name: "one"})
+	_, err = store.Create(t.Context(), "acct-a/one", &record{Name: "one"})
 	require.ErrorContains(t, err, "no JetStream client configured")
 
 	_, err = store.List(t.Context(), "")
@@ -237,8 +246,9 @@ func TestOver_ServesAPreOpenedBucket(t *testing.T) {
 
 func TestStore_SetOverwritesWhereCreateWouldConflict(t *testing.T) {
 	store := newStore(t)
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "first"}))
-	require.ErrorIs(t, store.Create(t.Context(), "acct-a/one", &record{Name: "second"}), kvstore.ErrExists)
+	mustCreate(t, store, "acct-a/one", record{Name: "first"})
+	_, err := store.Create(t.Context(), "acct-a/one", &record{Name: "second"})
+	require.ErrorIs(t, err, kvstore.ErrExists)
 
 	require.NoError(t, store.Set(t.Context(), "acct-a/one", &record{Name: "second", Count: 9}))
 	got, _, err := store.Get(t.Context(), "acct-a/one")
@@ -284,14 +294,12 @@ func TestStore_ExistsIsFalseForAnAbsentKey(t *testing.T) {
 
 func TestStore_CompareAndSetRejectsAStaleRevision(t *testing.T) {
 	store := newStore(t)
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one", Count: 1}))
-	_, stale, err := store.Get(t.Context(), "acct-a/one")
-	require.NoError(t, err)
+	stale := mustCreate(t, store, "acct-a/one", record{Name: "one", Count: 1})
 
 	// Another writer commits first, moving the revision on.
 	seedRaw(t, store, "acct-a/one", record{Name: "one", Count: 2})
 
-	err = store.CompareAndSet(t.Context(), "acct-a/one", &record{Name: "one", Count: 99}, stale)
+	err := store.CompareAndSet(t.Context(), "acct-a/one", &record{Name: "one", Count: 99}, stale)
 	require.ErrorIs(t, err, kvstore.ErrConflict)
 
 	got, fresh, err := store.Get(t.Context(), "acct-a/one")
@@ -302,6 +310,32 @@ func TestStore_CompareAndSetRejectsAStaleRevision(t *testing.T) {
 	got, _, err = store.Get(t.Context(), "acct-a/one")
 	require.NoError(t, err)
 	assert.Equal(t, 3, got.Count, "the same call commits at the current revision")
+}
+
+// TestStore_CreateReturnsTheClaimRevision pins the claim-then-CAS sequence a
+// single-writer state machine runs: the winner of the create holds a revision
+// good enough to commit its own first update, with no read in between.
+func TestStore_CreateReturnsTheClaimRevision(t *testing.T) {
+	store := newStore(t)
+
+	claimed, err := store.Create(t.Context(), "singleton", &record{Name: "provisioning"})
+	require.NoError(t, err)
+	require.NotZero(t, claimed, "a committed claim has a revision")
+
+	_, read, err := store.Get(t.Context(), "singleton")
+	require.NoError(t, err)
+	assert.Equal(t, read, claimed, "the claim revision is the record's current revision")
+
+	require.NoError(t, store.CompareAndSet(t.Context(), "singleton", &record{Name: "available"}, claimed),
+		"the winner promotes its own claim without re-reading")
+
+	// The spent revision must not commit a second time.
+	err = store.CompareAndSet(t.Context(), "singleton", &record{Name: "impostor"}, claimed)
+	require.ErrorIs(t, err, kvstore.ErrConflict)
+
+	got, _, err := store.Get(t.Context(), "singleton")
+	require.NoError(t, err)
+	assert.Equal(t, "available", got.Name)
 }
 
 // TestStore_ConfigAttemptsBoundsMutate pins both halves of the per-store budget:
@@ -322,7 +356,7 @@ func TestStore_ConfigAttemptsBoundsMutate(t *testing.T) {
 			return errBudgetSpent
 		},
 	})
-	require.NoError(t, store.Create(t.Context(), "acct-a/one", &record{Name: "one"}))
+	mustCreate(t, store, "acct-a/one", record{Name: "one"})
 
 	calls := 0
 	err := store.Mutate(t.Context(), "acct-a/one", func(rec *record) (bool, error) {


### PR DESCRIPTION
Converts `appliance.go`, the last hand-rolled bucket accessor in `ochrevector`, and makes `Store.Create` return the revision it was discarding.

Split out of #892 because it is not a mechanical port — it needed an API decision first.

## Why `Create` returns a revision

`jetstream.KeyValue.Create` returns the revision of the write it just committed. `Store.Create` threw it away, so a caller whose create *is* a claim had to re-read the key to get back a number it had already been handed.

`Appliance.Ensure` is exactly that caller. Every daemon in the cluster races to `Create` one fixed key; the winner drives the launch and then promotes the record to AVAILABLE under CAS, using the revision from its own claim as the precondition. Discarding it would have meant either a re-read — which reintroduces the race the claim exists to close — or leaving the whole state machine on raw KV.

Four call sites, all `if _, err :=`. That is not a migration, and a wrapper that drops information the layer below already returns forces every future caller with a CAS precondition back onto the raw handle.

## `appliance.go`

The bucket moves into a `kvstore.Store[ApplianceRecord]` and the `js`/`kv` fields and the `bucket` accessor go. `Appliance.mu` stays — it also guards `hostPortDeps`, `eniID`, `registry`, `jobs`, `kb` and `ds`, which `WithHostPort`, `WithStores` and `WithKBStores` attach after construction. Its comment now says so, since it is no longer obvious what it protects.

The bigger win is that `kv` stops being threaded through the state machine. `launchAndPromote`, `promote`, `waitOrResume`, `resume` and `getRecord` each took a `jetstream.KeyValue` purely so the whole of `Ensure` shared one open bucket; the store memoises that, so all five lose the parameter. `getRecord` also drops its `jetstream.KeyValueEntry` return in favour of a plain `uint64` — the only thing any caller ever took from the entry was `Revision()`.

`Ensure` resolves the bucket before minting a password, preserving the old ordering: an unreachable KV fails without generating credential material it would immediately discard. That is the one place where the obvious rewrite would have changed behaviour, because `Store.Create` opens the bucket lazily inside the call.

The `(nil, nil)` mapping from #892 applies here too — `getRecord` returns `(nil, 0, nil)` for an absent record, and `waitOrResume` and `dsn` both branch on it.

## Testing

`Store.Create`'s new return is pinned by `TestStore_CreateReturnsTheClaimRevision`: the claim revision equals the record's current revision, it commits the winner's own first update without a read in between, and it is refused the second time. Verified red by zeroing the revision in `Create`.

`TestStore_CompareAndSetRejectsAStaleRevision` now takes its stale revision straight from `Create` instead of a follow-up `Get`, which is the capability being added, so the test demonstrates it rather than just tolerating it.

The 15 `appliance.bucket(ctx)` sites in `appliance_test.go` split two ways. Ten seed or inspect stored bytes directly and now go through an `applianceRawKV(t, appliance)` helper. Five only existed to hand `kv` to `getRecord` or `waitOrResume` and are simply gone — those tests got shorter.

One test was rewritten rather than repointed. `TestBucket_RequiresJetStream` built `&Appliance{}` directly, bypassing `NewAppliance`; against the converted type that is a nil `store` and a panic, not an error. It now builds through the real constructor with a nil JetStream client and asserts on the message, which is what it was trying to prove and a stronger test than the original — the old one asserted only that *some* error came back from a struct no production path can produce.

A `mustCreate` helper absorbs the seeding creates in `store_test.go` that only ever asserted `NoError`; the three sites that assert on the create itself stayed explicit.

`make preflight`.

## Phase 3 status

This closes `ochrevector`. Remaining: PR 4 (`gateway/bedrock` typed stores), PR 5 (raw buckets, `Bucket` only) and PR 6 (`handlers/bedrock/service.go`). `guardrail.go:185` and `provisioned.go:425` are the last two single-shot CAS sites and can ride with PR 4.
