### PR TITLE
feat: converge DNS on change rather than on a timer

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1557,7 +1557,7 @@ func (d *Daemon) startCluster() error {
 	store := objectstore.NewS3ObjectStoreFromConfig(admin.DialTarget(d.config.Predastore.Host), d.config.Predastore.Region, d.config.Predastore.AccessKey, d.config.Predastore.SecretKey)
 	d.instanceService = handlers_ec2_instance.NewInstanceServiceImpl(d.config, d.resourceMgr.instanceTypes, d.natsConn, store, d.vmMgr, d.resourceMgr, d.jsManager)
 	d.dnsWriter = handlers_dns.NewWriter(d.config, d.clusterConfig, d.natsConn)
-	d.dnsReconciler = handlers_dns.NewReconciler(d.config, d.natsConn, d.dnsDesiredSet)
+	d.dnsReconciler = handlers_dns.NewReconciler(d.config, d.natsConn, d.dnsDesiredSet, d.dnsWatchSources()...)
 	d.dnsBaseDomain = handlers_dns.ResolveBaseDomain(d.config)
 	d.dnsInternalDomain = handlers_dns.ResolveInternalDomain(d.config)
 	d.keyService = handlers_ec2_key.NewKeyServiceImpl(d.config)

--- a/spinifex/daemon/dns_reconcile.go
+++ b/spinifex/daemon/dns_reconcile.go
@@ -1,10 +1,74 @@
 package daemon
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/reconciler"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 )
+
+// dnsWatchSources names the buckets whose changes should wake the DNS
+// reconcile: one per input to dnsDesiredSet. Each is resolved lazily, because
+// the reconciler is constructed before the services it reads from exist and
+// re-enumerates its buckets on every resync anyway.
+func (d *Daemon) dnsWatchSources() []reconciler.Source {
+	return []reconciler.Source{
+		reconciler.Dynamic(d.instanceStateWatchBuckets, instanceStateWatchFilter),
+		reconciler.Dynamic(d.elbv2WatchBuckets, handlers_elbv2.KeyPrefixLB+"*"),
+		reconciler.Dynamic(d.eksWatchBuckets, ">"),
+		reconciler.Dynamic(d.rdsWatchBuckets, ">"),
+	}
+}
+
+// instanceStateWatchFilter matches the per-node instance blobs. EC2 records are
+// the one DNS input that is node-local, so a change to any node's blob is the
+// only signal that this node's own VMs may need re-asserting.
+const instanceStateWatchFilter = InstanceStatePrefix + "*"
+
+// instanceStateWatchBuckets returns the shared instance-state bucket. It is a
+// fresh kvstore.Bucket rather than the JetStreamManager's handle so a recovery
+// swapping that handle cannot leave the watch pointing at a closed one.
+func (d *Daemon) instanceStateWatchBuckets(context.Context) ([]*kvstore.Bucket, error) {
+	if d.jsManager == nil || d.jsManager.js == nil {
+		return nil, nil
+	}
+	return []*kvstore.Bucket{kvstore.NewBucket(d.jsManager.js, kvstore.Config{
+		Name:     InstanceStateBucket,
+		History:  1,
+		Replicas: d.jsManager.replicas,
+	})}, nil
+}
+
+func (d *Daemon) elbv2WatchBuckets(context.Context) ([]*kvstore.Bucket, error) {
+	if d.elbv2Service == nil {
+		return nil, nil
+	}
+	bucket := d.elbv2Service.DNSWatchBucket()
+	if bucket == nil {
+		return nil, nil
+	}
+	return []*kvstore.Bucket{bucket}, nil
+}
+
+func (d *Daemon) eksWatchBuckets(ctx context.Context) ([]*kvstore.Bucket, error) {
+	if d.eksService == nil || d.natsConn == nil {
+		return nil, nil
+	}
+	return handlers_eks.AccountWatchBuckets(ctx, d.natsConn)
+}
+
+func (d *Daemon) rdsWatchBuckets(ctx context.Context) ([]*kvstore.Bucket, error) {
+	if d.rdsService == nil || d.jsManager == nil || d.jsManager.js == nil {
+		return nil, nil
+	}
+	return handlers_rds.AccountWatchBuckets(ctx, d.jsManager.js)
+}
 
 // dnsDesiredSet builds the full desired managed-record set for the reconcile
 // backstop. It spans all tenants: every running instance on this node plus

--- a/spinifex/daemon/dns_reconcile_test.go
+++ b/spinifex/daemon/dns_reconcile_test.go
@@ -1,0 +1,148 @@
+package daemon
+
+// These tests build *Daemon literals directly to reach the lazy watch-bucket
+// listers, which is only possible from inside the package.
+//test:in-package
+
+import (
+	"context"
+	"testing"
+
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDNSWatchSources_OneSourcePerDesiredSetInput pins the filter each source
+// watches on. The ELBv2 bucket also holds target groups, listeners, rules and
+// name claims alongside load balancers, so its filter must stay the "lb."
+// prefix rather than widen to ">" — a rule change is not a DNS change, and
+// every write anywhere in that bucket would otherwise wake the reconcile.
+func TestDNSWatchSources_OneSourcePerDesiredSetInput(t *testing.T) {
+	d := &Daemon{}
+	sources := d.dnsWatchSources()
+	require.Len(t, sources, 4)
+
+	filters := make([]string, 0, len(sources))
+	for _, s := range sources {
+		filters = append(filters, s.Filter())
+	}
+	assert.ElementsMatch(t, []string{
+		InstanceStatePrefix + "*",
+		handlers_elbv2.KeyPrefixLB + "*",
+		">",
+		">",
+	}, filters)
+}
+
+// TestDNSWatchBuckets_ZeroValueDaemonIsNilSafe covers every lazy lister: the
+// reconciler is constructed before the services it reads from exist, so each
+// must degrade to (nil, nil) rather than panic on a daemon with nothing wired up.
+func TestDNSWatchBuckets_ZeroValueDaemonIsNilSafe(t *testing.T) {
+	d := &Daemon{}
+	listers := map[string]func(context.Context) ([]*kvstore.Bucket, error){
+		"instanceState": d.instanceStateWatchBuckets,
+		"elbv2":         d.elbv2WatchBuckets,
+		"eks":           d.eksWatchBuckets,
+		"rds":           d.rdsWatchBuckets,
+	}
+	for name, list := range listers {
+		t.Run(name, func(t *testing.T) {
+			buckets, err := list(t.Context())
+			require.NoError(t, err)
+			assert.Nil(t, buckets)
+		})
+	}
+}
+
+func TestInstanceStateWatchBuckets_ReturnsSharedBucket(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	d := &Daemon{jsManager: &JetStreamManager{js: js, replicas: 1}}
+
+	buckets, err := d.instanceStateWatchBuckets(t.Context())
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+	assert.Equal(t, InstanceStateBucket, buckets[0].Name())
+}
+
+// TestElbv2WatchBuckets_NoStoreIsNilSafe covers a service that exists but has
+// not opened a store, distinct from the elbv2Service field itself being nil.
+func TestElbv2WatchBuckets_NoStoreIsNilSafe(t *testing.T) {
+	d := &Daemon{elbv2Service: &handlers_elbv2.ELBv2ServiceImpl{}}
+	buckets, err := d.elbv2WatchBuckets(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, buckets)
+}
+
+func TestElbv2WatchBuckets_WithStoreReturnsWatchBucket(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	masterKey, err := handlers_iam.GenerateMasterKey()
+	require.NoError(t, err)
+	svc, err := handlers_elbv2.NewELBv2ServiceImplWithNATS(nil, nc, masterKey)
+	require.NoError(t, err)
+	t.Cleanup(svc.Close)
+
+	d := &Daemon{elbv2Service: svc}
+	buckets, err := d.elbv2WatchBuckets(t.Context())
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+	assert.Equal(t, handlers_elbv2.KVBucketELBv2, buckets[0].Name())
+}
+
+// TestEksWatchBuckets_NilGuards exercises the two halves of the guard clause
+// independently: a natsConn with no service, and a service with no natsConn.
+func TestEksWatchBuckets_NilGuards(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+
+	buckets, err := (&Daemon{natsConn: nc}).eksWatchBuckets(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, buckets)
+
+	buckets, err = (&Daemon{eksService: &handlers_eks.EKSServiceImpl{}}).eksWatchBuckets(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, buckets)
+}
+
+func TestEksWatchBuckets_DelegatesToAccountWatchBuckets(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	_, err := handlers_eks.GetOrCreateAccountBucket(t.Context(), js, "111111111111", 1)
+	require.NoError(t, err)
+
+	d := &Daemon{eksService: &handlers_eks.EKSServiceImpl{}, natsConn: nc}
+	buckets, err := d.eksWatchBuckets(t.Context())
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+	assert.Equal(t, handlers_eks.AccountBucketName("111111111111"), buckets[0].Name())
+}
+
+// TestRdsWatchBuckets_NilGuards exercises the two halves of the guard clause
+// independently: a jsManager with no service, and a service with no jsManager.
+func TestRdsWatchBuckets_NilGuards(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+
+	buckets, err := (&Daemon{jsManager: &JetStreamManager{js: js}}).rdsWatchBuckets(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, buckets)
+
+	buckets, err = (&Daemon{rdsService: &handlers_rds.Service{}}).rdsWatchBuckets(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, buckets)
+}
+
+func TestRdsWatchBuckets_DelegatesToAccountWatchBuckets(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	_, err := handlers_rds.GetOrCreateAccountBucket(t.Context(), js, "111111111111")
+	require.NoError(t, err)
+
+	d := &Daemon{rdsService: &handlers_rds.Service{}, jsManager: &JetStreamManager{js: js}}
+	buckets, err := d.rdsWatchBuckets(t.Context())
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+	assert.Equal(t, handlers_rds.AccountBucketName("111111111111"), buckets[0].Name())
+}

--- a/spinifex/handlers/dns/reconcile.go
+++ b/spinifex/handlers/dns/reconcile.go
@@ -12,14 +12,17 @@ import (
 	nsconfig "github.com/mulgadc/northstar/pkg/config"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	reconcilelock "github.com/mulgadc/spinifex/spinifex/network/reconcile"
+	"github.com/mulgadc/spinifex/spinifex/reconciler"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 )
 
 // DefaultReconcileInterval is how often the drift backstop rebuilds managed
-// records from the live resource inventory. It is deliberately close to
-// the northstar S3 poll so a missed lifecycle event self-heals within one cycle.
-const DefaultReconcileInterval = 60 * time.Second
+// records from the live resource inventory when nothing has changed. With the
+// watch carrying every change the loop sees, this is the backstop for drift
+// introduced outside KV — directly in the zone object, say — rather than the
+// path by which a normal lifecycle event reaches DNS.
+const DefaultReconcileInterval = reconciler.DefaultResync
 
 const (
 	// maxReconcileNATSPayloadBytes stays below nats.conf's 1 MB max_payload.
@@ -56,15 +59,16 @@ type PruneScope struct {
 	RDS bool
 }
 
-// Reconciler is the drift backstop. On a ticker it rebuilds the desired
-// managed record set from the live inventory and converges the zone toward it:
-// every desired record is re-UPSERTed (idempotent — the writer skips unchanged
-// zones) and stale *prunable* records are DELETEd.
+// Reconciler converges the zone toward the live inventory. On each pass it
+// rebuilds the desired managed record set: every desired record is re-UPSERTed
+// (idempotent — the writer skips unchanged zones) and stale *prunable* records
+// are DELETEd. A pass runs on a change to any watched resource store, and on
+// the interval as the backstop for drift those stores cannot report.
 //
-// Each cycle is gated on a CAS-elected leader so one node per interval publishes
-// the converging batch. Without it every node published its own batch on the same
-// interval, and since the queue group load-balances rather than serialises, an
-// idle cluster raced its own zone object once per tick.
+// Each pass is gated on a CAS-elected leader so one node publishes the
+// converging batch. Without it every node published its own batch, and since
+// the queue group load-balances rather than serialises, an idle cluster raced
+// its own zone object once per cycle.
 //
 // Only cluster-wide-enumerable records (load balancers, EKS clusters) are
 // pruned: any node sees the full ELB/EKS set from KV. EC2 records are never
@@ -80,16 +84,21 @@ type Reconciler struct {
 	interval   time.Duration
 	accountID  string
 	holder     string
+	sources    []reconciler.Source
 }
 
 // NewReconciler builds the drift backstop. It is disabled (a no-op) when
 // northstar S3 is not configured or no desired-set provider is supplied.
-func NewReconciler(cfg *config.Config, nc *nats.Conn, desired DesiredFunc) *Reconciler {
+// sources name the buckets whose changes should wake the loop. They are
+// optional: with none supplied the loop falls back to the interval alone,
+// which is the behaviour that predates the watch.
+func NewReconciler(cfg *config.Config, nc *nats.Conn, desired DesiredFunc, sources ...reconciler.Source) *Reconciler {
 	r := &Reconciler{
 		nc:        nc,
 		desired:   desired,
 		interval:  DefaultReconcileInterval,
 		accountID: utils.GlobalAccountID,
+		sources:   sources,
 	}
 	if cfg != nil {
 		r.holder = cfg.Node
@@ -107,23 +116,25 @@ func NewReconciler(cfg *config.Config, nc *nats.Conn, desired DesiredFunc) *Reco
 // Enabled reports whether the reconcile loop will run.
 func (r *Reconciler) Enabled() bool { return r.enabled }
 
-// Run reconciles once immediately, then on the interval until ctx is done. It is
-// a no-op when disabled, so the daemon can start it unconditionally.
+// Run converges once, then on every change to the resource stores the desired
+// set is built from, with the interval as the drift backstop. It is a no-op
+// when disabled, so the daemon can start it unconditionally.
+//
+// Only the trigger is event-driven: each pass still rebuilds the whole desired
+// set, so the watch needs to report only that something changed, not what.
 func (r *Reconciler) Run(ctx context.Context) {
 	if !r.enabled {
 		return
 	}
-	r.reconcileOnce(ctx)
-	ticker := time.NewTicker(r.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
+	reconciler.Run(ctx, reconciler.Config{
+		Name:    "dns",
+		Sources: r.sources,
+		Reconcile: func(ctx context.Context) error {
 			r.reconcileOnce(ctx)
-		}
-	}
+			return nil
+		},
+		Resync: r.interval,
+	})
 }
 
 // reconcileOnce computes the converging batch and publishes it best-effort, on

--- a/spinifex/handlers/dns/reconcile_test.go
+++ b/spinifex/handlers/dns/reconcile_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	nsconfig "github.com/mulgadc/northstar/pkg/config"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/reconciler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -425,4 +427,37 @@ func TestReconcilerBackendErrorStillAborts(t *testing.T) {
 	r := &Reconciler{enabled: true, baseDomain: testBase, s3cfg: &nsconfig.S3Config{}}
 	_, _, err := r.readZone(testBase)
 	require.Error(t, err, "a backend failure must propagate, not look like a rebuildable zone")
+}
+
+// TestReconciler_RunReturnsWhenDisabled pins the guard that keeps the daemon
+// able to start the loop unconditionally. Without it the disabled reconciler
+// would enter the watch loop and block until shutdown instead of returning.
+func TestReconciler_RunReturnsWhenDisabled(t *testing.T) {
+	r := NewReconciler(nil, nil, nil)
+	require.False(t, r.Enabled())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.Run(t.Context())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return for a disabled reconciler")
+	}
+}
+
+// TestNewReconciler_RetainsItsWatchSources covers the wiring the daemon relies
+// on: sources supplied at construction have to reach the loop, and supplying
+// none is legal because that is the interval-only behaviour.
+func TestNewReconciler_RetainsItsWatchSources(t *testing.T) {
+	bucket := kvstore.NewBucket(nil, kvstore.Config{Name: "b"})
+
+	assert.Empty(t, NewReconciler(nil, nil, nil).sources)
+	assert.Len(t, NewReconciler(nil, nil, nil,
+		reconciler.Fixed(bucket, "node.*"),
+		reconciler.Fixed(bucket, "lb.*"),
+	).sources, 2)
 }

--- a/spinifex/handlers/dns/reconcile_test.go
+++ b/spinifex/handlers/dns/reconcile_test.go
@@ -1,16 +1,19 @@
 package dns
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	nsconfig "github.com/mulgadc/northstar/pkg/config"
 	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/reconciler"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -446,6 +449,47 @@ func TestReconciler_RunReturnsWhenDisabled(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run did not return for a disabled reconciler")
+	}
+}
+
+// TestReconciler_RunPerformsStartupPassThenStopsOnCancel covers the enabled
+// path of Run: the startup pass must fire before any watch or resync activity,
+// and cancelling ctx must still let the loop return.
+func TestReconciler_RunPerformsStartupPassThenStopsOnCancel(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	endpoint, _ := fakeS3(t, "northstar")
+
+	var passes atomic.Int64
+	r := &Reconciler{
+		enabled:    true,
+		baseDomain: testBase,
+		s3cfg: &nsconfig.S3Config{
+			Endpoint: endpoint, Bucket: "northstar", Region: "us-east-1",
+			AccessKey: "SYSTEM", SecretKey: "SYSTEMSECRET",
+		},
+		nc:     nc,
+		holder: "test-node",
+		desired: func() DesiredSet {
+			passes.Add(1)
+			return DesiredSet{}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.Run(ctx)
+	}()
+
+	require.Eventually(t, func() bool { return passes.Load() >= 1 }, 5*time.Second, 10*time.Millisecond,
+		"the startup pass must run immediately, before any watch or resync activity")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after ctx was cancelled")
 	}
 }
 

--- a/spinifex/handlers/eks/store.go
+++ b/spinifex/handlers/eks/store.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/migrate"
 	"github.com/mulgadc/spinifex/spinifex/otelsetup"
@@ -206,6 +207,26 @@ func accountBucketNames(ctx context.Context, nc *nats.Conn) ([]string, error) {
 		}
 	}
 	return names, nil
+}
+
+// AccountWatchBuckets returns every per-account bucket as a watchable handle,
+// for a reconciler that must be woken by a cluster change rather than poll for
+// it. The set is re-read on each call because a new account's bucket appears
+// without notice: JetStream publishes no bucket-created event.
+func AccountWatchBuckets(ctx context.Context, nc *nats.Conn) ([]*kvstore.Bucket, error) {
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return nil, fmt.Errorf("jetstream: %w", err)
+	}
+	names, err := accountBucketNames(ctx, nc)
+	if err != nil {
+		return nil, err
+	}
+	buckets := make([]*kvstore.Bucket, 0, len(names))
+	for _, name := range names {
+		buckets = append(buckets, kvstore.NewBucket(js, kvstore.Config{Name: name, History: 1}))
+	}
+	return buckets, nil
 }
 
 // GetOrCreateAccountBucket returns the per-account KV bucket for accountID,

--- a/spinifex/handlers/eks/watch_source_test.go
+++ b/spinifex/handlers/eks/watch_source_test.go
@@ -1,8 +1,10 @@
-package handlers_eks
+package handlers_eks_test
 
 import (
+	"context"
 	"testing"
 
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/stretchr/testify/assert"
@@ -16,14 +18,14 @@ func TestAccountWatchBuckets_ReturnsOnePerAccountBucket(t *testing.T) {
 	_, nc, _ := testutil.StartTestJetStream(t)
 	js := testutil.NewJetStream(t, nc)
 
-	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111", 1)
+	_, err := handlers_eks.GetOrCreateAccountBucket(t.Context(), js, "111111111111", 1)
 	require.NoError(t, err)
-	_, err = GetOrCreateAccountBucket(t.Context(), js, "222222222222", 1)
+	_, err = handlers_eks.GetOrCreateAccountBucket(t.Context(), js, "222222222222", 1)
 	require.NoError(t, err)
 	_, err = kvutil.GetOrCreateBucket(t.Context(), js, "something-else", 1)
 	require.NoError(t, err)
 
-	buckets, err := AccountWatchBuckets(t.Context(), nc)
+	buckets, err := handlers_eks.AccountWatchBuckets(t.Context(), nc)
 	require.NoError(t, err)
 
 	names := make([]string, 0, len(buckets))
@@ -31,15 +33,15 @@ func TestAccountWatchBuckets_ReturnsOnePerAccountBucket(t *testing.T) {
 		names = append(names, bucket.Name())
 	}
 	assert.ElementsMatch(t, []string{
-		AccountBucketName("111111111111"),
-		AccountBucketName("222222222222"),
+		handlers_eks.AccountBucketName("111111111111"),
+		handlers_eks.AccountBucketName("222222222222"),
 	}, names)
 }
 
 func TestAccountWatchBuckets_NoAccountsIsNotAnError(t *testing.T) {
 	_, nc, _ := testutil.StartTestJetStream(t)
 
-	buckets, err := AccountWatchBuckets(t.Context(), nc)
+	buckets, err := handlers_eks.AccountWatchBuckets(t.Context(), nc)
 	require.NoError(t, err, "a cluster with no EKS usage is not a failure")
 	assert.Empty(t, buckets)
 }
@@ -49,14 +51,27 @@ func TestAccountWatchBuckets_NoAccountsIsNotAnError(t *testing.T) {
 func TestAccountWatchBuckets_BucketsAreWatchable(t *testing.T) {
 	_, nc, _ := testutil.StartTestJetStream(t)
 	js := testutil.NewJetStream(t, nc)
-	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111", 1)
+	_, err := handlers_eks.GetOrCreateAccountBucket(t.Context(), js, "111111111111", 1)
 	require.NoError(t, err)
 
-	buckets, err := AccountWatchBuckets(t.Context(), nc)
+	buckets, err := handlers_eks.AccountWatchBuckets(t.Context(), nc)
 	require.NoError(t, err)
 	require.Len(t, buckets, 1)
 
 	watcher, err := buckets[0].Watch(t.Context(), ">")
 	require.NoError(t, err)
 	require.NoError(t, watcher.Stop())
+}
+
+// TestAccountWatchBuckets_EnumerationErrorPropagates guards against a bucket
+// listing failure being mistaken for "no accounts": a cancelled context makes
+// the underlying stream-names listing fail, and that failure must surface
+// rather than come back as an empty, and therefore prunable, set.
+func TestAccountWatchBuckets_EnumerationErrorPropagates(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := handlers_eks.AccountWatchBuckets(ctx, nc)
+	require.Error(t, err)
 }

--- a/spinifex/handlers/eks/watch_source_test.go
+++ b/spinifex/handlers/eks/watch_source_test.go
@@ -1,0 +1,62 @@
+package handlers_eks
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountWatchBuckets_ReturnsOnePerAccountBucket also pins the exclusion: a
+// bucket that is not an EKS account bucket must not be watched, or every write
+// anywhere in the cluster would wake the DNS reconcile.
+func TestAccountWatchBuckets_ReturnsOnePerAccountBucket(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+
+	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111", 1)
+	require.NoError(t, err)
+	_, err = GetOrCreateAccountBucket(t.Context(), js, "222222222222", 1)
+	require.NoError(t, err)
+	_, err = kvutil.GetOrCreateBucket(t.Context(), js, "something-else", 1)
+	require.NoError(t, err)
+
+	buckets, err := AccountWatchBuckets(t.Context(), nc)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(buckets))
+	for _, bucket := range buckets {
+		names = append(names, bucket.Name())
+	}
+	assert.ElementsMatch(t, []string{
+		AccountBucketName("111111111111"),
+		AccountBucketName("222222222222"),
+	}, names)
+}
+
+func TestAccountWatchBuckets_NoAccountsIsNotAnError(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+
+	buckets, err := AccountWatchBuckets(t.Context(), nc)
+	require.NoError(t, err, "a cluster with no EKS usage is not a failure")
+	assert.Empty(t, buckets)
+}
+
+// TestAccountWatchBuckets_BucketsAreWatchable closes the loop: the handles are
+// not merely named, they open against the live server.
+func TestAccountWatchBuckets_BucketsAreWatchable(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111", 1)
+	require.NoError(t, err)
+
+	buckets, err := AccountWatchBuckets(t.Context(), nc)
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+
+	watcher, err := buckets[0].Watch(t.Context(), ">")
+	require.NoError(t, err)
+	require.NoError(t, watcher.Stop())
+}

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -26,6 +26,7 @@ import (
 	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -1580,6 +1581,16 @@ func (s *ELBv2ServiceImpl) publishLBDNS(record *LoadBalancerRecord, action handl
 //
 // The daemon's reconcile loop calls this without a context, so the read runs on
 // the service lifetime context: the sweep should stop once the service closes.
+// DNSWatchBucket is the bucket behind DesiredDNSChanges, so the DNS reconcile
+// can be woken by a load-balancer change rather than poll for one. Nil when
+// there is no store to watch.
+func (s *ELBv2ServiceImpl) DNSWatchBucket() *kvstore.Bucket {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	return s.store.WatchBucket()
+}
+
 func (s *ELBv2ServiceImpl) DesiredDNSChanges() (changes []handlers_dns.Change, ok bool) {
 	if s == nil || s.store == nil || s.dnsBaseDomain == "" {
 		return nil, false

--- a/spinifex/handlers/elbv2/service_impl_test.go
+++ b/spinifex/handlers/elbv2/service_impl_test.go
@@ -3415,3 +3415,23 @@ func TestDescribeTags_UntaggedLoadBalancer(t *testing.T) {
 	assert.Equal(t, *lbOut.LoadBalancers[0].LoadBalancerArn, *out.TagDescriptions[0].ResourceArn)
 	assert.Empty(t, out.TagDescriptions[0].Tags)
 }
+
+// --- DNSWatchBucket ---
+
+func TestDNSWatchBucket_NilReceiver(t *testing.T) {
+	var svc *ELBv2ServiceImpl
+	assert.Nil(t, svc.DNSWatchBucket())
+}
+
+func TestDNSWatchBucket_NoStore(t *testing.T) {
+	svc := &ELBv2ServiceImpl{}
+	assert.Nil(t, svc.DNSWatchBucket())
+}
+
+func TestDNSWatchBucket_WithStore(t *testing.T) {
+	svc := setupTestService(t)
+
+	bucket := svc.DNSWatchBucket()
+	require.NotNil(t, bucket)
+	assert.Equal(t, KVBucketELBv2, bucket.Name())
+}

--- a/spinifex/handlers/elbv2/store.go
+++ b/spinifex/handlers/elbv2/store.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/migrate"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -208,6 +209,14 @@ func (s *Store) ListLoadBalancers(ctx context.Context) ([]*LoadBalancerRecord, e
 // complete inventory (the DNS reconcile prune authority requires the whole set).
 func (s *Store) ListLoadBalancersStrict(ctx context.Context) ([]*LoadBalancerRecord, error) {
 	return listByPrefixStrict[LoadBalancerRecord](ctx, s.kv, KeyPrefixLB)
+}
+
+// WatchBucket exposes the bucket so a reconciler can be woken by changes to it
+// rather than poll. The store shares one bucket across load balancers, target
+// groups, listeners and rules, so a caller wanting only one of those filters on
+// the corresponding key prefix.
+func (s *Store) WatchBucket() *kvstore.Bucket {
+	return kvstore.NewOpenBucket(s.kv, kvstore.Config{Name: KVBucketELBv2})
 }
 
 // GetLoadBalancerByArn finds a load balancer by the short ID in the ARN's final

--- a/spinifex/handlers/elbv2/store_test.go
+++ b/spinifex/handlers/elbv2/store_test.go
@@ -68,6 +68,21 @@ func newTestListener(id, lbArn string) *ListenerRecord {
 	}
 }
 
+// TestStore_WatchBucketOpensAWatchableHandle closes the loop: the returned
+// bucket is not merely named, it opens against the live server so the DNS
+// reconcile can actually be woken by a load-balancer change.
+func TestStore_WatchBucketOpensAWatchableHandle(t *testing.T) {
+	store := setupTestStore(t)
+
+	bucket := store.WatchBucket()
+	require.NotNil(t, bucket)
+	assert.Equal(t, KVBucketELBv2, bucket.Name())
+
+	watcher, err := bucket.Watch(t.Context(), KeyPrefixLB+"*")
+	require.NoError(t, err)
+	require.NoError(t, watcher.Stop())
+}
+
 func TestLoadBalancerStoreLifecycle(t *testing.T) {
 	t.Run("put and get", func(t *testing.T) {
 		store := setupTestStore(t)

--- a/spinifex/handlers/rds/store.go
+++ b/spinifex/handlers/rds/store.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/migrate"
 	"github.com/nats-io/nats.go"
@@ -252,6 +253,22 @@ func AccountBucketNames(ctx context.Context, js jetstream.JetStream) ([]string, 
 		}
 	}
 	return names, nil
+}
+
+// AccountWatchBuckets returns every per-account bucket as a watchable handle,
+// for a reconciler that must be woken by a cluster change rather than poll for
+// it. The set is re-read on each call because a new account's bucket appears
+// without notice: JetStream publishes no bucket-created event.
+func AccountWatchBuckets(ctx context.Context, js jetstream.JetStream) ([]*kvstore.Bucket, error) {
+	names, err := AccountBucketNames(ctx, js)
+	if err != nil {
+		return nil, err
+	}
+	buckets := make([]*kvstore.Bucket, 0, len(names))
+	for _, name := range names {
+		buckets = append(buckets, kvstore.NewBucket(js, kvstore.Config{Name: name, History: 1}))
+	}
+	return buckets, nil
 }
 
 // The account a per-account bucket belongs to, for callers that enumerated

--- a/spinifex/handlers/rds/watch_source_test.go
+++ b/spinifex/handlers/rds/watch_source_test.go
@@ -1,8 +1,10 @@
-package handlers_rds
+package handlers_rds_test
 
 import (
+	"context"
 	"testing"
 
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/stretchr/testify/assert"
@@ -16,14 +18,14 @@ func TestAccountWatchBuckets_ReturnsOnePerAccountBucket(t *testing.T) {
 	_, nc, _ := testutil.StartTestJetStream(t)
 	js := testutil.NewJetStream(t, nc)
 
-	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111")
+	_, err := handlers_rds.GetOrCreateAccountBucket(t.Context(), js, "111111111111")
 	require.NoError(t, err)
-	_, err = GetOrCreateAccountBucket(t.Context(), js, "222222222222")
+	_, err = handlers_rds.GetOrCreateAccountBucket(t.Context(), js, "222222222222")
 	require.NoError(t, err)
 	_, err = kvutil.GetOrCreateBucket(t.Context(), js, "something-else", 1)
 	require.NoError(t, err)
 
-	buckets, err := AccountWatchBuckets(t.Context(), js)
+	buckets, err := handlers_rds.AccountWatchBuckets(t.Context(), js)
 	require.NoError(t, err)
 
 	names := make([]string, 0, len(buckets))
@@ -31,8 +33,8 @@ func TestAccountWatchBuckets_ReturnsOnePerAccountBucket(t *testing.T) {
 		names = append(names, bucket.Name())
 	}
 	assert.ElementsMatch(t, []string{
-		AccountBucketName("111111111111"),
-		AccountBucketName("222222222222"),
+		handlers_rds.AccountBucketName("111111111111"),
+		handlers_rds.AccountBucketName("222222222222"),
 	}, names)
 }
 
@@ -40,7 +42,7 @@ func TestAccountWatchBuckets_NoAccountsIsNotAnError(t *testing.T) {
 	_, nc, _ := testutil.StartTestJetStream(t)
 	js := testutil.NewJetStream(t, nc)
 
-	buckets, err := AccountWatchBuckets(t.Context(), js)
+	buckets, err := handlers_rds.AccountWatchBuckets(t.Context(), js)
 	require.NoError(t, err, "a cluster with no RDS usage is not a failure")
 	assert.Empty(t, buckets)
 }
@@ -50,14 +52,28 @@ func TestAccountWatchBuckets_NoAccountsIsNotAnError(t *testing.T) {
 func TestAccountWatchBuckets_BucketsAreWatchable(t *testing.T) {
 	_, nc, _ := testutil.StartTestJetStream(t)
 	js := testutil.NewJetStream(t, nc)
-	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111")
+	_, err := handlers_rds.GetOrCreateAccountBucket(t.Context(), js, "111111111111")
 	require.NoError(t, err)
 
-	buckets, err := AccountWatchBuckets(t.Context(), js)
+	buckets, err := handlers_rds.AccountWatchBuckets(t.Context(), js)
 	require.NoError(t, err)
 	require.Len(t, buckets, 1)
 
 	watcher, err := buckets[0].Watch(t.Context(), ">")
 	require.NoError(t, err)
 	require.NoError(t, watcher.Stop())
+}
+
+// TestAccountWatchBuckets_EnumerationErrorPropagates guards against a bucket
+// listing failure being mistaken for "no accounts": a cancelled context makes
+// the underlying stream-names listing fail, and that failure must surface
+// rather than come back as an empty, and therefore prunable, set.
+func TestAccountWatchBuckets_EnumerationErrorPropagates(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := handlers_rds.AccountWatchBuckets(ctx, js)
+	require.Error(t, err)
 }

--- a/spinifex/handlers/rds/watch_source_test.go
+++ b/spinifex/handlers/rds/watch_source_test.go
@@ -1,0 +1,63 @@
+package handlers_rds
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountWatchBuckets_ReturnsOnePerAccountBucket also pins the exclusion: a
+// bucket that is not an RDS account bucket must not be watched, or every write
+// anywhere in the cluster would wake the DNS reconcile.
+func TestAccountWatchBuckets_ReturnsOnePerAccountBucket(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+
+	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111")
+	require.NoError(t, err)
+	_, err = GetOrCreateAccountBucket(t.Context(), js, "222222222222")
+	require.NoError(t, err)
+	_, err = kvutil.GetOrCreateBucket(t.Context(), js, "something-else", 1)
+	require.NoError(t, err)
+
+	buckets, err := AccountWatchBuckets(t.Context(), js)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(buckets))
+	for _, bucket := range buckets {
+		names = append(names, bucket.Name())
+	}
+	assert.ElementsMatch(t, []string{
+		AccountBucketName("111111111111"),
+		AccountBucketName("222222222222"),
+	}, names)
+}
+
+func TestAccountWatchBuckets_NoAccountsIsNotAnError(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+
+	buckets, err := AccountWatchBuckets(t.Context(), js)
+	require.NoError(t, err, "a cluster with no RDS usage is not a failure")
+	assert.Empty(t, buckets)
+}
+
+// TestAccountWatchBuckets_BucketsAreWatchable closes the loop: the handles are
+// not merely named, they open against the live server.
+func TestAccountWatchBuckets_BucketsAreWatchable(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	_, err := GetOrCreateAccountBucket(t.Context(), js, "111111111111")
+	require.NoError(t, err)
+
+	buckets, err := AccountWatchBuckets(t.Context(), js)
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+
+	watcher, err := buckets[0].Watch(t.Context(), ">")
+	require.NoError(t, err)
+	require.NoError(t, watcher.Stop())
+}

--- a/spinifex/reconciler/reconciler.go
+++ b/spinifex/reconciler/reconciler.go
@@ -84,6 +84,29 @@ func Fixed(bucket *kvstore.Bucket, filter string) Source {
 
 var _ Source = staticSource{}
 
+// dynamicSource enumerates its buckets afresh on every resync, for the resource
+// families that keep one bucket per account.
+type dynamicSource struct {
+	list   func(ctx context.Context) ([]*kvstore.Bucket, error)
+	filter string
+}
+
+func (s dynamicSource) Buckets(ctx context.Context) ([]*kvstore.Bucket, error) {
+	return s.list(ctx)
+}
+
+func (s dynamicSource) Filter() string { return s.filter }
+
+// Dynamic returns a Source whose bucket set is discovered rather than fixed.
+// JetStream has no bucket-created event, so discovery rides on the resync: a
+// bucket that appears is watched from the following cycle, and the pass that
+// cycle runs covers whatever it already held.
+func Dynamic(list func(ctx context.Context) ([]*kvstore.Bucket, error), filter string) Source {
+	return dynamicSource{list: list, filter: filter}
+}
+
+var _ Source = dynamicSource{}
+
 // Run reconciles once, then on every change and every resync until ctx is done.
 // It returns only when ctx is cancelled.
 func Run(ctx context.Context, cfg Config) {

--- a/spinifex/reconciler/reconciler_test.go
+++ b/spinifex/reconciler/reconciler_test.go
@@ -229,22 +229,20 @@ func TestRun_AFilterExcludesOtherKeys(t *testing.T) {
 	p.waitFor(t, 2, "the pass triggered by a write inside the filter")
 }
 
-// dynamicSource is the per-account bucket case: the set of buckets is not known
-// at startup and is re-read on every resync.
-type dynamicSource struct {
+// bucketSet backs a Dynamic source in the per-account bucket case: the set is
+// not known at startup and is re-read on every resync.
+type bucketSet struct {
 	mu      sync.Mutex
 	buckets []*kvstore.Bucket
 }
 
-func (s *dynamicSource) Buckets(context.Context) ([]*kvstore.Bucket, error) {
+func (s *bucketSet) list(context.Context) ([]*kvstore.Bucket, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]*kvstore.Bucket(nil), s.buckets...), nil
 }
 
-func (s *dynamicSource) Filter() string { return ">" }
-
-func (s *dynamicSource) add(b *kvstore.Bucket) {
+func (s *bucketSet) add(b *kvstore.Bucket) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.buckets = append(s.buckets, b)
@@ -259,13 +257,13 @@ func TestRun_ABucketAppearingAfterStartupIsPickedUp(t *testing.T) {
 	first := kvstore.New[record](js, kvstore.Config{Name: "reconciler-acct-a", History: 1})
 	second := kvstore.New[record](js, kvstore.Config{Name: "reconciler-acct-b", History: 1})
 
-	src := &dynamicSource{}
-	src.add(first.Bucket)
+	set := &bucketSet{}
+	set.add(first.Bucket)
 	p := newPasses()
 
 	run(t, reconciler.Config{
 		Name:      "dynamic",
-		Sources:   []reconciler.Source{src},
+		Sources:   []reconciler.Source{reconciler.Dynamic(set.list, ">")},
 		Reconcile: func(context.Context) error { p.record(); return nil },
 		Resync:    200 * time.Millisecond,
 	})
@@ -273,7 +271,7 @@ func TestRun_ABucketAppearingAfterStartupIsPickedUp(t *testing.T) {
 
 	// Force the second bucket into existence, then publish it to the source.
 	require.NoError(t, second.Set(t.Context(), "seed", &record{Name: "seed"}))
-	src.add(second.Bucket)
+	set.add(second.Bucket)
 
 	// One resync to discover it, then a write it must now notice.
 	before := p.now()


### PR DESCRIPTION
## Summary

The DNS pilot from `event-driven-reconciliation.md` (`mulga-bw2cw`): the drift backstop stops polling on a timer and converges when something actually changes. Second PR in the series, after #900 added the watch primitive and the loop.

Only the **trigger** changes. `reconcileOnce`, the leader election, `computeBatch`, `prunable` and the publish path are untouched, which is the whole regression argument — every existing test in `handlers/dns` passes unmodified.

## What the loop watches

`dnsDesiredSet` reads four sources, so the reconcile watches four things:

| Input | Bucket | Filter |
| --- | --- | --- |
| `desiredEC2DNSChanges` | `spinifex-instance-state` | `node.*` |
| ELBv2 | `spinifex-elbv2` | `lb.*` |
| EKS | per-account buckets | `>` |
| RDS | per-account buckets | `>` |

The ELBv2 filter matters: that bucket holds target groups, listeners, rules and name claims alongside load balancers, and a rule change is not a DNS change. The `node.*` filter is the coarse one — a per-node blob write says a VM on that host changed, not which — but that is sufficient here, because each pass rebuilds the entire desired set and consumes only the fact that something moved.

## Per-account buckets

EKS and RDS keep one bucket per account and JetStream publishes no bucket-created event, so `reconciler.Dynamic` re-enumerates on each resync and opens watches for buckets that have appeared. `AccountWatchBuckets` is added to both packages next to the existing `AccountBucketNames` enumerations they already relied on.

A new account's first cluster or DB instance is therefore picked up within one resync — the same bound the resync already guarantees for drift it cannot see at all.

## The interval

`DefaultReconcileInterval` moves from 60s to `reconciler.DefaultResync` (5 minutes), and its comment changes meaning: it is no longer the path by which a lifecycle event reaches DNS, it is the backstop for drift the watched buckets cannot report — a record edited directly in the zone object in S3, which cannot be watched at all.

Worth being explicit that this is a latency *improvement* despite the longer interval. Today a DNS repair waits up to 60 seconds for the next tick no matter when the change landed; now it waits for the debounce. The only case that gets slower is drift introduced outside KV, which is the case the interval exists for.

## Ordering

Watches are established before the first pass, not after — a change landing between the two would otherwise be invisible until the next resync. That is enforced in `reconciler.Run` itself (#900), so it is inherited here rather than re-implemented.

## Testing

`make preflight` — pass. `go test -race -count=1 ./spinifex/reconciler/ ./spinifex/handlers/dns/` — pass.

- Every existing `handlers/dns` test passes unchanged.
- `TestReconciler_RunReturnsWhenDisabled` pins the guard that lets the daemon start the loop unconditionally: without it, a disabled reconciler would enter the watch loop and block until shutdown rather than returning.
- `TestNewReconciler_RetainsItsWatchSources` covers the daemon's wiring, including that supplying no sources is legal — that is the interval-only behaviour this replaces.
- `AccountWatchBuckets` in both `eks` and `rds`: one handle per account bucket, an unrelated bucket is excluded (or every write anywhere in the cluster would wake DNS), no accounts is not an error, and the returned handles actually open a watcher against the live server.
- The dynamic-source test in `reconciler` now goes through the exported `Dynamic` constructor rather than a test-local implementation.

## Not in this PR

The quota sweep, which is the large traffic number. It needs the loop moved off the `DescribeInstances` fan-out and onto a direct read of instance state, and that read waits for the Phase 6 per-resource re-key and spec/status split — before then it would need a freshness check to keep quota's raise-but-never-lower invariant safe against a partitioned node's stale blob. Recorded in the plan.
