### PR TITLE
refactor: move stream-loss detection into kvutil

### DIFF
--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -185,25 +185,6 @@ func (m *JetStreamManager) InitTerminatedInstanceBucket() error {
 	return nil
 }
 
-// isStreamUnavailable checks if an error indicates the underlying JetStream stream
-// was lost or is unreachable. This can happen during NATS cluster formation when
-// streams created with low replication are disrupted by node join/catchup operations.
-// Different KV operations surface different errors when the stream is gone:
-//   - Get/Keys → ErrNoResponders ("no responders available for request")
-//   - Put/Delete → ErrNoStreamResponse ("no response from stream")
-//   - Direct stream queries → ErrStreamNotFound ("stream not found")
-func isStreamUnavailable(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, jetstream.ErrStreamNotFound) ||
-		errors.Is(err, jetstream.ErrNoStreamResponse) ||
-		errors.Is(err, nats.ErrNoResponders) {
-		return true
-	}
-	return strings.Contains(err.Error(), "stream not found")
-}
-
 // recoverBucket attempts to reconnect to or re-create a KV bucket after the
 // underlying JetStream stream was lost during cluster formation.
 // Returns the recovered KV handle directly so callers avoid a racy re-read.
@@ -220,7 +201,7 @@ func (m *JetStreamManager) recoverBucket(ctx context.Context, cfg jetstream.KeyV
 		return kv, nil
 	}
 
-	if !errors.Is(err, jetstream.ErrBucketNotFound) && !isStreamUnavailable(err) {
+	if !errors.Is(err, jetstream.ErrBucketNotFound) && !kvutil.IsStreamUnavailable(err) {
 		return nil, err
 	}
 
@@ -469,7 +450,7 @@ func (m *JetStreamManager) WriteState(nodeID string, vms map[string]*vm.VM) erro
 	key := InstanceStatePrefix + nodeID
 	_, err = m.kv.Put(context.Background(), key, jsonData)
 	if err != nil {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "WriteState", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -548,7 +529,7 @@ func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, bool, er
 			slog.Debug("No existing state in JetStream KV", "key", key)
 			return make(map[string]*vm.VM), false, nil
 		}
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "LoadState", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -592,7 +573,7 @@ func (m *JetStreamManager) DeleteState(nodeID string) error {
 	key := InstanceStatePrefix + nodeID
 	err := m.kv.Delete(context.Background(), key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "DeleteState", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -687,7 +668,7 @@ func (m *JetStreamManager) WriteStoppedInstance(instanceID string, instance *vm.
 	key := StoppedInstancePrefix + instanceID
 	err = kvutil.Put(context.Background(), m.kv, key, kvutil.CASConfig{CreateIfAbsent: true}, jsonData)
 	if err != nil {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "WriteStoppedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -719,7 +700,7 @@ func (m *JetStreamManager) LoadStoppedInstance(instanceID string) (*vm.VM, error
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, nil
 		}
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "LoadStoppedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -757,7 +738,7 @@ func (m *JetStreamManager) DeleteStoppedInstance(instanceID string) error {
 	key := StoppedInstancePrefix + instanceID
 	err := m.kv.Delete(context.Background(), key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "DeleteStoppedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -793,7 +774,7 @@ func (m *JetStreamManager) ClaimStoppedInstance(instanceID string) (*vm.VM, erro
 	key := StoppedInstancePrefix + instanceID
 	instance, notFound, err := kvutil.Claim[vm.VM](context.Background(), m.kv, key, kvutil.CASConfig{})
 	if err != nil {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "ClaimStoppedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -832,7 +813,7 @@ func (m *JetStreamManager) UpdateStoppedInstance(instanceID string, mutate func(
 	apply := func(v *vm.VM) (bool, error) { mutate(v); return true, nil }
 	updated, err := kvutil.Update(context.Background(), m.kv, key, kvutil.CASConfig{}, apply)
 	if err != nil {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "UpdateStoppedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -856,7 +837,7 @@ func (m *JetStreamManager) ListStoppedInstances() ([]*vm.VM, error) {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return nil, nil
 		}
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "ListStoppedInstances", "err", err)
 			kv, recoverErr := m.recoverKVBucket(context.Background())
 			if recoverErr != nil {
@@ -926,7 +907,7 @@ func (m *JetStreamManager) WriteTerminatedInstance(instanceID string, instance *
 	key := TerminatedInstancePrefix + instanceID
 	err = kvutil.Put(context.Background(), m.terminatedKV, key, kvutil.CASConfig{CreateIfAbsent: true}, jsonData)
 	if err != nil {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "WriteTerminatedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
 			if recoverErr != nil {
@@ -960,7 +941,7 @@ func (m *JetStreamManager) UpdateTerminatedInstance(instanceID string, mutate fu
 	apply := func(v *vm.VM) (bool, error) { mutate(v); return true, nil }
 	updated, err := kvutil.Update(context.Background(), m.terminatedKV, key, kvutil.CASConfig{}, apply)
 	if err != nil {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "UpdateTerminatedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
 			if recoverErr != nil {
@@ -984,7 +965,7 @@ func (m *JetStreamManager) ListTerminatedInstances() ([]*vm.VM, error) {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
 			return nil, nil
 		}
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "ListTerminatedInstances", "err", err)
 			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
 			if recoverErr != nil {
@@ -1040,7 +1021,7 @@ func (m *JetStreamManager) DeleteTerminatedInstance(instanceID string) error {
 	key := TerminatedInstancePrefix + instanceID
 	err := m.terminatedKV.Delete(context.Background(), key)
 	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "DeleteTerminatedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
 			if recoverErr != nil {
@@ -1071,7 +1052,7 @@ func (m *JetStreamManager) LoadTerminatedInstance(instanceID string) (*vm.VM, er
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return nil, nil
 		}
-		if isStreamUnavailable(err) {
+		if kvutil.IsStreamUnavailable(err) {
 			slog.Warn("KV stream unavailable, attempting recovery", "operation", "LoadTerminatedInstance", "key", key, "err", err)
 			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
 			if recoverErr != nil {

--- a/spinifex/daemon/jetstream_test.go
+++ b/spinifex/daemon/jetstream_test.go
@@ -1144,16 +1144,6 @@ func TestJetStreamManager_ListStoppedInstances_RecoveryFailure(t *testing.T) {
 	assert.Nil(t, instances)
 }
 
-func TestIsStreamUnavailable(t *testing.T) {
-	assert.False(t, isStreamUnavailable(nil))
-	assert.True(t, isStreamUnavailable(jetstream.ErrStreamNotFound))
-	assert.True(t, isStreamUnavailable(jetstream.ErrNoStreamResponse))
-	assert.True(t, isStreamUnavailable(nats.ErrNoResponders))
-	assert.True(t, isStreamUnavailable(errors.New("nats: stream not found")))
-	assert.False(t, isStreamUnavailable(errors.New("some other error")))
-	assert.False(t, isStreamUnavailable(jetstream.ErrKeyNotFound))
-}
-
 // --- Terminated instance KV tests ---
 
 func TestJetStreamManager_WriteAndLoadTerminatedInstance(t *testing.T) {

--- a/spinifex/kvutil/kvutil.go
+++ b/spinifex/kvutil/kvutil.go
@@ -13,10 +13,12 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mulgadc/bluebottle/pkg/safecast"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -69,6 +71,28 @@ func getOrCreateBucket(ctx context.Context, js jetstream.KeyValueManager, cfg je
 		return nil, fmt.Errorf("open KV bucket %s: %w", bucket, err)
 	}
 	return kv, nil
+}
+
+// IsStreamUnavailable reports whether err means the KV bucket's underlying
+// JetStream stream was lost or is unreachable, which happens during NATS
+// cluster formation when a low-replication stream is disrupted by a node
+// joining or catching up. Each operation surfaces it differently:
+//
+//   - Get/Keys → ErrNoResponders ("no responders available for request")
+//   - Put/Delete → ErrNoStreamResponse ("no response from stream")
+//   - Direct stream queries → ErrStreamNotFound ("stream not found")
+func IsStreamUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, jetstream.ErrStreamNotFound) ||
+		errors.Is(err, jetstream.ErrNoStreamResponse) ||
+		errors.Is(err, nats.ErrNoResponders) {
+		return true
+	}
+	// Some paths wrap the condition as an untyped error, so the string is the
+	// only signal left. Narrow, but dropping it would lose real detections.
+	return strings.Contains(err.Error(), "stream not found")
 }
 
 // DeleteBucketIfExists deletes a KV bucket, treating an already-absent bucket

--- a/spinifex/kvutil/stream_test.go
+++ b/spinifex/kvutil/stream_test.go
@@ -1,0 +1,35 @@
+package kvutil_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsStreamUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not a failure", nil, false},
+		{"stream not found", jetstream.ErrStreamNotFound, true},
+		{"no stream response", jetstream.ErrNoStreamResponse, true},
+		{"no responders", nats.ErrNoResponders, true},
+		{"wrapped sentinel", fmt.Errorf("load state: %w", jetstream.ErrStreamNotFound), true},
+		{"untyped, matched on message", errors.New("nats: stream not found"), true},
+		{"missing key is not a missing stream", jetstream.ErrKeyNotFound, false},
+		{"unrelated failure", errors.New("some other error"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, kvutil.IsStreamUnavailable(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Moves `isStreamUnavailable` from `daemon/jetstream.go` into `kvutil` as an exported `IsStreamUnavailable`. No behaviour change — this is the mechanical first step of `docs/development/josh/improvements/kvstore-stream-recovery.md`.

## Why

Detecting a lost JetStream stream currently happens in exactly one file in the tree, guarding 14 branches in `daemon/jetstream.go`. Eighteen files build stores on `kvstore` and none of them handle stream loss at all, because `kvstore.Bucket` memoises its `jetstream.KeyValue` on first use and has no invalidation path.

Fixing that means `kvstore` needs the predicate, and `kvstore` already depends on `kvutil`. This PR only moves it; the recovery itself is PR 2.

## Changes

- `kvutil.IsStreamUnavailable` — the same implementation, including the `strings.Contains(err.Error(), "stream not found")` fallback. That fallback is fragile, but removing it is a separate argument and not one to have inside a recovery change, so it comes across unchanged with a comment saying why it is there.
- `daemon`'s private copy is deleted and its 15 call sites repoint at the exported one.
- `TestIsStreamUnavailable` moves to `kvutil` with the function, as an external `kvutil_test` package, and becomes table-driven. Two cases are new: a **wrapped** sentinel (`fmt.Errorf("...: %w", ErrStreamNotFound)`), which is how these errors actually arrive at the call sites, and `ErrKeyNotFound`, which pins that a missing key is not a missing stream.

## Testing

`make preflight` passes. The ten `TestJetStreamManager_*_RecoverAfterStreamLost` tests and the three `_RecoveryFailure` tests pass unchanged, which is the point — they exercise the same predicate through the same 15 branches.

## Follow-ups

PR 2 of the plan: `Bucket.Reopen`, an operation wrapper that reopens and re-runs once on stream loss, `Config.RecreateIfMissing` (opt-in, because recreating an absent bucket is silent data loss for most callers) and `Config.OnOpen` so a recreated bucket is re-stamped with its schema version.

PR 3 is then change 4 of `instance-state-authority.md`, which is blocked until the primitive can recover.

Bead: `mulga-4vs8t`.
