### PR TITLE
refactor: route bedrock serving endpoints through kvstore

### DIFF
--- a/spinifex/handlers/bedrock/eviction_test.go
+++ b/spinifex/handlers/bedrock/eviction_test.go
@@ -168,9 +168,7 @@ func TestEvictForCapacity_NeverEvictsTheRequester(t *testing.T) {
 	s, _ := newTestService(t, h, 200, exhaustedGPU())
 	seedReadyEndpoint(t, s, testModelID, time.Now().UTC().Add(-time.Hour))
 
-	kv, err := s.bucket(t.Context())
-	require.NoError(t, err)
-	assert.False(t, s.evictForCapacity(t.Context(), kv, testModelID, 5120))
+	assert.False(t, s.evictForCapacity(t.Context(), testModelID, 5120))
 	assert.Empty(t, h.launcher.terminations())
 }
 
@@ -214,8 +212,6 @@ func TestSelectEvictable_SkipsRecordCreatedPinnedViaEnsure(t *testing.T) {
 // today, so a launched one cannot be joined by a second through Ensure.
 func seedReadyEndpoint(t *testing.T, s *Service, modelID string, readyAt time.Time) EndpointRecord {
 	t.Helper()
-	kv, err := s.bucket(t.Context())
-	require.NoError(t, err)
 	rec := EndpointRecord{
 		AccountID:  utils.GlobalAccountID,
 		ModelID:    modelID,
@@ -226,19 +222,17 @@ func seedReadyEndpoint(t *testing.T, s *Service, modelID string, readyAt time.Ti
 		ReadyAt:    readyAt,
 		Generation: 2,
 	}
-	_, err = createJSONRevision(t.Context(), kv, EndpointKey(utils.GlobalAccountID, modelID), rec)
+	_, err := s.store.Create(t.Context(), EndpointKey(utils.GlobalAccountID, modelID), &rec)
 	require.NoError(t, err)
 	return rec
 }
 
 func pinEndpoint(t *testing.T, s *Service, modelID string) {
 	t.Helper()
-	kv, err := s.bucket(t.Context())
-	require.NoError(t, err)
 	key := EndpointKey(utils.GlobalAccountID, modelID)
-	rec, rev, found, err := getFullJSON(t.Context(), kv, key)
+	rec, rev, found, err := s.store.getRevision(t.Context(), key)
 	require.NoError(t, err)
 	require.True(t, found)
 	rec.Pinned = true
-	require.NoError(t, updateJSON(t.Context(), kv, key, rev, rec))
+	require.NoError(t, s.store.CompareAndSet(t.Context(), key, &rec, rev))
 }

--- a/spinifex/handlers/bedrock/reaper.go
+++ b/spinifex/handlers/bedrock/reaper.go
@@ -9,9 +9,9 @@ import (
 
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
 	"github.com/mulgadc/spinifex/spinifex/kvlease"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/otelsetup"
 	"github.com/mulgadc/spinifex/spinifex/utils"
-	"github.com/nats-io/nats.go/jetstream"
 )
 
 // Sweep and lease timing. The holder refreshes well inside the bucket's TTL,
@@ -49,7 +49,7 @@ func NewReaper(svc *Service, holder string, deps ReaperDeps) *Reaper {
 	r := &Reaper{svc: svc, holder: holder, deps: deps}
 	r.lease, r.leaseErr = kvlease.New(kvlease.Config{
 		Name:   "bedrock/reaper",
-		Bucket: r.leaderBucket,
+		Bucket: svc.leader.KV,
 		Key:    leaderKey,
 		Holder: holder,
 		TTL:    KVBucketLeaderTTL,
@@ -124,22 +124,10 @@ func (r *Reaper) IsLeader() bool {
 	return r.lease.Held()
 }
 
-func (r *Reaper) leaderBucket(ctx context.Context) (jetstream.KeyValue, error) {
-	js, err := r.svc.js()
-	if err != nil {
-		return nil, err
-	}
-	return GetOrCreateLeaderBucket(ctx, js)
-}
-
 // sweepOnce scrapes every READY endpoint once and acts on what it saw. One
 // endpoint's failure does not stop the pass: the others still need deciding.
 func (r *Reaper) sweepOnce(ctx context.Context) error {
-	kv, err := r.svc.bucket(ctx)
-	if err != nil {
-		return err
-	}
-	recs, err := ListEndpoints(ctx, kv, utils.GlobalAccountID)
+	recs, err := r.svc.store.list(ctx, utils.GlobalAccountID)
 	if err != nil {
 		return err
 	}
@@ -150,7 +138,7 @@ func (r *Reaper) sweepOnce(ctx context.Context) error {
 		if rec.State != StateReady {
 			continue
 		}
-		if err := r.sweepEndpoint(ctx, kv, rec); err != nil {
+		if err := r.sweepEndpoint(ctx, rec); err != nil {
 			failures = append(failures, fmt.Errorf("%s: %w", rec.ModelID, err))
 		}
 	}
@@ -175,19 +163,19 @@ func reaperScrapesMetrics(rec EndpointRecord) bool {
 }
 
 // sweepEndpoint decides one endpoint's fate from a single probe.
-func (r *Reaper) sweepEndpoint(ctx context.Context, kv jetstream.KeyValue, rec EndpointRecord) error {
+func (r *Reaper) sweepEndpoint(ctx context.Context, rec EndpointRecord) error {
 	scrapeCtx, cancel := context.WithTimeout(ctx, r.scrapeTimeout())
 	defer cancel()
 
 	// A bundle with no vLLM member exposes no load metrics to reclaim on, so
 	// it is kept warm and only liveness-probed rather than idle-scraped.
 	if !reaperScrapesMetrics(rec) {
-		return r.sweepLiveness(scrapeCtx, kv, rec)
+		return r.sweepLiveness(scrapeCtx, rec)
 	}
 
 	sample, err := scrapeMetrics(scrapeCtx, r.svc.httpClient(), rec.BaseURL)
 	if err != nil {
-		return r.recordScrapeFailure(ctx, kv, rec, err)
+		return r.recordScrapeFailure(ctx, rec, err)
 	}
 
 	now := time.Now().UTC()
@@ -208,7 +196,7 @@ func (r *Reaper) sweepEndpoint(ctx context.Context, kv jetstream.KeyValue, rec E
 		}
 		return nil
 	}
-	return r.persistObservation(ctx, kv, rec, updated)
+	return r.persistObservation(ctx, rec, updated)
 }
 
 // sweepLiveness keeps a service-only bundle (embed/rerank, no generative
@@ -216,14 +204,14 @@ func (r *Reaper) sweepEndpoint(ctx context.Context, kv jetstream.KeyValue, rec E
 // persistently unreachable, unpinned endpoint. A healthy probe refreshes the
 // warm clock; there is deliberately no scale-to-zero for a bundle whose whole
 // purpose is to stay warm on the retrieval hot path.
-func (r *Reaper) sweepLiveness(ctx context.Context, kv jetstream.KeyValue, rec EndpointRecord) error {
+func (r *Reaper) sweepLiveness(ctx context.Context, rec EndpointRecord) error {
 	if !probeOnce(ctx, r.svc.httpClient(), rec.BaseURL+"/health") {
-		return r.recordScrapeFailure(ctx, kv, rec, fmt.Errorf("liveness probe of %s/health failed", rec.BaseURL))
+		return r.recordScrapeFailure(ctx, rec, fmt.Errorf("liveness probe of %s/health failed", rec.BaseURL))
 	}
 	updated := rec
 	updated.ScrapeFailures = 0
 	updated.LastActiveAt = time.Now().UTC()
-	return r.persistObservation(ctx, kv, rec, updated)
+	return r.persistObservation(ctx, rec, updated)
 }
 
 // shouldReap applies the two rules an idle endpoint must clear before its GPU
@@ -242,7 +230,7 @@ func (r *Reaper) shouldReap(rec EndpointRecord, now time.Time) bool {
 // recordScrapeFailure counts an unknown sample and escalates a persistently
 // unreachable endpoint to terminate-and-relaunch. Never treats the failure as
 // idleness: a wedged VM must not be mistaken for a quiet one.
-func (r *Reaper) recordScrapeFailure(ctx context.Context, kv jetstream.KeyValue, rec EndpointRecord, cause error) error {
+func (r *Reaper) recordScrapeFailure(ctx context.Context, rec EndpointRecord, cause error) error {
 	updated := rec
 	updated.ScrapeFailures = rec.ScrapeFailures + 1
 
@@ -253,14 +241,14 @@ func (r *Reaper) recordScrapeFailure(ctx context.Context, kv jetstream.KeyValue,
 		slog.WarnContext(ctx, "bedrock reaper: scrape failed for a pinned endpoint; not reaping",
 			"model", rec.ModelID, "instanceId", rec.InstanceID,
 			"consecutiveFailures", updated.ScrapeFailures, "err", cause)
-		return r.persistObservation(ctx, kv, rec, updated)
+		return r.persistObservation(ctx, rec, updated)
 	}
 
 	if updated.ScrapeFailures < maxScrapeFailures {
 		slog.WarnContext(ctx, "bedrock reaper: metrics scrape failed",
 			"model", rec.ModelID, "instanceId", rec.InstanceID,
 			"consecutiveFailures", updated.ScrapeFailures, "err", cause)
-		return r.persistObservation(ctx, kv, rec, updated)
+		return r.persistObservation(ctx, rec, updated)
 	}
 
 	slog.ErrorContext(ctx, "bedrock reaper: endpoint unreachable; terminating and relaunching",
@@ -282,13 +270,13 @@ func (r *Reaper) recordScrapeFailure(ctx context.Context, kv jetstream.KeyValue,
 // persistObservation CAS-writes the sweep's findings, and only when they
 // changed: a steady-state idle endpoint would otherwise cost a KV write per
 // tick per endpoint forever.
-func (r *Reaper) persistObservation(ctx context.Context, kv jetstream.KeyValue, prev, next EndpointRecord) error {
+func (r *Reaper) persistObservation(ctx context.Context, prev, next EndpointRecord) error {
 	if prev.LastActiveAt.Equal(next.LastActiveAt) && prev.InFlight == next.InFlight &&
 		prev.SuccessTotal == next.SuccessTotal && prev.ScrapeFailures == next.ScrapeFailures {
 		return nil
 	}
 	key := resolveKey(utils.GlobalAccountID, next.ModelID)
-	current, rev, found, err := getFullJSON(ctx, kv, key)
+	current, rev, found, err := r.svc.store.getRevision(ctx, key)
 	if err != nil {
 		return err
 	}
@@ -298,8 +286,8 @@ func (r *Reaper) persistObservation(ctx context.Context, kv jetstream.KeyValue, 
 		return nil
 	}
 	next.Generation = current.Generation + 1
-	if err := updateJSON(ctx, kv, key, rev, next); err != nil {
-		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
+	if err := r.svc.store.CompareAndSet(ctx, key, &next, rev); err != nil {
+		if errors.Is(err, kvstore.ErrConflict) {
 			return nil
 		}
 		return err

--- a/spinifex/handlers/bedrock/reaper_test.go
+++ b/spinifex/handlers/bedrock/reaper_test.go
@@ -15,7 +15,6 @@ import (
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/utils"
-	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,7 +74,7 @@ type reaperFixture struct {
 	reaper    *Reaper
 	harness   *launchHarness
 	transport *vllmTransport
-	kv        jetstream.KeyValue
+	store     *endpointStore
 }
 
 func newReaperFixture(t *testing.T, deps ReaperDeps) *reaperFixture {
@@ -95,15 +94,12 @@ func newReaperFixture(t *testing.T, deps ReaperDeps) *reaperFixture {
 		PollInterval:   5 * time.Millisecond,
 		Replicas:       1,
 	})
-	kv, err := svc.bucket(t.Context())
-	require.NoError(t, err)
-
 	return &reaperFixture{
 		svc:       svc,
 		reaper:    NewReaper(svc, "node-a", deps),
 		harness:   h,
 		transport: transport,
-		kv:        kv,
+		store:     svc.store,
 	}
 }
 
@@ -125,7 +121,7 @@ func (f *reaperFixture) ready(t *testing.T) EndpointRecord {
 func (f *reaperFixture) age(t *testing.T, readyAgo, activeAgo time.Duration) EndpointRecord {
 	t.Helper()
 	key := resolveKey(utils.GlobalAccountID, testModelID)
-	rec, rev, found, err := getFullJSON(t.Context(), f.kv, key)
+	rec, rev, found, err := f.store.getRevision(t.Context(), key)
 	require.NoError(t, err)
 	require.True(t, found)
 
@@ -134,13 +130,13 @@ func (f *reaperFixture) age(t *testing.T, readyAgo, activeAgo time.Duration) End
 	if activeAgo > 0 {
 		rec.LastActiveAt = now.Add(-activeAgo)
 	}
-	require.NoError(t, updateJSON(t.Context(), f.kv, key, rev, rec))
+	require.NoError(t, f.store.CompareAndSet(t.Context(), key, &rec, rev))
 	return rec
 }
 
 func (f *reaperFixture) current(t *testing.T) (EndpointRecord, bool) {
 	t.Helper()
-	rec, _, found, err := getFullJSON(t.Context(), f.kv, resolveKey(utils.GlobalAccountID, testModelID))
+	rec, _, found, err := f.store.getRevision(t.Context(), resolveKey(utils.GlobalAccountID, testModelID))
 	require.NoError(t, err)
 	return rec, found
 }
@@ -179,10 +175,10 @@ func TestReaper_NeverReapsPinnedEndpoint(t *testing.T) {
 	f.age(t, time.Hour, time.Hour)
 
 	key := resolveKey(utils.GlobalAccountID, testModelID)
-	rec, rev, _, err := getFullJSON(t.Context(), f.kv, key)
+	rec, rev, _, err := f.store.getRevision(t.Context(), key)
 	require.NoError(t, err)
 	rec.Pinned = true
-	require.NoError(t, updateJSON(t.Context(), f.kv, key, rev, rec))
+	require.NoError(t, f.store.CompareAndSet(t.Context(), key, &rec, rev))
 
 	require.NoError(t, f.reaper.sweepOnce(t.Context()))
 
@@ -292,11 +288,11 @@ func TestReaper_PinnedEndpointNotReapedOnScrapeFailure(t *testing.T) {
 	f.ready(t)
 
 	key := resolveKey(utils.GlobalAccountID, testModelID)
-	rec, rev, found, err := getFullJSON(t.Context(), f.kv, key)
+	rec, rev, found, err := f.store.getRevision(t.Context(), key)
 	require.NoError(t, err)
 	require.True(t, found)
 	rec.Pinned = true
-	require.NoError(t, updateJSON(t.Context(), f.kv, key, rev, rec))
+	require.NoError(t, f.store.CompareAndSet(t.Context(), key, &rec, rev))
 
 	f.transport.breakScrapes()
 	for range maxScrapeFailures + 2 {
@@ -318,7 +314,7 @@ func TestReaper_ServiceOnlyBundleLivenessProbedNotReaped(t *testing.T) {
 
 	const embedModelID = "embed-only-bundle"
 	key := resolveKey(utils.GlobalAccountID, embedModelID)
-	_, err := createJSONRevision(t.Context(), f.kv, key, EndpointRecord{
+	rec := EndpointRecord{
 		AccountID:    utils.GlobalAccountID,
 		ModelID:      embedModelID,
 		State:        StateReady,
@@ -328,12 +324,13 @@ func TestReaper_ServiceOnlyBundleLivenessProbedNotReaped(t *testing.T) {
 		ReadyAt:      time.Now().Add(-time.Hour),
 		LastActiveAt: time.Now().Add(-time.Hour),
 		Generation:   1,
-	})
+	}
+	_, err := f.store.Create(t.Context(), key, &rec)
 	require.NoError(t, err)
 
 	require.NoError(t, f.reaper.sweepOnce(t.Context()))
 
-	rec, rev, found, err := getFullJSON(t.Context(), f.kv, key)
+	rec, rev, found, err := f.store.getRevision(t.Context(), key)
 	require.NoError(t, err)
 	require.True(t, found, "a warm service bundle is never idle-reaped")
 	assert.Empty(t, f.harness.launcher.terminated)
@@ -379,9 +376,10 @@ func TestReaper_UnchangedObservationWritesNothing(t *testing.T) {
 func TestReaper_SkipsNonReadyRecords(t *testing.T) {
 	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Nanosecond})
 	key := resolveKey(utils.GlobalAccountID, testModelID)
-	_, err := createJSONRevision(t.Context(), f.kv, key, EndpointRecord{
+	rec := EndpointRecord{
 		AccountID: utils.GlobalAccountID, ModelID: testModelID, State: StateStarting, Generation: 1,
-	})
+	}
+	_, err := f.store.Create(t.Context(), key, &rec)
 	require.NoError(t, err)
 
 	require.NoError(t, f.reaper.sweepOnce(t.Context()))

--- a/spinifex/handlers/bedrock/service.go
+++ b/spinifex/handlers/bedrock/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -60,8 +61,12 @@ type ServiceDeps struct {
 // any replica may read/write any key — hence the KV CAS layer beneath the
 // local per-key mutex (see ensureMu).
 type Service struct {
-	nc   *nats.Conn
-	deps ServiceDeps
+	nc    *nats.Conn
+	deps  ServiceDeps
+	store *endpointStore
+	// leader is the reaper's TTL-backed lease bucket, built alongside the
+	// endpoints store so both share this Service's one JetStream client.
+	leader *kvstore.Bucket
 
 	// ensureMu collapses concurrent Ensure calls FOR THE SAME KEY on THIS
 	// replica into one KV round trip: without it, N concurrent local callers
@@ -78,28 +83,35 @@ type Service struct {
 var _ EndpointService = (*Service)(nil)
 
 // NewService constructs a Service bound to nc, using deps for launch/capacity.
+// Both buckets are resolved lazily but memoised, so the get-or-create round
+// trip is paid once for the daemon rather than once per KV call.
 func NewService(nc *nats.Conn, deps ServiceDeps) *Service {
-	return &Service{nc: nc, deps: deps}
+	js := serviceJetStream(nc)
+	return &Service{
+		nc:     nc,
+		deps:   deps,
+		store:  newEndpointStore(js, deps.Replicas),
+		leader: newLeaderBucket(js),
+	}
+}
+
+// serviceJetStream derives a JetStream client from nc, or nil when there is no
+// connection to derive one from. kvstore reports a nil client as
+// missingJetStream, which is the error the accessors used to raise themselves.
+func serviceJetStream(nc *nats.Conn) jetstream.JetStream {
+	if nc == nil {
+		return nil
+	}
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return nil
+	}
+	return js
 }
 
 // WaitLaunches blocks until every async launch this Service has started so
 // far has finished. Test-only.
 func (s *Service) WaitLaunches() { s.launchWG.Wait() }
-
-func (s *Service) js() (jetstream.JetStream, error) {
-	if s.nc == nil {
-		return nil, errors.New("bedrock service: nil nats connection")
-	}
-	return jetstream.New(s.nc)
-}
-
-func (s *Service) bucket(ctx context.Context) (jetstream.KeyValue, error) {
-	js, err := s.js()
-	if err != nil {
-		return nil, err
-	}
-	return GetOrCreateEndpointsBucket(ctx, js, s.deps.Replicas)
-}
 
 func (s *Service) startupTimeout() time.Duration {
 	if s.deps.StartupTimeout > 0 {
@@ -168,13 +180,7 @@ func (s *Service) Ensure(ctx context.Context, in *EnsureEndpointInput, _ string)
 	unlock := s.ensureMu.lock(key)
 	defer unlock()
 
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	var existing EndpointRecord
-	found, err := getJSON(ctx, kv, key, &existing)
+	existing, found, err := s.store.get(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("bedrock: read endpoint %s: %w", in.ModelID, err)
 	}
@@ -193,7 +199,7 @@ func (s *Service) Ensure(ctx context.Context, in *EnsureEndpointInput, _ string)
 		// No free device. A GPU held by a model nobody is calling is not a
 		// reason to refuse this one, so make room and re-check — but return the
 		// original refusal, unchanged, when nothing can be given up.
-		if !s.evictForCapacity(ctx, kv, in.ModelID, spec.TotalMinVRAMMiB) {
+		if !s.evictForCapacity(ctx, in.ModelID, spec.TotalMinVRAMMiB) {
 			return nil, err
 		}
 		if retryErr := admitBundleCapacity(s.deps.GPU, in.ModelID); retryErr != nil {
@@ -213,13 +219,12 @@ func (s *Service) Ensure(ctx context.Context, in *EnsureEndpointInput, _ string)
 		Generation: 1,
 		Pinned:     in.Pinned,
 	}
-	if _, err := createJSONRevision(ctx, kv, key, rec); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
+	if _, err := s.store.Create(ctx, key, &rec); err != nil {
+		if errors.Is(err, kvstore.ErrExists) {
 			// Lost the cross-replica race after the read above: some other
 			// replica's Ensure claimed the key in between. Its record is the
 			// answer, not an error.
-			var winner EndpointRecord
-			if ok, gerr := getJSON(ctx, kv, key, &winner); gerr == nil && ok {
+			if winner, ok, gerr := s.store.get(ctx, key); gerr == nil && ok {
 				winner.ModelID = in.ModelID
 				return &EnsureEndpointOutput{Endpoint: winner}, nil
 			}
@@ -256,8 +261,8 @@ func (s *Service) Ensure(ctx context.Context, in *EnsureEndpointInput, _ string)
 //
 // Delete takes the per-key mutex for the victim while Ensure holds it for
 // wantModelID. The two can never be the same key, so the locks are disjoint.
-func (s *Service) evictForCapacity(ctx context.Context, kv jetstream.KeyValue, wantModelID string, minVRAMMiB int) bool {
-	recs, err := ListEndpoints(ctx, kv, utils.GlobalAccountID)
+func (s *Service) evictForCapacity(ctx context.Context, wantModelID string, minVRAMMiB int) bool {
+	recs, err := s.store.list(ctx, utils.GlobalAccountID)
 	if err != nil {
 		slog.ErrorContext(ctx, "bedrock: list endpoints for eviction failed", "model", wantModelID, "err", err)
 		return false
@@ -341,17 +346,12 @@ func (s *Service) runLaunch(ctx context.Context, key string, rec EndpointRecord,
 	rec.ReadyAt = time.Now().UTC()
 	rec.Generation++
 
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		slog.ErrorContext(ctx, "bedrock: bucket unavailable to record READY", "group", spec.GroupID, "err", err)
-		return
-	}
-	_, rev, gerr := readCurrent(ctx, kv, key)
+	_, rev, gerr := s.readCurrent(ctx, key)
 	if gerr != nil {
 		slog.ErrorContext(ctx, "bedrock: re-read endpoint before READY write failed", "group", spec.GroupID, "err", gerr)
 		return
 	}
-	if err := updateJSON(ctx, kv, key, rev, rec); err != nil {
+	if err := s.store.CompareAndSet(ctx, key, &rec, rev); err != nil {
 		slog.ErrorContext(ctx, "bedrock: CAS write of READY state failed", "group", spec.GroupID, "err", err)
 	}
 }
@@ -379,21 +379,15 @@ func (s *Service) abortLaunch(ctx context.Context, key, modelID string) {
 		slog.ErrorContext(ctx, "bedrock: illegal abort transition", "model", modelID, "err", err)
 		return
 	}
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		slog.ErrorContext(ctx, "bedrock: bucket unavailable to abort launch", "model", modelID, "err", err)
-		return
-	}
-	if err := deleteJSON(ctx, kv, key); err != nil {
+	if err := s.store.Purge(ctx, key); err != nil {
 		slog.ErrorContext(ctx, "bedrock: revert of failed launch failed; record may be stuck STARTING",
 			"model", modelID, "err", err)
 	}
 }
 
 // readCurrent re-reads key's current record and revision.
-func readCurrent(ctx context.Context, kv jetstream.KeyValue, key string) (EndpointRecord, uint64, error) {
-	var rec EndpointRecord
-	rev, found, err := getJSONRevision(ctx, kv, key, &rec)
+func (s *Service) readCurrent(ctx context.Context, key string) (EndpointRecord, uint64, error) {
+	rec, rev, found, err := s.store.getRevision(ctx, key)
 	if err != nil {
 		return EndpointRecord{}, 0, err
 	}
@@ -411,12 +405,7 @@ func (s *Service) Describe(ctx context.Context, in *DescribeEndpointInput, _ str
 		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
 	}
 	storeAccountID := resolveAccountID(in.AccountID)
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var rec EndpointRecord
-	found, err := getJSON(ctx, kv, resolveKey(storeAccountID, in.ModelID), &rec)
+	rec, found, err := s.store.get(ctx, resolveKey(storeAccountID, in.ModelID))
 	if err != nil {
 		return nil, fmt.Errorf("bedrock: describe endpoint %s: %w", in.ModelID, err)
 	}
@@ -432,11 +421,7 @@ func (s *Service) Describe(ctx context.Context, in *DescribeEndpointInput, _ str
 // every account: an operator listing must see a pinned, account-scoped
 // endpoint alongside the shared platform ones, not just the latter.
 func (s *Service) List(ctx context.Context, _ *ListEndpointsInput, _ string) (*ListEndpointsOutput, error) {
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	recs, err := ListAllEndpoints(ctx, kv)
+	recs, err := s.store.listAll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -459,11 +444,7 @@ func (s *Service) Delete(ctx context.Context, in *DeleteEndpointInput, _ string)
 	unlock := s.ensureMu.lock(key)
 	defer unlock()
 
-	kv, err := s.bucket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	rec, rev, found, err := getFullJSON(ctx, kv, key)
+	rec, rev, found, err := s.store.getRevision(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("bedrock: read endpoint %s: %w", in.ModelID, err)
 	}
@@ -480,7 +461,7 @@ func (s *Service) Delete(ctx context.Context, in *DeleteEndpointInput, _ string)
 		}
 		rec.State = StateDraining
 		rec.Generation++
-		if err := updateJSON(ctx, kv, key, rev, rec); err != nil {
+		if err := s.store.CompareAndSet(ctx, key, &rec, rev); err != nil {
 			return nil, fmt.Errorf("bedrock: mark endpoint %s draining: %w", in.ModelID, err)
 		}
 	}
@@ -491,18 +472,10 @@ func (s *Service) Delete(ctx context.Context, in *DeleteEndpointInput, _ string)
 	if err := validateTransition(StateDraining, StateAbsent); err != nil {
 		return nil, err
 	}
-	if err := deleteJSON(ctx, kv, key); err != nil {
+	if err := s.store.Purge(ctx, key); err != nil {
 		return nil, fmt.Errorf("bedrock: remove endpoint %s record: %w", in.ModelID, err)
 	}
 	return &DeleteEndpointOutput{Removed: true}, nil
-}
-
-// getFullJSON is getJSONRevision with the found flag surfaced alongside the
-// value and revision, for callers (Delete) that branch on all three.
-func getFullJSON(ctx context.Context, kv jetstream.KeyValue, key string) (EndpointRecord, uint64, bool, error) {
-	var rec EndpointRecord
-	rev, found, err := getJSONRevision(ctx, kv, key, &rec)
-	return rec, rev, found, err
 }
 
 // keyMutex hands out a per-key *sync.Mutex, creating it on first use. Entries

--- a/spinifex/handlers/bedrock/service_test.go
+++ b/spinifex/handlers/bedrock/service_test.go
@@ -207,15 +207,13 @@ func TestDelete_IdempotentOnAbsent(t *testing.T) {
 
 func TestDelete_RefusesNonReadyState(t *testing.T) {
 	h := newLaunchHarness()
-	s, nc := newTestService(t, h, http.StatusOK, sufficientGPU())
+	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())
 
-	js := testutil.NewJetStream(t, nc)
-	kv, err := GetOrCreateEndpointsBucket(t.Context(), js, 1)
-	require.NoError(t, err)
 	key := resolveKey(utils.GlobalAccountID, testModelID)
-	_, err = createJSONRevision(t.Context(), kv, key, EndpointRecord{
+	rec := EndpointRecord{
 		AccountID: utils.GlobalAccountID, ModelID: testModelID, State: StateStarting, Generation: 1,
-	})
+	}
+	_, err := s.store.Create(t.Context(), key, &rec)
 	require.NoError(t, err)
 
 	_, err = s.Delete(t.Context(), &DeleteEndpointInput{ModelID: testModelID}, "")
@@ -229,16 +227,14 @@ func TestDelete_RefusesNonReadyState(t *testing.T) {
 // DRAINING as neither servable nor relaunchable.
 func TestDelete_ResumesFromDraining(t *testing.T) {
 	h := newLaunchHarness()
-	s, nc := newTestService(t, h, http.StatusOK, sufficientGPU())
+	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())
 
-	js := testutil.NewJetStream(t, nc)
-	kv, err := GetOrCreateEndpointsBucket(t.Context(), js, 1)
-	require.NoError(t, err)
 	key := resolveKey(utils.GlobalAccountID, testModelID)
-	_, err = createJSONRevision(t.Context(), kv, key, EndpointRecord{
+	rec := EndpointRecord{
 		AccountID: utils.GlobalAccountID, ModelID: testModelID, State: StateDraining,
 		InstanceID: "i-stranded", Generation: 2,
-	})
+	}
+	_, err := s.store.Create(t.Context(), key, &rec)
 	require.NoError(t, err)
 
 	_, err = s.Delete(t.Context(), &DeleteEndpointInput{ModelID: testModelID}, "")
@@ -260,7 +256,7 @@ const testAccountID = "111111111111"
 // unpinned, exactly as every pre-existing caller relies on.
 func TestEnsure_EmptyAccountIDKeysGlobalAndUnpinned(t *testing.T) {
 	h := newLaunchHarness()
-	s, nc := newTestService(t, h, http.StatusOK, sufficientGPU())
+	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())
 
 	out, err := s.Ensure(t.Context(), &EnsureEndpointInput{ModelID: testModelID}, "")
 	require.NoError(t, err)
@@ -268,11 +264,7 @@ func TestEnsure_EmptyAccountIDKeysGlobalAndUnpinned(t *testing.T) {
 	assert.False(t, out.Endpoint.Pinned)
 	s.WaitLaunches()
 
-	js := testutil.NewJetStream(t, nc)
-	kv, err := GetOrCreateEndpointsBucket(t.Context(), js, 1)
-	require.NoError(t, err)
-	var rec EndpointRecord
-	found, err := getJSON(t.Context(), kv, resolveKey(utils.GlobalAccountID, testModelID), &rec)
+	rec, found, err := s.store.get(t.Context(), resolveKey(utils.GlobalAccountID, testModelID))
 	require.NoError(t, err)
 	require.True(t, found, "an empty AccountID must key the record under GlobalAccountID")
 	assert.False(t, rec.Pinned)
@@ -283,7 +275,7 @@ func TestEnsure_EmptyAccountIDKeysGlobalAndUnpinned(t *testing.T) {
 // GlobalAccountID endpoint and persist Pinned on it.
 func TestEnsure_RealAccountIDKeysUnderAccountAndPersistsPinned(t *testing.T) {
 	h := newLaunchHarness()
-	s, nc := newTestService(t, h, http.StatusOK, sufficientGPU())
+	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())
 
 	out, err := s.Ensure(t.Context(), &EnsureEndpointInput{
 		ModelID: testModelID, AccountID: testAccountID, Pinned: true,
@@ -293,18 +285,13 @@ func TestEnsure_RealAccountIDKeysUnderAccountAndPersistsPinned(t *testing.T) {
 	assert.True(t, out.Endpoint.Pinned)
 	s.WaitLaunches()
 
-	js := testutil.NewJetStream(t, nc)
-	kv, err := GetOrCreateEndpointsBucket(t.Context(), js, 1)
-	require.NoError(t, err)
-	var rec EndpointRecord
-	found, err := getJSON(t.Context(), kv, resolveKey(testAccountID, testModelID), &rec)
+	rec, found, err := s.store.get(t.Context(), resolveKey(testAccountID, testModelID))
 	require.NoError(t, err)
 	require.True(t, found, "a real AccountID must key the record under that account, not Global")
 	assert.True(t, rec.Pinned)
 
 	// Nothing must have landed under the shared Global key.
-	var globalRec EndpointRecord
-	foundGlobal, err := getJSON(t.Context(), kv, resolveKey(utils.GlobalAccountID, testModelID), &globalRec)
+	_, foundGlobal, err := s.store.get(t.Context(), resolveKey(utils.GlobalAccountID, testModelID))
 	require.NoError(t, err)
 	assert.False(t, foundGlobal)
 }

--- a/spinifex/handlers/bedrock/store.go
+++ b/spinifex/handlers/bedrock/store.go
@@ -3,13 +3,10 @@ package handlers_bedrock
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -33,13 +30,19 @@ const (
 	leaderKey         = "reaper"
 )
 
-// GetOrCreateLeaderBucket returns the reaper's TTL-backed leader bucket.
-func GetOrCreateLeaderBucket(ctx context.Context, js jetstream.JetStream) (jetstream.KeyValue, error) {
-	kv, err := kvutil.GetOrCreateBucketWithTTL(ctx, js, KVBucketLeader, 1, KVBucketLeaderTTL)
-	if err != nil {
-		return nil, fmt.Errorf("bedrock: create leader KV bucket: %w", err)
-	}
-	return kv, nil
+// missingJetStream is the error every accessor reports when the Service was
+// built without a NATS connection to derive a JetStream client from.
+const missingJetStream = "bedrock service: nil nats connection"
+
+// newLeaderBucket returns the reaper's TTL-backed leader bucket. The lease
+// carries no value of its own, so it is a Bucket rather than a Store[T].
+func newLeaderBucket(js jetstream.JetStream) *kvstore.Bucket {
+	return kvstore.NewBucket(js, kvstore.Config{
+		Name:    KVBucketLeader,
+		History: 1,
+		TTL:     KVBucketLeaderTTL,
+		Missing: missingJetStream,
+	})
 }
 
 // EndpointKey returns the KV key for accountID's modelID endpoint record.
@@ -51,136 +54,74 @@ func EndpointKey(accountID, modelID string) string {
 }
 
 // endpointsPrefix returns the KV key prefix under which accountID's endpoint
-// records live, for ListEndpoints to enumerate.
+// records live, for list to enumerate.
 func endpointsPrefix(accountID string) string {
 	return accountID + "/"
 }
 
-// GetOrCreateEndpointsBucket returns the shared bedrock-endpoints KV bucket,
-// creating it on first use at the given replica count (clamped to a minimum
-// of 1).
-func GetOrCreateEndpointsBucket(ctx context.Context, js jetstream.JetStream, replicas int) (jetstream.KeyValue, error) {
-	kv, err := kvutil.GetOrCreateBucketWithReplicas(ctx, js, KVBucketEndpoints, KVBucketEndpointsHistory, replicas)
+// endpointStore is the typed accessor for the shared bedrock-endpoints bucket.
+// One per Service, so the get-or-create round trip is paid once rather than on
+// every read and write.
+type endpointStore struct {
+	*kvstore.Store[EndpointRecord]
+}
+
+// newEndpointStore returns the endpoints store over js, replicated across
+// replicas nodes. A nil js is permitted: every accessor then reports
+// missingJetStream rather than panicking.
+func newEndpointStore(js jetstream.JetStream, replicas int) *endpointStore {
+	return &endpointStore{Store: kvstore.New[EndpointRecord](js, kvstore.Config{
+		Name:     KVBucketEndpoints,
+		History:  KVBucketEndpointsHistory,
+		Replicas: replicas,
+		Missing:  missingJetStream,
+	})}
+}
+
+// get reads key's record, reporting (zero, false, nil) when it is absent.
+func (s *endpointStore) get(ctx context.Context, key string) (EndpointRecord, bool, error) {
+	rec, _, found, err := s.getRevision(ctx, key)
+	return rec, found, err
+}
+
+// getRevision is get with the entry revision surfaced too, for the callers
+// that follow with a CAS update.
+func (s *endpointStore) getRevision(ctx context.Context, key string) (EndpointRecord, uint64, bool, error) {
+	rec, rev, err := s.Get(ctx, key)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return EndpointRecord{}, 0, false, nil
+	}
 	if err != nil {
-		return nil, fmt.Errorf("bedrock: create endpoints KV bucket: %w", err)
+		return EndpointRecord{}, 0, false, err
 	}
-	return kv, nil
+	return *rec, rev, true, nil
 }
 
-// Returns (false, nil) when the key is absent.
-func getJSON(ctx context.Context, kv jetstream.KeyValue, key string, out any) (bool, error) {
-	entry, err := kv.Get(ctx, key)
-	if errors.Is(err, jetstream.ErrKeyNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	if err := json.Unmarshal(entry.Value(), out); err != nil {
-		return false, fmt.Errorf("unmarshal %s: %w", key, err)
-	}
-	return true, nil
+// list returns every endpoint record under accountID's key prefix. Used by the
+// reaper and eviction candidate search, both of which only ever act on the
+// shared platform account's endpoints; listAll is the cross-account view an
+// operator listing needs instead.
+func (s *endpointStore) list(ctx context.Context, accountID string) ([]EndpointRecord, error) {
+	return s.listPrefix(ctx, endpointsPrefix(accountID))
 }
 
-// getJSON plus the entry revision, for callers that follow with a CAS update.
-func getJSONRevision(ctx context.Context, kv jetstream.KeyValue, key string, out any) (uint64, bool, error) {
-	entry, err := kv.Get(ctx, key)
-	if errors.Is(err, jetstream.ErrKeyNotFound) {
-		return 0, false, nil
-	}
-	if err != nil {
-		return 0, false, err
-	}
-	if err := json.Unmarshal(entry.Value(), out); err != nil {
-		return 0, false, fmt.Errorf("unmarshal %s: %w", key, err)
-	}
-	return entry.Revision(), true, nil
-}
-
-// createJSONRevision writes v at key only if nothing is stored there,
-// returning the created entry's revision. Returns jetstream.ErrKeyExists when
-// the key is already taken — the caller's cue to fall back to the read+CAS path.
-func createJSONRevision(ctx context.Context, kv jetstream.KeyValue, key string, v any) (uint64, error) {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return 0, err
-	}
-	rev, err := kv.Create(ctx, key, data)
-	if err != nil {
-		return 0, err
-	}
-	return rev, nil
-}
-
-// updateJSON writes v at key only if the stored entry is still at rev — the
-// CAS primitive single-flight and state transitions build on.
-func updateJSON(ctx context.Context, kv jetstream.KeyValue, key string, rev uint64, v any) error {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-	if _, err := kv.Update(ctx, key, data, rev); err != nil {
-		return fmt.Errorf("update %s: %w", key, err)
-	}
-	return nil
-}
-
-// deleteJSON removes key unconditionally. Purge (not just Delete) so no
-// stale revision survives to confuse a subsequent createJSONRevision's
-// "does the key exist" check under History=1.
-func deleteJSON(ctx context.Context, kv jetstream.KeyValue, key string) error {
-	if err := kv.Purge(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return fmt.Errorf("purge %s: %w", key, err)
-	}
-	return nil
-}
-
-// ListEndpoints returns every endpoint record under accountID's key prefix.
-// Used by the reaper and eviction candidate search, both of which only ever
-// act on the shared platform account's endpoints; ListAllEndpoints is the
-// cross-account view an operator listing needs instead.
-func ListEndpoints(ctx context.Context, kv jetstream.KeyValue, accountID string) ([]EndpointRecord, error) {
-	prefix := endpointsPrefix(accountID)
-	return listEndpointRecords(ctx, kv, func(key string) bool {
-		return strings.HasPrefix(key, prefix)
-	})
-}
-
-// ListAllEndpoints returns every endpoint record in the bucket regardless of
-// which account it is keyed under, so an operator listing sees a pinned,
+// listAll returns every endpoint record in the bucket regardless of which
+// account it is keyed under, so an operator listing sees a pinned,
 // account-scoped endpoint alongside the shared platform ones.
-func ListAllEndpoints(ctx context.Context, kv jetstream.KeyValue) ([]EndpointRecord, error) {
-	return listEndpointRecords(ctx, kv, func(string) bool { return true })
+func (s *endpointStore) listAll(ctx context.Context) ([]EndpointRecord, error) {
+	return s.listPrefix(ctx, "")
 }
 
-// listEndpointRecords reads every KV key that satisfies keep, decoding each
-// into an EndpointRecord, and is the shared body of ListEndpoints and
-// ListAllEndpoints.
-func listEndpointRecords(ctx context.Context, kv jetstream.KeyValue, keep func(key string) bool) ([]EndpointRecord, error) {
-	keys, err := kvutil.Keys(ctx, kv)
+// listPrefix normalises Store.List's nil to an empty slice, so an empty bucket
+// — the normal state before any endpoint exists — reads the same as a filtered
+// listing that matched nothing.
+func (s *endpointStore) listPrefix(ctx context.Context, prefix string) ([]EndpointRecord, error) {
+	recs, err := s.List(ctx, prefix)
 	if err != nil {
-		// An empty bucket is the normal state before any endpoint has ever
-		// been created, not a failure, matching every other kvutil.Keys caller.
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return []EndpointRecord{}, nil
-		}
-		return nil, fmt.Errorf("bedrock: list endpoint keys: %w", err)
+		return nil, err
 	}
-	out := make([]EndpointRecord, 0, len(keys))
-	for _, key := range keys {
-		if !keep(key) {
-			continue
-		}
-		var rec EndpointRecord
-		ok, getErr := getJSON(ctx, kv, key, &rec)
-		if getErr != nil {
-			return nil, fmt.Errorf("bedrock: read endpoint %s: %w", key, getErr)
-		}
-		if !ok {
-			// Deleted between Keys() and Get() — not an error, just gone.
-			continue
-		}
-		out = append(out, rec)
+	if recs == nil {
+		return []EndpointRecord{}, nil
 	}
-	return out, nil
+	return recs, nil
 }

--- a/spinifex/handlers/bedrock/store_test.go
+++ b/spinifex/handlers/bedrock/store_test.go
@@ -3,8 +3,8 @@ package handlers_bedrock
 import (
 	"testing"
 
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
-	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,36 +14,32 @@ func TestEndpointKey_Base64EncodesColonBearingModelID(t *testing.T) {
 	assert.Equal(t, "000000000000/"+"bWV0YS5sbGFtYTMtMi0xYi1pbnN0cnVjdC12MTow", key)
 }
 
-func newTestBucket(t *testing.T) jetstream.KeyValue {
+func newTestBucket(t *testing.T) *endpointStore {
 	t.Helper()
 	_, _, js := testutil.StartTestJetStream(t)
-	kv, err := GetOrCreateEndpointsBucket(t.Context(), js, 1)
-	require.NoError(t, err)
-	return kv
+	return newEndpointStore(js, 1)
 }
 
 func TestStore_CreateGetUpdateDelete(t *testing.T) {
-	kv := newTestBucket(t)
+	store := newTestBucket(t)
 	key := EndpointKey("000000000000", "test-model")
 
 	// Absent key reads as not-found, not an error.
-	var rec EndpointRecord
-	found, err := getJSON(t.Context(), kv, key, &rec)
+	_, found, err := store.get(t.Context(), key)
 	require.NoError(t, err)
 	assert.False(t, found)
 
-	rec = EndpointRecord{AccountID: "000000000000", ModelID: "test-model", State: StateStarting, Generation: 1}
-	rev, err := createJSONRevision(t.Context(), kv, key, rec)
+	rec := EndpointRecord{AccountID: "000000000000", ModelID: "test-model", State: StateStarting, Generation: 1}
+	rev, err := store.Create(t.Context(), key, &rec)
 	require.NoError(t, err)
 	assert.Positive(t, rev)
 
 	// A second create at the same key is rejected: this is the claim
 	// primitive Ensure relies on for cross-replica single-flight.
-	_, err = createJSONRevision(t.Context(), kv, key, rec)
-	assert.ErrorIs(t, err, jetstream.ErrKeyExists)
+	_, err = store.Create(t.Context(), key, &rec)
+	assert.ErrorIs(t, err, kvstore.ErrExists)
 
-	var got EndpointRecord
-	gotRev, found, err := getJSONRevision(t.Context(), kv, key, &got)
+	got, gotRev, found, err := store.getRevision(t.Context(), key)
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, rev, gotRev)
@@ -51,46 +47,46 @@ func TestStore_CreateGetUpdateDelete(t *testing.T) {
 
 	got.State = StateReady
 	got.Generation = 2
-	require.NoError(t, updateJSON(t.Context(), kv, key, gotRev, got))
+	require.NoError(t, store.CompareAndSet(t.Context(), key, &got, gotRev))
 
 	// The CAS update must fail against the now-stale revision — this is what
 	// stops a launch goroutine and a concurrent writer stomping each other.
-	err = updateJSON(t.Context(), kv, key, gotRev, got)
-	assert.Error(t, err)
+	err = store.CompareAndSet(t.Context(), key, &got, gotRev)
+	assert.ErrorIs(t, err, kvstore.ErrConflict)
 
-	require.NoError(t, deleteJSON(t.Context(), kv, key))
-	found, err = getJSON(t.Context(), kv, key, &rec)
+	require.NoError(t, store.Purge(t.Context(), key))
+	_, found, err = store.get(t.Context(), key)
 	require.NoError(t, err)
 	assert.False(t, found)
 
-	// Deleting an already-absent key is idempotent.
-	require.NoError(t, deleteJSON(t.Context(), kv, key))
+	// Purging an already-absent key is idempotent.
+	require.NoError(t, store.Purge(t.Context(), key))
 }
 
 func TestListEndpoints_FiltersByAccountPrefix(t *testing.T) {
-	kv := newTestBucket(t)
+	store := newTestBucket(t)
 
 	seed := func(accountID, modelID string, state EndpointState) {
 		rec := EndpointRecord{AccountID: accountID, ModelID: modelID, State: state, Generation: 1}
-		_, err := createJSONRevision(t.Context(), kv, EndpointKey(accountID, modelID), rec)
+		_, err := store.Create(t.Context(), EndpointKey(accountID, modelID), &rec)
 		require.NoError(t, err)
 	}
 	seed("000000000000", "model-a", StateReady)
 	seed("000000000000", "model-b", StateStarting)
 	seed("111111111111", "model-c", StateReady)
 
-	recs, err := ListEndpoints(t.Context(), kv, "000000000000")
+	recs, err := store.list(t.Context(), "000000000000")
 	require.NoError(t, err)
 	require.Len(t, recs, 2)
 	modelIDs := []string{recs[0].ModelID, recs[1].ModelID}
 	assert.ElementsMatch(t, []string{"model-a", "model-b"}, modelIDs)
 
-	recs, err = ListEndpoints(t.Context(), kv, "111111111111")
+	recs, err = store.list(t.Context(), "111111111111")
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	assert.Equal(t, "model-c", recs[0].ModelID)
 
-	recs, err = ListEndpoints(t.Context(), kv, "222222222222")
+	recs, err = store.list(t.Context(), "222222222222")
 	require.NoError(t, err)
 	assert.Empty(t, recs)
 }
@@ -98,9 +94,9 @@ func TestListEndpoints_FiltersByAccountPrefix(t *testing.T) {
 // A bucket that has never held an endpoint is the normal pre-launch state.
 // JetStream reports it as ErrNoKeysFound, which must read as empty, not fail.
 func TestListEndpoints_EmptyBucketIsNotAnError(t *testing.T) {
-	kv := newTestBucket(t)
+	store := newTestBucket(t)
 
-	recs, err := ListEndpoints(t.Context(), kv, "000000000000")
+	recs, err := store.list(t.Context(), "000000000000")
 	require.NoError(t, err)
 	assert.Empty(t, recs)
 }
@@ -110,17 +106,17 @@ func TestListEndpoints_EmptyBucketIsNotAnError(t *testing.T) {
 // records in one pass, which is what an operator listing needs to see a
 // pinned endpoint alongside the shared platform ones.
 func TestListAllEndpoints_ReturnsAcrossAccounts(t *testing.T) {
-	kv := newTestBucket(t)
+	store := newTestBucket(t)
 
 	seed := func(accountID, modelID string, state EndpointState, pinned bool) {
 		rec := EndpointRecord{AccountID: accountID, ModelID: modelID, State: state, Pinned: pinned, Generation: 1}
-		_, err := createJSONRevision(t.Context(), kv, EndpointKey(accountID, modelID), rec)
+		_, err := store.Create(t.Context(), EndpointKey(accountID, modelID), &rec)
 		require.NoError(t, err)
 	}
 	seed("000000000000", "model-a", StateReady, false)
 	seed("111111111111", "model-c", StateReady, true)
 
-	recs, err := ListAllEndpoints(t.Context(), kv)
+	recs, err := store.listAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, recs, 2)
 
@@ -137,9 +133,9 @@ func TestListAllEndpoints_ReturnsAcrossAccounts(t *testing.T) {
 // TestListAllEndpoints_EmptyBucketIsNotAnError mirrors ListEndpoints' own
 // empty-bucket guard.
 func TestListAllEndpoints_EmptyBucketIsNotAnError(t *testing.T) {
-	kv := newTestBucket(t)
+	store := newTestBucket(t)
 
-	recs, err := ListAllEndpoints(t.Context(), kv)
+	recs, err := store.listAll(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, recs)
 }

--- a/spinifex/kvstore/store.go
+++ b/spinifex/kvstore/store.go
@@ -103,6 +103,19 @@ func (s *Store[T]) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
+// Purge is Delete for a key whose history must go with it, so a later Create
+// sees a key that never existed rather than one with a delete marker on top.
+func (s *Store[T]) Purge(ctx context.Context, key string) error {
+	kv, err := s.KV(ctx)
+	if err != nil {
+		return err
+	}
+	if err := kv.Purge(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("kvstore: purge %s: %w", key, err)
+	}
+	return nil
+}
+
 // List decodes every record whose key carries the given prefix. An empty
 // prefix matches everything and an empty bucket is not an error. A key that
 // disappears between the listing and the read is skipped.

--- a/spinifex/kvstore/store_test.go
+++ b/spinifex/kvstore/store_test.go
@@ -460,3 +460,46 @@ func TestBucket_TTLOpensABucketWithThatMaxAge(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 90*time.Minute, status.TTL(), "Config.TTL must reach the created bucket")
 }
+
+func TestStore_PurgeIsIdempotent(t *testing.T) {
+	store := newStore(t)
+	mustCreate(t, store, "acct-a/one", record{Name: "one"})
+
+	require.NoError(t, store.Purge(t.Context(), "acct-a/one"))
+	require.NoError(t, store.Purge(t.Context(), "acct-a/one"), "purging an absent key is success")
+	require.NoError(t, store.Purge(t.Context(), "never-existed"))
+
+	_, _, err := store.Get(t.Context(), "acct-a/one")
+	require.ErrorIs(t, err, kvstore.ErrNotFound)
+}
+
+// TestStore_PurgeDropsTheHistoryDeleteKeeps is the whole reason Purge exists
+// alongside Delete: a deleted key keeps its prior values in history, a purged
+// one collapses to the marker alone.
+func TestStore_PurgeDropsTheHistoryDeleteKeeps(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	store := kvstore.New[record](testutil.NewJetStream(t, nc), kvstore.Config{
+		Name:    "kvstore-purge-test",
+		History: 5,
+	})
+	kv, err := store.KV(t.Context())
+	require.NoError(t, err)
+
+	seed := func(key string) {
+		mustCreate(t, store, key, record{Name: key, Count: 1})
+		seedRaw(t, store, key, record{Name: key, Count: 2})
+	}
+
+	seed("deleted")
+	require.NoError(t, store.Delete(t.Context(), "deleted"))
+	deleted, err := kv.History(t.Context(), "deleted")
+	require.NoError(t, err)
+	assert.Len(t, deleted, 3, "a delete leaves the two prior values behind its marker")
+
+	seed("purged")
+	require.NoError(t, store.Purge(t.Context(), "purged"))
+	purged, err := kv.History(t.Context(), "purged")
+	require.NoError(t, err)
+	require.Len(t, purged, 1, "a purge takes the prior values with it")
+	assert.Equal(t, jetstream.KeyValuePurge, purged[0].Operation())
+}


### PR DESCRIPTION
## Summary

Last of the Bedrock conversions onto `kvstore`: `handlers/bedrock` — the serving-endpoint service, its store and its reaper.

The win here is different from the earlier PRs. `Service.bucket()` had **no memoisation at all**: every KV operation built a fresh `jetstream.New(s.nc)` and did a get-or-create round trip against `bedrock-endpoints` before touching a key. The reaper does that once per endpoint per tick. `kvstore.Store` resolves the bucket once per `Service` and caches the handle, so the round trip is paid at first use and never again.

`handlers/bedrock/store.go` loses its whole hand-rolled JSON layer — `getJSON`, `getJSONRevision`, `createJSONRevision`, `updateJSON`, `deleteJSON`, `listEndpointRecords`, `GetOrCreateEndpointsBucket`, `GetOrCreateLeaderBucket` — and keeps only what is genuinely local to endpoints: the key encoding and the four typed accessors over `Store[EndpointRecord]`.

## `Store.Purge`

`deleteJSON` documented and used `kv.Purge`, not `kv.Delete`, and that is load-bearing: an endpoint record is deleted and then re-created under the same key on the next launch, and `Create` is the single-writer claim. A delete marker sitting on top of the key is not the same starting state as a key that never existed, so mapping `deleteJSON` onto `Store.Delete` would have been a silent behaviour change.

`Store.Purge` is added instead — `Delete`'s shape, `kv.Purge`'s semantics, same idempotence on an absent key. Two tests cover it, one of which asserts the actual difference: after `Delete` a key's prior values remain in history, after `Purge` only the purge marker survives.

## Sentinel staleness, again

`reaper.go`'s `persistObservation` compared against `jetstream.ErrKeyRevisionMismatch` to decide that a lost CAS race is a no-op rather than a failure — the reaper's observation is advisory, so another writer winning is fine. Routed through `Store.CompareAndSet`, that comparison silently stops matching, because the store maps the mismatch onto `kvstore.ErrConflict`. It now checks the sentinel it will actually receive.

This is the same trap as the earlier PRs in the series: a sentinel comparison that was correct before a conversion is not automatically correct after it, in either direction, and the compiler says nothing.

## What did not convert

- **`bedrock-leader`** is a `Bucket`, not a `Store[T]`. The lease value is opaque to us — `kvlease` owns it — and the bucket's TTL is what makes the lease self-healing. A codec would change what is on disk for no gain. `kvlease.Config.Bucket` is signature-compatible with `Bucket.KV`, so the wiring is a one-line swap.
- **`serviceJetStream`** keeps `NewService` total on a nil `*nats.Conn`: it returns a nil client rather than erroring, and `kvstore` reports the nil as `missingJetStream` — byte-for-byte the error the old accessors raised themselves. Tests that construct a Service without NATS keep working unchanged.

## Testing

- `make preflight` — pass.
- `go test ./spinifex/handlers/bedrock/ ./spinifex/kvstore/` — pass.
- New: `TestStore_PurgeIsIdempotent`, `TestStore_PurgeDropsTheHistoryDeleteKeeps`.
- The four test files in `handlers/bedrock` that reached the deleted JSON helpers directly now go through `endpointStore`, which is the same coverage against the new surface rather than new assertions.

## Follow-up worth a bead

Carried from the previous PR and still open: `bedrock-usage-dedupe` is created through the TTL helper, which takes no replica count, so it is R1 even on a replicated cluster. Losing the node holding it loses the dedupe markers, and usage and cost are then double-counted for the replayed window.
