### PR TITLE
fix: route every running-state write through the local file

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2261,7 +2261,7 @@ func (d *Daemon) initJetStream() error {
 		retryDelay = min(retryDelay*2, 10*time.Second)
 	}
 
-	d.stateStore = newStateStoreAdapter(d.jsManager)
+	d.stateStore = newStateStoreAdapter(d.jsManager, d.persistState)
 
 	return nil
 }
@@ -2584,22 +2584,28 @@ func (d *Daemon) localStatePath() string {
 // WriteState persists instance state. Local file is the source of truth; KV is
 // best-effort. Both forms are marshalled inside vmMgr.View to avoid data races.
 func (d *Daemon) WriteState() error {
+	var err error
+	d.vmMgr.View(func(vms map[string]*vm.VM) {
+		err = d.persistState(d.node, vms)
+	})
+	return err
+}
+
+// persistState is the single path both stores move through: every caller that
+// changes the running set reaches it, so the file cannot fall behind the map.
+// Callers hold the manager lock, so vms cannot change mid-encode; the two locks
+// are always taken manager-first to keep one order across every writer.
+func (d *Daemon) persistState(nodeID string, vms map[string]*vm.VM) error {
 	d.stateWriteMu.Lock()
 	defer d.stateWriteMu.Unlock()
 
-	var (
-		localData, kvData []byte
-		marshalErr        error
-	)
-	d.vmMgr.View(func(vms map[string]*vm.VM) {
-		localData, marshalErr = MarshalLocalState(vms)
-		if marshalErr != nil {
-			return
-		}
-		kvData, marshalErr = marshalInstanceState(vms)
-	})
-	if marshalErr != nil {
-		return fmt.Errorf("marshal state: %w", marshalErr)
+	localData, err := MarshalLocalState(vms)
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	kvData, err := marshalInstanceState(vms)
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
 	}
 
 	// The KV write is independent of local disk health (JetStream, not this
@@ -2615,7 +2621,7 @@ func (d *Daemon) WriteState() error {
 	}
 
 	if d.jsManager != nil {
-		d.jsManager.WriteStateBytesBestEffort(d.node, kvData, kvSyncTimeout)
+		d.jsManager.WriteStateBytesBestEffort(nodeID, kvData, kvSyncTimeout)
 	}
 
 	if localErr != nil {

--- a/spinifex/daemon/daemon_handlers_test.go
+++ b/spinifex/daemon/daemon_handlers_test.go
@@ -118,7 +118,7 @@ func createFullTestDaemonWithJetStream(t *testing.T, natsURL string) *Daemon {
 	require.NoError(t, err)
 	err = daemon.jsManager.InitTerminatedInstanceBucket()
 	require.NoError(t, err)
-	daemon.stateStore = newStateStoreAdapter(daemon.jsManager)
+	daemon.stateStore = newStateStoreAdapter(daemon.jsManager, daemon.persistState)
 
 	// Re-bind the instance service so describe-stopped/terminated handlers see
 	// the KV that was just initialised.

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -1695,7 +1695,7 @@ func TestTerminatedTeardownReaper_SelfHealsFailedVolumeTeardown(t *testing.T) {
 	jsManager, err := NewJetStreamManager(daemon.natsConn, 1)
 	require.NoError(t, err)
 	require.NoError(t, jsManager.InitTerminatedInstanceBucket())
-	daemon.stateStore = newStateStoreAdapter(jsManager)
+	daemon.stateStore = newStateStoreAdapter(jsManager, daemon.persistState)
 
 	// DeleteVolume's snapshot-reference guard requires a non-nil snapshotKV.
 	js, err := jetstream.New(daemon.natsConn)

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
@@ -45,7 +46,7 @@ func createDaemonWithJetStream(t *testing.T) *Daemon {
 	require.NoError(t, daemon.jsManager.InitKVBucket())
 	require.NoError(t, daemon.jsManager.InitClusterStateBucket())
 	require.NoError(t, daemon.jsManager.InitTerminatedInstanceBucket())
-	daemon.stateStore = newStateStoreAdapter(daemon.jsManager)
+	daemon.stateStore = newStateStoreAdapter(daemon.jsManager, daemon.persistState)
 
 	// Wire just enough vm.Deps for manager-driven state operations to work
 	// (migrate, MarkFailed, Restore classification). Full wiring (network
@@ -590,6 +591,97 @@ func simulateCleanRestore(t *testing.T, daemon *Daemon) {
 	t.Helper()
 	require.NoError(t, daemon.jsManager.WriteShutdownMarker(daemon.node))
 	daemon.vmMgr.Restore()
+}
+
+// TestUpdateAndPersist_MutationsReachTheLocalFile covers the API mutations of a
+// running instance at their shared choke point. Each case mirrors the mutation a
+// real handler applies; all of them used to persist to KV alone, leaving the
+// file to whatever a later, unrelated writer happened to flush.
+func TestUpdateAndPersist_MutationsReachTheLocalFile(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*vm.VM)
+		verify func(*testing.T, *vm.VM)
+	}{
+		{
+			name:   "associate IAM instance profile",
+			mutate: func(v *vm.VM) { v.IamInstanceProfileArn = "arn:aws:iam::000000000000:instance-profile/app" },
+			verify: func(t *testing.T, v *vm.VM) {
+				assert.Equal(t, "arn:aws:iam::000000000000:instance-profile/app", v.IamInstanceProfileArn)
+			},
+		},
+		{
+			name: "modify instance attribute",
+			mutate: func(v *vm.VM) {
+				v.RunInstancesInput = &ec2.RunInstancesInput{DisableApiTermination: aws.Bool(true)}
+			},
+			verify: func(t *testing.T, v *vm.VM) {
+				require.NotNil(t, v.RunInstancesInput)
+				assert.Equal(t, aws.Bool(true), v.RunInstancesInput.DisableApiTermination)
+			},
+		},
+		{
+			name: "set instance monitoring",
+			mutate: func(v *vm.VM) {
+				v.RunInstancesInput = &ec2.RunInstancesInput{
+					Monitoring: &ec2.RunInstancesMonitoringEnabled{Enabled: aws.Bool(true)},
+				}
+			},
+			verify: func(t *testing.T, v *vm.VM) {
+				require.NotNil(t, v.RunInstancesInput)
+				require.NotNil(t, v.RunInstancesInput.Monitoring)
+				assert.Equal(t, aws.Bool(true), v.RunInstancesInput.Monitoring.Enabled)
+			},
+		},
+		{
+			name: "set instance tags",
+			mutate: func(v *vm.VM) {
+				v.Instance = &ec2.Instance{
+					Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("web")}},
+				}
+			},
+			verify: func(t *testing.T, v *vm.VM) {
+				require.NotNil(t, v.Instance)
+				require.Len(t, v.Instance.Tags, 1)
+				assert.Equal(t, "web", aws.StringValue(v.Instance.Tags[0].Value))
+			},
+		},
+		{
+			name: "set spot lineage",
+			mutate: func(v *vm.VM) {
+				v.InstanceLifecycle = ec2.InstanceLifecycleTypeSpot
+				v.SpotInstanceRequestId = "sir-abc"
+			},
+			verify: func(t *testing.T, v *vm.VM) {
+				assert.Equal(t, ec2.InstanceLifecycleTypeSpot, v.InstanceLifecycle)
+				assert.Equal(t, "sir-abc", v.SpotInstanceRequestId)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			daemon := createDaemonWithJetStream(t)
+			daemon.vmMgr.Insert(&vm.VM{ID: "i-mutate", Status: vm.StateRunning})
+			require.NoError(t, daemon.WriteState())
+
+			found, err := daemon.vmMgr.UpdateAndPersist("i-mutate", func(v *vm.VM) bool {
+				tt.mutate(v)
+				return true
+			})
+			require.NoError(t, err)
+			require.True(t, found)
+
+			// Read the file directly: no second writer runs in between, so
+			// anything missing here is a write path that skipped it.
+			state, err := ReadLocalState(daemon.localStatePath())
+			require.NoError(t, err)
+			require.NotNil(t, state)
+			persisted, ok := state.VMS["i-mutate"]
+			require.True(t, ok, "the mutated instance must be in the local file")
+			tt.verify(t, persisted)
+		})
+	}
 }
 
 // TestRestoreInstances_LocalRecordSurvivesMissingKVKey pins the boot-path

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -28,19 +28,22 @@ import (
 )
 
 // stateStoreAdapter satisfies vm.StateStore by delegating to JetStreamManager.
-// Tolerates nil JetStreamManager during early boot.
+// Tolerates nil JetStreamManager during early boot. The running set is the one
+// exception: it goes through the daemon's persist path so that the local file,
+// not just KV, sees every change the vm package makes.
 type stateStoreAdapter struct {
-	js *JetStreamManager
+	js      *JetStreamManager
+	persist func(nodeID string, vms map[string]*vm.VM) error
 }
 
 var _ vm.StateStore = (*stateStoreAdapter)(nil)
 
-func newStateStoreAdapter(js *JetStreamManager) *stateStoreAdapter {
-	return &stateStoreAdapter{js: js}
+func newStateStoreAdapter(js *JetStreamManager, persist func(string, map[string]*vm.VM) error) *stateStoreAdapter {
+	return &stateStoreAdapter{js: js, persist: persist}
 }
 
 func (a *stateStoreAdapter) SaveRunningState(nodeID string, snapshot map[string]*vm.VM) error {
-	return a.js.WriteState(nodeID, snapshot)
+	return a.persist(nodeID, snapshot)
 }
 
 func (a *stateStoreAdapter) LoadRunningState(nodeID string) (map[string]*vm.VM, bool, error) {


### PR DESCRIPTION
## Summary

Twelve write paths persisted instance state to JetStream KV and never touched the node's local state file, including every API mutation of a running instance. This routes them all through one persist path, so the file and KV move together.

Follows #909, which fixed the boot path that read those two stores.

## The problem

Two writers, different destinations:

| Writer | Local file | KV |
| --- | --- | --- |
| `Daemon.WriteState` (`daemon.go`) | yes | best-effort |
| `vm.Manager.writeRunningState` (`vm/shutdown.go`) | **no** | yes |

The second has twelve callers across `shutdown.go`, `restore.go`, `volumes.go`, `device_map.go`, `crash_recovery.go` and `manager.go`. One of them is `Manager.UpdateAndPersist`, which is the choke point for all eight API mutations of a running instance: IAM profile associate/disassociate/replace, `ModifyInstanceAttribute`, `ModifyInstanceMetadataOptions`, set-tags, set-monitoring, set-spot-lineage.

So the file was not a replica of the in-memory map. It was a replica of whatever the map held the last time something called the *other* writer.

This does not lose data while KV is healthy — restore reads the mutations back from KV. It bites precisely where the file is meant to be the fallback: a node booting disconnected, which is what DDIL Tier 1 (`6c54a6790`) exists for. A node that comes up without KV serves the last state some unrelated writer happened to flush.

## Changes

`Daemon.persistState(nodeID, vms)` is extracted from `WriteState` and becomes the single path both stores move through. `stateStoreAdapter.SaveRunningState` calls it instead of `JetStreamManager.WriteState`, so all twelve callers reach the local file **without a single call site changing**. `Daemon.WriteState` is now a thin wrapper: take the manager lock, call `persistState`.

**Lock ordering moved with it, deliberately.** `WriteState` used to take `stateWriteMu` first and the manager lock second, inside `View`. `writeRunningState` holds the manager lock and would then take `stateWriteMu` — the opposite order, and a deadlock once the two paths joined. Both are now manager-lock-first, with the marshal and the write both inside, which keeps the marshal/write atomicity the original ordering was there to buy.

`newStateStoreAdapter` takes the persist function rather than reaching for the daemon, so the adapter still has no daemon reference.

## Testing

`TestUpdateAndPersist_MutationsReachTheLocalFile` — a table over the five mutation shapes the real handlers apply (IAM profile ARN, `DisableApiTermination`, monitoring, instance tags, spot lineage), each asserting the local file reflects the change with no second writer in between. **All five fail without this change**, verified by reverting the one adapter line.

It is written at `UpdateAndPersist` rather than against eight handlers individually. That is the choke point every one of them goes through; driving each handler would add NATS and service wiring for no extra coverage.

`vm`, `daemon` and every `handlers/ec2/*` package pass under `-race`, which is where a lock-order regression would show. `make preflight` passes.

Not verified on a live cluster: the failure mode is a lost update across a restart, which needs the same KV key manipulation that is unavailable on a running cluster (`mulga-uqe78`).

## Follow-ups

Changes 4 and 5 of `docs/development/josh/improvements/instance-state-authority.md`: adopting `kvstore.Store[T]` for instance state, and converging the three record envelopes.

Bead: `mulga-gsz70`.
