### PR TITLE
fix: keep a node's instances when its KV record is absent at boot

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2180,12 +2180,14 @@ func (d *Daemon) leakedVolumeInstances() (map[string]bool, error) {
 }
 
 // nodeRunningVMs returns this node's running VMs for the EKS billable reaper to
-// scan. A nil stateStore (early init / test) yields an empty set.
+// scan. A nil stateStore (early init / test) yields an empty set. The reaper
+// only ever acts on VMs in this list, so a missing record fails closed and the
+// absence flag adds nothing.
 func (d *Daemon) nodeRunningVMs() ([]*vm.VM, error) {
 	if d.stateStore == nil {
 		return nil, nil
 	}
-	running, err := d.stateStore.LoadRunningState(d.node)
+	running, _, err := d.stateStore.LoadRunningState(d.node)
 	if err != nil {
 		return nil, err
 	}

--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -532,37 +532,40 @@ func marshalInstanceState(vms map[string]*vm.VM) ([]byte, error) {
 }
 
 // LoadState loads the instance state from the KV store for the given node.
-// Returns an empty (non-nil) map when no state exists for the node.
-func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, error) {
+// The bool reports whether a record exists at all. A node that has never
+// written state and a node whose record was lost both read as empty, and a
+// caller that would drop instances on the strength of that must tell them
+// apart.
+func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, bool, error) {
 	if m.kv == nil {
-		return nil, errors.New("KV bucket not initialized")
+		return nil, false, errors.New("KV bucket not initialized")
 	}
 
 	key := InstanceStatePrefix + nodeID
 	entry, err := m.kv.Get(context.Background(), key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			slog.Debug("No existing state in JetStream KV, returning empty state", "key", key)
-			return make(map[string]*vm.VM), nil
+			slog.Debug("No existing state in JetStream KV", "key", key)
+			return make(map[string]*vm.VM), false, nil
 		}
 		if isStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "LoadState", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
-				return nil, err
+				return nil, false, err
 			}
 			// Retry the read — if we reconnected, data may still exist
 			entry, err = kv.Get(context.Background(), key)
 			if err != nil {
 				if errors.Is(err, jetstream.ErrKeyNotFound) {
 					slog.Warn("No state found after KV recovery", "key", key)
-					return make(map[string]*vm.VM), nil
+					return make(map[string]*vm.VM), false, nil
 				}
-				return nil, err
+				return nil, false, err
 			}
 			// Fall through to unmarshal below
 		} else {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
@@ -570,14 +573,14 @@ func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, error) {
 		VMS map[string]*vm.VM `json:"vms"`
 	}
 	if err := json.Unmarshal(entry.Value(), &state); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if state.VMS == nil {
 		state.VMS = make(map[string]*vm.VM)
 	}
 
 	slog.Debug("Loaded state from JetStream KV", "key", key, "instances", len(state.VMS))
-	return state.VMS, nil
+	return state.VMS, true, nil
 }
 
 // DeleteState removes the instance state from the KV store for the given node.

--- a/spinifex/daemon/jetstream_test.go
+++ b/spinifex/daemon/jetstream_test.go
@@ -52,8 +52,9 @@ func TestJetStreamManager_WriteAndLoadState(t *testing.T) {
 	require.NoError(t, err, "Failed to write state")
 
 	// Load state
-	loadedInstances, err := jsm.LoadState(testNodeID)
+	loadedInstances, found, err := jsm.LoadState(testNodeID)
 	require.NoError(t, err, "Failed to load state")
+	require.True(t, found, "A node that has written state has a record")
 	require.NotNil(t, loadedInstances, "Loaded instances should not be nil")
 
 	// Verify the loaded state matches
@@ -81,8 +82,9 @@ func TestJetStreamManager_LoadState_KeyNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load state for a non-existent node
-	instances, err := jsm.LoadState("non-existent-node")
+	instances, found, err := jsm.LoadState("non-existent-node")
 	require.NoError(t, err, "Should not error when key not found")
+	assert.False(t, found, "A node with no record must be distinguishable from one running nothing")
 	require.NotNil(t, instances, "Should return non-nil instances")
 	assert.Empty(t, instances, "Should return empty VMS map")
 }
@@ -144,8 +146,9 @@ func TestJetStreamManager_BucketReconnection(t *testing.T) {
 	require.NoError(t, err, "Second InitKVBucket should succeed (reconnect)")
 
 	// Verify data persisted
-	loadedInstances, err := jsm2.LoadState("persist-node")
+	loadedInstances, found, err := jsm2.LoadState("persist-node")
 	require.NoError(t, err)
+	assert.True(t, found)
 	assert.NotEmpty(t, loadedInstances, "Should have persisted instances")
 	assert.NotNil(t, loadedInstances["i-persist"], "Should have i-persist")
 	assert.Equal(t, vm.StateRunning, loadedInstances["i-persist"].Status)
@@ -177,8 +180,9 @@ func TestJetStreamManager_DeleteState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify state exists
-	loadedInstances, err := jsm.LoadState(testNodeID)
+	loadedInstances, found, err := jsm.LoadState(testNodeID)
 	require.NoError(t, err)
+	assert.True(t, found)
 	assert.NotEmpty(t, loadedInstances)
 
 	// Delete state
@@ -186,8 +190,9 @@ func TestJetStreamManager_DeleteState(t *testing.T) {
 	require.NoError(t, err, "Should delete state without error")
 
 	// Verify state is gone (should return empty state)
-	loadedInstances, err = jsm.LoadState(testNodeID)
+	loadedInstances, found, err = jsm.LoadState(testNodeID)
 	require.NoError(t, err)
+	assert.False(t, found, "A deleted record reads as absent, not as an empty one")
 	assert.Empty(t, loadedInstances, "Should return empty state after deletion")
 }
 
@@ -251,7 +256,7 @@ func TestJetStreamManager_WriteState_UpdateExisting(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load and verify updated state
-	loadedInstances, err := jsm.LoadState(testNodeID)
+	loadedInstances, _, err := jsm.LoadState(testNodeID)
 	require.NoError(t, err)
 	assert.Len(t, loadedInstances, 2, "Should have 2 instances")
 	assert.Equal(t, vm.StateStopped, loadedInstances["i-initial"].Status, "Status should be updated")
@@ -288,13 +293,13 @@ func TestJetStreamManager_MultipleNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load and verify node-1 state
-	loadedNode1, err := jsm.LoadState("node-1")
+	loadedNode1, _, err := jsm.LoadState("node-1")
 	require.NoError(t, err)
 	assert.Len(t, loadedNode1, 1)
 	assert.NotNil(t, loadedNode1["i-node1-001"])
 
 	// Load and verify node-2 state
-	loadedNode2, err := jsm.LoadState("node-2")
+	loadedNode2, _, err := jsm.LoadState("node-2")
 	require.NoError(t, err)
 	assert.Len(t, loadedNode2, 2)
 	assert.NotNil(t, loadedNode2["i-node2-001"])
@@ -321,7 +326,7 @@ func TestJetStreamManager_KVNotInitialized(t *testing.T) {
 	err = jsm.WriteState("test-node", testInstances)
 	assert.Error(t, err, "WriteState should error when KV not initialized")
 
-	_, err = jsm.LoadState("test-node")
+	_, _, err = jsm.LoadState("test-node")
 	assert.Error(t, err, "LoadState should error when KV not initialized")
 
 	err = jsm.DeleteState("test-node")
@@ -722,7 +727,7 @@ func TestJetStreamManager_StoppedInstances_NoInterference(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify per-node state is unaffected
-	loaded, err := jsm.LoadState("interference-test-node")
+	loaded, _, err := jsm.LoadState("interference-test-node")
 	require.NoError(t, err)
 	assert.Len(t, loaded, 1)
 	assert.NotNil(t, loaded["i-running-001"])
@@ -877,7 +882,7 @@ func TestJetStreamManager_WriteState_RecoverAfterStreamLost(t *testing.T) {
 	require.NoError(t, err, "WriteState should recover after stream loss")
 
 	// Verify data was written
-	loaded, err := jsm.LoadState("recovery-node")
+	loaded, _, err := jsm.LoadState("recovery-node")
 	require.NoError(t, err)
 	assert.Len(t, loaded, 1)
 	assert.NotNil(t, loaded["i-recover-001"])
@@ -896,8 +901,9 @@ func TestJetStreamManager_LoadState_RecoverAfterStreamLost(t *testing.T) {
 	deleteInstanceStateBucket(t, nc)
 
 	// LoadState should recover and return empty state
-	loaded, err := jsm.LoadState("any-node")
+	loaded, found, err := jsm.LoadState("any-node")
 	require.NoError(t, err, "LoadState should recover after stream loss")
+	assert.False(t, found, "A bucket recreated by recovery holds no record for the node")
 	assert.Empty(t, loaded)
 }
 
@@ -1045,7 +1051,7 @@ func TestJetStreamManager_LoadState_RecoveryFailure(t *testing.T) {
 	deleteInstanceStateBucket(t, nc)
 	swapToNonJSContext(t, jsm)
 
-	loaded, err := jsm.LoadState("fail-node")
+	loaded, _, err := jsm.LoadState("fail-node")
 	assert.Error(t, err, "LoadState should return error when recovery fails")
 	assert.Nil(t, loaded)
 }

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -592,6 +592,121 @@ func simulateCleanRestore(t *testing.T, daemon *Daemon) {
 	daemon.vmMgr.Restore()
 }
 
+// TestRestoreInstances_LocalRecordSurvivesMissingKVKey pins the boot-path
+// precedence. startLocal loads the local file, then startCluster's restore
+// pulls from KV. An absent KV key means "this node has no record here", which
+// is not the same as "this node has no instances".
+func TestRestoreInstances_LocalRecordSurvivesMissingKVKey(t *testing.T) {
+	daemon := createDaemonWithJetStream(t)
+
+	// StateError is the one status classifyRestoredInstances leaves untouched,
+	// keeping this test on the load path rather than the relaunch machinery.
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:     "i-survivor",
+		Status: vm.StateError,
+	})
+	require.NoError(t, daemon.WriteState())
+
+	// The node's KV record disappears: bucket recreated by recoverKVBucket,
+	// purged, or lost with its raft group. The local file still has it.
+	require.NoError(t, daemon.jsManager.DeleteState(daemon.node))
+
+	// Fresh process, then the real boot order.
+	daemon.vmMgr.Replace(map[string]*vm.VM{})
+	require.NoError(t, daemon.LoadState())
+	require.Equal(t, 1, daemon.vmMgr.Count(), "local file should carry the instance into boot")
+
+	require.NoError(t, daemon.jsManager.WriteShutdownMarker(daemon.node))
+	require.NoError(t, daemon.restoreInstances())
+
+	_, ok := daemon.vmMgr.Get("i-survivor")
+	assert.True(t, ok, "an instance held locally and absent from KV must survive restore")
+
+	state, err := ReadLocalState(daemon.localStatePath())
+	require.NoError(t, err)
+	require.NotNil(t, state, "local state file must still exist after restore")
+	assert.Contains(t, state.VMS, "i-survivor",
+		"restore must not write a KV-derived empty map over the local file")
+}
+
+// TestRestoreInstances_MissingKVKeyRepublishesLocalRecord is the other half of
+// the partition-recovery case: surviving the read is not enough, the node has
+// to put its record back so the rest of the cluster can see it again.
+func TestRestoreInstances_MissingKVKeyRepublishesLocalRecord(t *testing.T) {
+	daemon := createDaemonWithJetStream(t)
+
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:     "i-republish",
+		Status: vm.StateError,
+	})
+	require.NoError(t, daemon.WriteState())
+	require.NoError(t, daemon.jsManager.DeleteState(daemon.node))
+
+	daemon.vmMgr.Replace(map[string]*vm.VM{})
+	require.NoError(t, daemon.LoadState())
+
+	require.NoError(t, daemon.jsManager.WriteShutdownMarker(daemon.node))
+	require.NoError(t, daemon.restoreInstances())
+
+	republished, found, err := daemon.jsManager.LoadState(daemon.node)
+	require.NoError(t, err)
+	require.True(t, found, "the node must write a record back, not leave the key absent")
+	assert.Contains(t, republished, "i-republish",
+		"the node must republish its own record after finding KV missing it")
+}
+
+// TestRestoreInstances_ClusterRecordWinsForSharedInstance keeps the merge from
+// becoming a licence to ignore the cluster: where both stores hold the same
+// instance, the published record is still the one that applies.
+func TestRestoreInstances_ClusterRecordWinsForSharedInstance(t *testing.T) {
+	daemon := createDaemonWithJetStream(t)
+
+	daemon.vmMgr.Insert(&vm.VM{ID: "i-shared", Status: vm.StateError, InstanceType: "t3.micro"})
+	daemon.vmMgr.Insert(&vm.VM{ID: "i-local-only", Status: vm.StateError})
+	require.NoError(t, daemon.WriteState())
+
+	// The cluster record covers only i-shared, and disagrees about it.
+	require.NoError(t, daemon.jsManager.WriteState(daemon.node, map[string]*vm.VM{
+		"i-shared": {ID: "i-shared", Status: vm.StateError, InstanceType: "t3.small"},
+	}))
+
+	daemon.vmMgr.Replace(map[string]*vm.VM{})
+	require.NoError(t, daemon.LoadState())
+	require.NoError(t, daemon.jsManager.WriteShutdownMarker(daemon.node))
+	require.NoError(t, daemon.restoreInstances())
+
+	shared, ok := daemon.vmMgr.Get("i-shared")
+	require.True(t, ok)
+	assert.Equal(t, "t3.small", shared.InstanceType,
+		"the cluster record wins where both stores hold the instance")
+
+	_, ok = daemon.vmMgr.Get("i-local-only")
+	assert.True(t, ok, "an instance the cluster record omits is still this node's to keep")
+}
+
+// TestRestoreInstances_StaleLocalTerminatedRecordIsMigrated pins the
+// self-healing half. Keeping a record the cluster dropped can revive a stale
+// terminal entry, so classification must still retire it.
+func TestRestoreInstances_StaleLocalTerminatedRecordIsMigrated(t *testing.T) {
+	daemon := createDaemonWithJetStream(t)
+
+	daemon.vmMgr.Insert(&vm.VM{ID: "i-stale-terminated", Status: vm.StateTerminated})
+	require.NoError(t, daemon.WriteState())
+	require.NoError(t, daemon.jsManager.DeleteState(daemon.node))
+
+	daemon.vmMgr.Replace(map[string]*vm.VM{})
+	require.NoError(t, daemon.LoadState())
+	require.NoError(t, daemon.jsManager.WriteShutdownMarker(daemon.node))
+	require.NoError(t, daemon.restoreInstances())
+
+	_, ok := daemon.vmMgr.Get("i-stale-terminated")
+	assert.False(t, ok, "a terminated record survives the merge only to be migrated out of it")
+
+	terminated, err := daemon.jsManager.LoadTerminatedInstance("i-stale-terminated")
+	require.NoError(t, err)
+	require.NotNil(t, terminated, "the revived record must land in the terminated bucket")
+}
+
 // TestRestoreInstances_StoppingFinalizedToStopped verifies that an instance
 // stuck in StateStopping when the daemon died gets finalized to StateStopped
 // and migrated to shared KV.
@@ -915,7 +1030,7 @@ func TestStatePersistence_RoundTrip(t *testing.T) {
 
 	// Simulate restart: clear and reload.
 	daemon.vmMgr.Replace(map[string]*vm.VM{})
-	snapshot, err := daemon.jsManager.LoadState(daemon.node)
+	snapshot, _, err := daemon.jsManager.LoadState(daemon.node)
 	require.NoError(t, err)
 	daemon.vmMgr.Replace(snapshot)
 

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -43,7 +43,7 @@ func (a *stateStoreAdapter) SaveRunningState(nodeID string, snapshot map[string]
 	return a.js.WriteState(nodeID, snapshot)
 }
 
-func (a *stateStoreAdapter) LoadRunningState(nodeID string) (map[string]*vm.VM, error) {
+func (a *stateStoreAdapter) LoadRunningState(nodeID string) (map[string]*vm.VM, bool, error) {
 	return a.js.LoadState(nodeID)
 }
 

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -271,11 +271,20 @@ func (m *Manager) View(fn func(map[string]*VM)) {
 	fn(m.vms)
 }
 
-// Replace bulk-resets the manager to the given VMs (copied). Used by Restore.
+// Replace bulk-resets the manager to the given VMs (copied).
 func (m *Manager) Replace(vms map[string]*VM) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.vms = make(map[string]*VM, len(vms))
+	maps.Copy(m.vms, vms)
+}
+
+// AdoptClusterState folds the cluster's published snapshot over the running
+// set, keeping records the cluster has no copy of. Used by Restore: an entry
+// only this node holds is a record to republish, not one to delete.
+func (m *Manager) AdoptClusterState(vms map[string]*VM) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	maps.Copy(m.vms, vms)
 }
 

--- a/spinifex/vm/manager_deps_test.go
+++ b/spinifex/vm/manager_deps_test.go
@@ -41,13 +41,13 @@ func (f *fakeStateStore) SaveRunningState(nodeID string, snap map[string]*VM) er
 	return nil
 }
 
-func (f *fakeStateStore) LoadRunningState(nodeID string) (map[string]*VM, error) {
+func (f *fakeStateStore) LoadRunningState(nodeID string) (map[string]*VM, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if v, ok := f.saved[nodeID]; ok {
-		return v, nil
+		return v, true, nil
 	}
-	return map[string]*VM{}, nil
+	return map[string]*VM{}, false, nil
 }
 
 func (f *fakeStateStore) WriteStoppedInstance(id string, v *VM) error {

--- a/spinifex/vm/mock/mock.go
+++ b/spinifex/vm/mock/mock.go
@@ -97,13 +97,13 @@ func (s *StateStore) SaveRunningState(nodeID string, snap map[string]*vm.VM) err
 	return nil
 }
 
-func (s *StateStore) LoadRunningState(nodeID string) (map[string]*vm.VM, error) {
+func (s *StateStore) LoadRunningState(nodeID string) (map[string]*vm.VM, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if v, ok := s.Saved[nodeID]; ok {
-		return v, nil
+		return v, true, nil
 	}
-	return map[string]*vm.VM{}, nil
+	return map[string]*vm.VM{}, false, nil
 }
 
 func (s *StateStore) WriteStoppedInstance(id string, v *vm.VM) error {

--- a/spinifex/vm/restore.go
+++ b/spinifex/vm/restore.go
@@ -76,17 +76,23 @@ func (m *Manager) Restore() {
 	m.reportRecordlessQEMUOrphans()
 }
 
-// loadRunningState replaces the manager's running set from the persisted snapshot.
-// A missing key returns an empty map and no error.
+// loadRunningState folds the cluster's snapshot into the running set, which by
+// this point already holds whatever the node's own state file carried in. With
+// no cluster record at all there is nothing to fold and the local set stands.
 func (m *Manager) loadRunningState() error {
 	if m.deps.StateStore == nil {
 		return fmt.Errorf("StateStore not wired")
 	}
-	loaded, err := m.deps.StateStore.LoadRunningState(m.deps.NodeID)
+	loaded, found, err := m.deps.StateStore.LoadRunningState(m.deps.NodeID)
 	if err != nil {
 		return err
 	}
-	m.Replace(loaded)
+	if !found {
+		slog.Warn("No cluster record for this node, keeping local instance state",
+			"node", m.deps.NodeID, "instances", m.Count())
+		return nil
+	}
+	m.AdoptClusterState(loaded)
 	return nil
 }
 

--- a/spinifex/vm/restore_test.go
+++ b/spinifex/vm/restore_test.go
@@ -370,11 +370,11 @@ type markerStateStore struct {
 	snapshot  map[string]*VM
 }
 
-func (s *markerStateStore) LoadRunningState(string) (map[string]*VM, error) {
+func (s *markerStateStore) LoadRunningState(string) (map[string]*VM, bool, error) {
 	s.loadCalls.Add(1)
 	out := make(map[string]*VM, len(s.snapshot))
 	maps.Copy(out, s.snapshot)
-	return out, nil
+	return out, true, nil
 }
 
 // TestRestore_HappyPath exercises Restore's clean-shutdown branch end-

--- a/spinifex/vm/shutdown_test.go
+++ b/spinifex/vm/shutdown_test.go
@@ -1325,8 +1325,8 @@ func (s *signalingStore) SaveRunningState(string, map[string]*VM) error {
 	}
 	return nil
 }
-func (s *signalingStore) LoadRunningState(string) (map[string]*VM, error) {
-	return map[string]*VM{}, nil
+func (s *signalingStore) LoadRunningState(string) (map[string]*VM, bool, error) {
+	return map[string]*VM{}, true, nil
 }
 func (s *signalingStore) WriteStoppedInstance(string, *VM) error  { return nil }
 func (s *signalingStore) LoadStoppedInstance(string) (*VM, error) { return nil, nil }

--- a/spinifex/vm/state_store.go
+++ b/spinifex/vm/state_store.go
@@ -8,9 +8,11 @@ type StateStore interface {
 	// given node. The supplied map is owned by the caller and must not be
 	// retained.
 	SaveRunningState(nodeID string, snapshot map[string]*VM) error
-	// LoadRunningState returns the VMs persisted for the given node. An
-	// empty (non-nil) map is returned when no state exists.
-	LoadRunningState(nodeID string) (map[string]*VM, error)
+	// LoadRunningState returns the VMs persisted for the given node. The
+	// bool reports whether a record exists: "no record" and "a record
+	// holding no instances" both come back as an empty map, and only the
+	// second is evidence that the node runs nothing.
+	LoadRunningState(nodeID string) (map[string]*VM, bool, error)
 
 	WriteStoppedInstance(id string, v *VM) error
 	LoadStoppedInstance(id string) (*VM, error)


### PR DESCRIPTION
## Summary

A node that boots with a local instance-state file and no matching JetStream KV record loses every instance in that file, on disk as well as in memory. This makes absence readable and stops the boot path resolving the conflict by deletion.

The bug is reproduced first, as a test, and the test is in the diff.

## The bug

Boot runs in two stages:

```
startLocal    daemon.go:1372   d.LoadState()      -> vmMgr.Replace(localFile.VMS)
startCluster  daemon.go:2413   d.vmMgr.Restore()  -> loadRunningState() -> m.Replace(kvBlob)
                               d.WriteState()     -> writes the KV-derived map back over the local file
```

`LoadState` flattened `ErrKeyNotFound` into an empty map with a nil error, so "this node has no record in KV" and "this node runs nothing" were the same value. `Replace` then wiped the map the local file had just populated, and `WriteState` persisted the wipe.

`recoverKVBucket` recreates the bucket on stream loss, so an empty bucket under a node that has instances is reachable, not theoretical.

The new test's log is the whole finding:

```
INFO Loaded local state path=.../instance-state.json instances=1
INFO Clean shutdown marker found, trusting KV state
INFO Loaded state "instance count"=0
```

The DDIL Tier 1 commit `6c54a6790` states the local file is the source of truth. `vm.Manager.Restore` was never converted to match.

## Changes

**Absence is not empty.** `JetStreamManager.LoadState` and `vm.StateStore.LoadRunningState` return `(map, found bool, err error)`. Both the first read and the post-recovery retry report `found = false` on `ErrKeyNotFound` rather than returning a bare empty map.

**Boot merges instead of replacing.** `Manager.loadRunningState` keeps the local set untouched when there is no cluster record at all, and otherwise folds the published snapshot over it via the new `Manager.AdoptClusterState`. An instance the local file holds and KV does not now survives, and `Restore`'s existing closing `writeRunningState` republishes it — which is the partition-recovery case.

`Replace` is unchanged and still used elsewhere.

## Scope

This is a **presence-level** merge. Where both stores hold an instance the KV record still wins wholesale, exactly as `Replace` did. The field-level spec/status split the plan describes needs that split to exist first, which is Phase 6 of `declarative-control-plane.md`; inventing the boundary inside a merge helper now would only mean moving it later. The deletion bug does not need it.

The union's own risk is a stale local record the cluster correctly dropped, which the merge revives. That case self-heals: an instance only leaves the running set after a terminal status is set, so classification re-migrates the revived record on the same pass. `TestRestoreInstances_StaleLocalTerminatedRecordIsMigrated` pins it.

## Testing

Four new tests in `daemon/state_test.go`, all driving the real boot order (`LoadState` -> `restoreInstances`) against an in-process JetStream:

| Test | Pins |
| --- | --- |
| `LocalRecordSurvivesMissingKVKey` | The instance stays in the map and in the local file |
| `MissingKVKeyRepublishesLocalRecord` | The node writes its record back to KV |
| `ClusterRecordWinsForSharedInstance` | KV still wins where both stores hold the instance |
| `StaleLocalTerminatedRecordIsMigrated` | A revived terminal record is retired, not resurrected |

The first two fail on `dev` and pass here.

`daemon/jetstream_test.go` now asserts the `found` flag at the three readings that carry meaning: a node that never wrote, a node whose key was deleted, and a bucket recreated by `recoverKVBucket`.

**Every existing `TestRestoreInstances_*` passes unedited.** They clear the in-memory map before restoring, so their merge runs against an empty local set and reduces to the old `Replace`. Nothing had to be reworded to go green, which is the point: none of them had encoded the bug as intended behaviour.

`daemon/disconnect_test.go` and the `vm` invariant suites pass unchanged. `make preflight` passes.

## Why not verified on a live cluster

It was attempted on env19 first and abandoned. There is no way to delete a single JetStream KV key on a running cluster: no `nats` CLI on the nodes, no `spx admin kv`, and the `:8222` endpoints are read-only. The remaining option was hand-rolling a raw JetStream protocol delete against a live three-node raft group, which is not a reasonable thing to do to reproduce a bug. Raised as `mulga-uqe78`. The Go test is the better regression guard regardless.

## Follow-ups

Changes 3–5 of `docs/development/josh/improvements/instance-state-authority.md`, each its own PR: routing `writeRunningState` through the shared persist path (the twelve KV-only write paths), adopting `kvstore.Store[T]` for instance state, and converging the three record envelopes.

Bead: `mulga-gsz70`.
