### PR TITLE
refactor: move instance state onto kvstore typed stores

### DIFF
--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/migrate"
 	"github.com/mulgadc/spinifex/spinifex/otelsetup"
-	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -49,14 +48,24 @@ type KVSyncObserver interface {
 }
 
 // JetStreamManager manages JetStream KV store operations for instance state.
+//
+// The instance-state bucket carries two record types, so it is one kvstore
+// bucket with two typed views over it: they share its handle, and a recovery
+// driven through either repairs both.
 type JetStreamManager struct {
-	js           jetstream.JetStream
-	kv           jetstream.KeyValue // spinifex-instance-state
-	clusterKV    jetstream.KeyValue // spinifex-cluster-state
-	terminatedKV jetstream.KeyValue // spinifex-terminated-instances
-	replicas     int
-	kvMu         sync.Mutex // protects kv during recovery
-	obs          KVSyncObserver
+	js        jetstream.JetStream
+	stateB    *kvstore.Bucket           // spinifex-instance-state
+	nodeState *kvstore.Store[nodeState] // node.<id> records
+	stopped   *kvstore.Store[vm.VM]     // instance.<id> records
+	term      *kvstore.Store[vm.VM]     // spinifex-terminated-instances
+	clusterKV jetstream.KeyValue        // spinifex-cluster-state
+	replicas  int
+	obs       KVSyncObserver
+}
+
+// nodeState is the envelope a node's running set is stored in.
+type nodeState struct {
+	VMS map[string]*vm.VM `json:"vms"`
 }
 
 // SetSyncObserver registers obs to receive best-effort KV sync outcomes. Pass
@@ -90,36 +99,57 @@ func NewJetStreamManager(nc *nats.Conn, replicas int) (*JetStreamManager, error)
 	}, nil
 }
 
+// instanceStateConfig describes the instance-state bucket. Extracted so the
+// bucket can be rebuilt against a different JetStream client without the
+// description drifting from the one InitKVBucket creates.
+func instanceStateConfig(replicas int) kvstore.Config {
+	return kvstore.Config{
+		Name:        InstanceStateBucket,
+		Description: "Spinifex instance state storage",
+		History:     1,
+		Replicas:    replicas,
+		// The owning node republishes its record on its next write, so an
+		// emptied bucket costs a sync rather than the records themselves.
+		RecreateIfMissing: true,
+		OnOpen: func(ctx context.Context, kv jetstream.KeyValue) error {
+			return migrate.DefaultRegistry.RunKV(ctx, InstanceStateBucket, kv, InstanceStateBucketVersion)
+		},
+		Missing: "KV bucket not initialized",
+	}
+}
+
+// terminatedInstanceConfig describes the terminated-instances bucket.
+func terminatedInstanceConfig(replicas int) kvstore.Config {
+	return kvstore.Config{
+		Name:              TerminatedInstanceBucket,
+		Description:       "Terminated instances (auto-expire after 1 hour)",
+		History:           1,
+		Replicas:          replicas,
+		TTL:               1 * time.Hour,
+		RecreateIfMissing: true,
+		OnOpen: func(ctx context.Context, kv jetstream.KeyValue) error {
+			return migrate.DefaultRegistry.RunKV(ctx, TerminatedInstanceBucket, kv, TerminatedInstanceBucketVersion)
+		},
+		Missing: "terminated instance KV bucket not initialized",
+	}
+}
+
+// setInstanceStateBucket points the two typed views at b. They share its
+// handle, so a recovery driven through either repairs both.
+func (m *JetStreamManager) setInstanceStateBucket(b *kvstore.Bucket) {
+	m.stateB = b
+	m.nodeState = kvstore.On[nodeState](b)
+	m.stopped = kvstore.On[vm.VM](b)
+}
+
 // InitKVBucket initializes the KV bucket, creating it if it doesn't exist.
 func (m *JetStreamManager) InitKVBucket() error {
-	ctx := context.Background()
-	// Try to get the existing bucket first
-	kv, err := m.js.KeyValue(ctx, InstanceStateBucket)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrBucketNotFound) {
-			// Bucket doesn't exist, create it
-			slog.Debug("Creating JetStream KV bucket", "bucket", InstanceStateBucket, "replicas", m.replicas)
-			kv, err = m.js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
-				Bucket:      InstanceStateBucket,
-				Description: "Spinifex instance state storage",
-				History:     1,          // Only keep latest value
-				Replicas:    m.replicas, // Replication across cluster nodes
-			})
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	} else {
-		slog.Debug("Connected to existing JetStream KV bucket", "bucket", InstanceStateBucket)
-	}
+	m.setInstanceStateBucket(kvstore.NewBucket(m.js, instanceStateConfig(m.replicas)))
 
-	m.kv = kv
-	if err := migrate.DefaultRegistry.RunKV(ctx, InstanceStateBucket, kv, InstanceStateBucketVersion); err != nil {
-		return fmt.Errorf("migrate %s: %w", InstanceStateBucket, err)
-	}
-	return nil
+	// Opened eagerly: a bucket that cannot be created must fail startup here,
+	// not on the first write, and Tier 1 boot must not reach cluster KV at all.
+	_, err := m.stateB.KV(context.Background())
+	return err
 }
 
 // InitClusterStateBucket initializes the cluster-state KV bucket, creating it if it doesn't exist.
@@ -156,88 +186,9 @@ func (m *JetStreamManager) InitClusterStateBucket() error {
 // InitTerminatedInstanceBucket initializes the terminated-instances KV bucket with a 1-hour TTL.
 // JetStream automatically purges keys after 1 hour, matching AWS behavior for terminated instances.
 func (m *JetStreamManager) InitTerminatedInstanceBucket() error {
-	ctx := context.Background()
-	kv, err := m.js.KeyValue(ctx, TerminatedInstanceBucket)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrBucketNotFound) {
-			slog.Debug("Creating JetStream KV bucket", "bucket", TerminatedInstanceBucket, "replicas", m.replicas)
-			kv, err = m.js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
-				Bucket:      TerminatedInstanceBucket,
-				Description: "Terminated instances (auto-expire after 1 hour)",
-				History:     1,
-				Replicas:    m.replicas,
-				TTL:         1 * time.Hour,
-			})
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	} else {
-		slog.Debug("Connected to existing JetStream KV bucket", "bucket", TerminatedInstanceBucket)
-	}
-
-	m.terminatedKV = kv
-	if err := migrate.DefaultRegistry.RunKV(ctx, TerminatedInstanceBucket, kv, TerminatedInstanceBucketVersion); err != nil {
-		return fmt.Errorf("migrate %s: %w", TerminatedInstanceBucket, err)
-	}
-	return nil
-}
-
-// recoverBucket attempts to reconnect to or re-create a KV bucket after the
-// underlying JetStream stream was lost during cluster formation.
-// Returns the recovered KV handle directly so callers avoid a racy re-read.
-// When a bucket is recreated, the schema version is re-stamped.
-func (m *JetStreamManager) recoverBucket(ctx context.Context, cfg jetstream.KeyValueConfig, field *jetstream.KeyValue, version int) (jetstream.KeyValue, error) {
-	m.kvMu.Lock()
-	defer m.kvMu.Unlock()
-
-	// Try to reconnect to existing bucket first (another goroutine may have recovered it)
-	kv, err := m.js.KeyValue(ctx, cfg.Bucket)
-	if err == nil {
-		*field = kv
-		slog.Info("Reconnected to KV bucket", "bucket", cfg.Bucket)
-		return kv, nil
-	}
-
-	if !errors.Is(err, jetstream.ErrBucketNotFound) && !kvutil.IsStreamUnavailable(err) {
-		return nil, err
-	}
-
-	// Bucket truly doesn't exist — recreate it
-	slog.Warn("KV bucket stream lost, recreating", "bucket", cfg.Bucket, "replicas", m.replicas)
-	cfg.History = 1
-	cfg.Replicas = m.replicas
-	kv, err = m.js.CreateKeyValue(ctx, cfg)
-	if err != nil {
-		slog.Error("Failed to recreate KV bucket", "bucket", cfg.Bucket, "err", err)
-		return nil, err
-	}
-
-	if err := migrate.DefaultRegistry.RunKV(ctx, cfg.Bucket, kv, version); err != nil {
-		slog.Error("Failed to run migrations on recreated bucket", "bucket", cfg.Bucket, "err", err)
-		return nil, fmt.Errorf("migrate recreated bucket %s: %w", cfg.Bucket, err)
-	}
-
-	*field = kv
-	slog.Info("KV bucket recreated successfully", "bucket", cfg.Bucket)
-	return kv, nil
-}
-
-func (m *JetStreamManager) recoverKVBucket(ctx context.Context) (jetstream.KeyValue, error) {
-	return m.recoverBucket(ctx, jetstream.KeyValueConfig{
-		Bucket:      InstanceStateBucket,
-		Description: "Spinifex instance state storage",
-	}, &m.kv, InstanceStateBucketVersion)
-}
-
-func (m *JetStreamManager) recoverTerminatedKVBucket(ctx context.Context) (jetstream.KeyValue, error) {
-	return m.recoverBucket(ctx, jetstream.KeyValueConfig{
-		Bucket:      TerminatedInstanceBucket,
-		Description: "Terminated instances (auto-expire after 1 hour)",
-		TTL:         1 * time.Hour,
-	}, &m.terminatedKV, TerminatedInstanceBucketVersion)
+	m.term = kvstore.New[vm.VM](m.js, terminatedInstanceConfig(m.replicas))
+	_, err := m.term.KV(context.Background())
+	return err
 }
 
 // Heartbeat represents a daemon's periodic health status published to cluster KV.
@@ -438,30 +389,12 @@ func (m *JetStreamManager) WriteServiceManifest(nodeID string, services []string
 // WriteState writes the instance state to the KV store for the given node.
 // vms must be a snapshot owned by the caller — JetStreamManager does not lock.
 func (m *JetStreamManager) WriteState(nodeID string, vms map[string]*vm.VM) error {
-	if m.kv == nil {
+	if m.nodeState == nil {
 		return errors.New("KV bucket not initialized")
 	}
 
-	jsonData, err := marshalInstanceState(vms)
-	if err != nil {
-		return err
-	}
-
 	key := InstanceStatePrefix + nodeID
-	_, err = m.kv.Put(context.Background(), key, jsonData)
-	if err != nil {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "WriteState", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return err
-			}
-			if _, retryErr := kv.Put(context.Background(), key, jsonData); retryErr != nil {
-				return retryErr
-			}
-			slog.Debug("Wrote state to JetStream KV (after recovery)", "key", key, "instances", len(vms))
-			return nil
-		}
+	if err := m.nodeState.Set(context.Background(), key, &nodeState{VMS: vms}); err != nil {
 		return err
 	}
 
@@ -475,7 +408,7 @@ func (m *JetStreamManager) WriteState(nodeID string, vms map[string]*vm.VM) erro
 // local state file is the source of truth and KV is a best-effort cache; hot
 // paths marshal under a short-lived lock and commit lock-free.
 func (m *JetStreamManager) WriteStateBytesBestEffort(nodeID string, jsonData []byte, timeout time.Duration) {
-	if m.kv == nil {
+	if m.stateB == nil {
 		slog.Debug("KV bucket not initialized, skipping cluster sync", "node", nodeID)
 		return
 	}
@@ -484,7 +417,13 @@ func (m *JetStreamManager) WriteStateBytesBestEffort(nodeID string, jsonData []b
 	defer cancel()
 
 	key := InstanceStatePrefix + nodeID
-	_, err := m.kv.Put(ctx, key, jsonData)
+	// Pre-marshalled bytes, so this goes to the raw handle rather than through
+	// a typed view. Best-effort by contract: a failure is logged, not recovered
+	// from here, and the next typed write repairs the bucket for both.
+	kv, err := m.stateB.KV(ctx)
+	if err == nil {
+		_, err = kv.Put(ctx, key, jsonData)
+	}
 	if err != nil {
 		if m.obs != nil {
 			m.obs.RecordKVSyncFailure(InstanceStateBucket, err)
@@ -502,14 +441,10 @@ func (m *JetStreamManager) WriteStateBytesBestEffort(nodeID string, jsonData []b
 	slog.Debug("Wrote state to KV (best-effort)", "key", key, "bytes", len(jsonData))
 }
 
-// marshalInstanceState produces the JSON wire form of vms.
+// marshalInstanceState produces the JSON wire form of vms, for the best-effort
+// path that marshals under the caller's lock and commits lock-free.
 func marshalInstanceState(vms map[string]*vm.VM) ([]byte, error) {
-	state := struct {
-		VMS map[string]*vm.VM `json:"vms"`
-	}{
-		VMS: vms,
-	}
-	return json.Marshal(state)
+	return json.Marshal(nodeState{VMS: vms})
 }
 
 // LoadState loads the instance state from the KV store for the given node.
@@ -518,42 +453,17 @@ func marshalInstanceState(vms map[string]*vm.VM) ([]byte, error) {
 // caller that would drop instances on the strength of that must tell them
 // apart.
 func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, bool, error) {
-	if m.kv == nil {
+	if m.nodeState == nil {
 		return nil, false, errors.New("KV bucket not initialized")
 	}
 
 	key := InstanceStatePrefix + nodeID
-	entry, err := m.kv.Get(context.Background(), key)
+	state, _, err := m.nodeState.Get(context.Background(), key)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
+		if errors.Is(err, kvstore.ErrNotFound) {
 			slog.Debug("No existing state in JetStream KV", "key", key)
 			return make(map[string]*vm.VM), false, nil
 		}
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "LoadState", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, false, err
-			}
-			// Retry the read — if we reconnected, data may still exist
-			entry, err = kv.Get(context.Background(), key)
-			if err != nil {
-				if errors.Is(err, jetstream.ErrKeyNotFound) {
-					slog.Warn("No state found after KV recovery", "key", key)
-					return make(map[string]*vm.VM), false, nil
-				}
-				return nil, false, err
-			}
-			// Fall through to unmarshal below
-		} else {
-			return nil, false, err
-		}
-	}
-
-	var state struct {
-		VMS map[string]*vm.VM `json:"vms"`
-	}
-	if err := json.Unmarshal(entry.Value(), &state); err != nil {
 		return nil, false, err
 	}
 	if state.VMS == nil {
@@ -566,25 +476,12 @@ func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, bool, er
 
 // DeleteState removes the instance state from the KV store for the given node.
 func (m *JetStreamManager) DeleteState(nodeID string) error {
-	if m.kv == nil {
+	if m.nodeState == nil {
 		return errors.New("KV bucket not initialized")
 	}
 
 	key := InstanceStatePrefix + nodeID
-	err := m.kv.Delete(context.Background(), key)
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "DeleteState", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return err
-			}
-			// Retry — if we reconnected the key may still exist
-			if retryErr := kv.Delete(context.Background(), key); retryErr != nil && !errors.Is(retryErr, jetstream.ErrKeyNotFound) {
-				return retryErr
-			}
-			return nil
-		}
+	if err := m.nodeState.Delete(context.Background(), key); err != nil {
 		return err
 	}
 
@@ -656,30 +553,14 @@ func (m *JetStreamManager) UpdateReplicas(newReplicas int) error {
 // callers that read-modify-write a stopped instance (e.g. tag/attribute
 // mutations) build on.
 func (m *JetStreamManager) WriteStoppedInstance(instanceID string, instance *vm.VM) error {
-	if m.kv == nil {
+	if m.stopped == nil {
 		return errors.New("KV bucket not initialized")
 	}
 
-	jsonData, err := json.Marshal(instance)
-	if err != nil {
-		return err
-	}
-
 	key := StoppedInstancePrefix + instanceID
-	err = kvutil.Put(context.Background(), m.kv, key, kvutil.CASConfig{CreateIfAbsent: true}, jsonData)
-	if err != nil {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "WriteStoppedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return err
-			}
-			if retryErr := kvutil.Put(context.Background(), kv, key, kvutil.CASConfig{CreateIfAbsent: true}, jsonData); retryErr != nil {
-				return retryErr
-			}
-			slog.Debug("Wrote stopped instance to JetStream KV (after recovery)", "key", key, "instanceId", instanceID)
-			return nil
-		}
+	// Replace rather than Set: this overwrites the record wholesale, and doing
+	// it under CAS is what stops a racing update landing out of order.
+	if err := m.stopped.Replace(context.Background(), key, instance); err != nil {
 		return err
 	}
 
@@ -690,66 +571,29 @@ func (m *JetStreamManager) WriteStoppedInstance(instanceID string, instance *vm.
 // LoadStoppedInstance loads a stopped instance from the shared KV store.
 // Returns nil, nil if the key does not exist.
 func (m *JetStreamManager) LoadStoppedInstance(instanceID string) (*vm.VM, error) {
-	if m.kv == nil {
+	if m.stopped == nil {
 		return nil, errors.New("KV bucket not initialized")
 	}
 
-	key := StoppedInstancePrefix + instanceID
-	entry, err := m.kv.Get(context.Background(), key)
+	instance, _, err := m.stopped.Get(context.Background(), StoppedInstancePrefix+instanceID)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
+		if errors.Is(err, kvstore.ErrNotFound) {
 			return nil, nil
 		}
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "LoadStoppedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, err
-			}
-			// Retry — if we reconnected, data may still exist
-			entry, err = kv.Get(context.Background(), key)
-			if err != nil {
-				if errors.Is(err, jetstream.ErrKeyNotFound) {
-					return nil, nil
-				}
-				return nil, err
-			}
-			// Fall through to unmarshal below
-		} else {
-			return nil, err
-		}
-	}
-
-	var instance vm.VM
-	if err := json.Unmarshal(entry.Value(), &instance); err != nil {
 		return nil, err
 	}
-
-	return &instance, nil
+	return instance, nil
 }
 
 // DeleteStoppedInstance removes a stopped instance from the shared KV store.
 // It is idempotent — deleting a non-existent key is not an error.
 func (m *JetStreamManager) DeleteStoppedInstance(instanceID string) error {
-	if m.kv == nil {
+	if m.stopped == nil {
 		return errors.New("KV bucket not initialized")
 	}
 
 	key := StoppedInstancePrefix + instanceID
-	err := m.kv.Delete(context.Background(), key)
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "DeleteStoppedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return err
-			}
-			// Retry — if we reconnected the key may still exist
-			if retryErr := kv.Delete(context.Background(), key); retryErr != nil && !errors.Is(retryErr, jetstream.ErrKeyNotFound) {
-				return retryErr
-			}
-			return nil
-		}
+	if err := m.stopped.Delete(context.Background(), key); err != nil {
 		return err
 	}
 
@@ -767,26 +611,14 @@ func (m *JetStreamManager) DeleteStoppedInstance(instanceID string) error {
 // retry after the instance was already claimed) gets vm.ErrStoppedInstanceClaimed
 // instead of a VM and must not proceed to allocate resources or launch qemu.
 func (m *JetStreamManager) ClaimStoppedInstance(instanceID string) (*vm.VM, error) {
-	if m.kv == nil {
+	if m.stopped == nil {
 		return nil, errors.New("KV bucket not initialized")
 	}
 
 	key := StoppedInstancePrefix + instanceID
-	instance, notFound, err := kvutil.Claim[vm.VM](context.Background(), m.kv, key, kvutil.CASConfig{})
+	instance, notFound, err := m.stopped.Claim(context.Background(), key)
 	if err != nil {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "ClaimStoppedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, err
-			}
-			instance, notFound, err = kvutil.Claim[vm.VM](context.Background(), kv, key, kvutil.CASConfig{})
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	if notFound {
 		return nil, vm.ErrStoppedInstanceClaimed
@@ -805,21 +637,25 @@ func (m *JetStreamManager) ClaimStoppedInstance(instanceID string) (*vm.VM, erro
 // stopped instance so they cannot race a claim into recreating a stale
 // record. Returns jetstream.ErrKeyNotFound if no record exists.
 func (m *JetStreamManager) UpdateStoppedInstance(instanceID string, mutate func(*vm.VM)) (*vm.VM, error) {
-	if m.kv == nil {
+	if m.stopped == nil {
 		return nil, errors.New("KV bucket not initialized")
 	}
+	return mutateVM(m.stopped, StoppedInstancePrefix+instanceID, mutate)
+}
 
-	key := StoppedInstancePrefix + instanceID
-	apply := func(v *vm.VM) (bool, error) { mutate(v); return true, nil }
-	updated, err := kvutil.Update(context.Background(), m.kv, key, kvutil.CASConfig{}, apply)
+// mutateVM applies mutate under the store's CAS loop and returns the committed
+// record. An absent key comes back as jetstream.ErrKeyNotFound, which is the
+// sentinel the callers and both StateStore interfaces are written against.
+func mutateVM(store *kvstore.Store[vm.VM], key string, mutate func(*vm.VM)) (*vm.VM, error) {
+	var updated *vm.VM
+	err := store.Mutate(context.Background(), key, func(v *vm.VM) (bool, error) {
+		mutate(v)
+		updated = v
+		return true, nil
+	})
 	if err != nil {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "UpdateStoppedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, err
-			}
-			return kvutil.Update(context.Background(), kv, key, kvutil.CASConfig{}, apply)
+		if errors.Is(err, kvstore.ErrNotFound) {
+			return nil, jetstream.ErrKeyNotFound
 		}
 		return nil, err
 	}
@@ -828,61 +664,27 @@ func (m *JetStreamManager) UpdateStoppedInstance(instanceID string, mutate func(
 
 // ListStoppedInstances returns all stopped instances from the shared KV store.
 func (m *JetStreamManager) ListStoppedInstances() ([]*vm.VM, error) {
-	if m.kv == nil {
+	if m.stopped == nil {
 		return nil, errors.New("KV bucket not initialized")
 	}
+	return listVMs(m.stopped, StoppedInstancePrefix)
+}
 
-	keys, err := m.kv.Keys(context.Background())
+// listVMs returns every record under prefix. Unlike the raw scan it replaces it
+// fails on an undecodable record rather than skipping it: both callers feed
+// DescribeInstances, where a silently dropped instance reads as terminated.
+func listVMs(store *kvstore.Store[vm.VM], prefix string) ([]*vm.VM, error) {
+	records, err := store.List(context.Background(), prefix)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil, nil
-		}
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "ListStoppedInstances", "err", err)
-			kv, recoverErr := m.recoverKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, err
-			}
-			// Retry — if we reconnected, data may still exist
-			keys, err = kv.Keys(context.Background())
-			if err != nil {
-				if errors.Is(err, jetstream.ErrNoKeysFound) {
-					return nil, nil
-				}
-				return nil, err
-			}
-			// Fall through to iterate keys below
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
-
-	var instances []*vm.VM
-	for _, key := range keys {
-		if key == utils.VersionKey {
-			continue
-		}
-		if !strings.HasPrefix(key, StoppedInstancePrefix) {
-			continue
-		}
-
-		entry, err := m.kv.Get(context.Background(), key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				continue
-			}
-			return nil, err
-		}
-
-		var instance vm.VM
-		if err := json.Unmarshal(entry.Value(), &instance); err != nil {
-			slog.Error("Failed to unmarshal stopped instance", "key", key, "err", err)
-			continue
-		}
-
-		instances = append(instances, &instance)
+	instances := make([]*vm.VM, 0, len(records))
+	for i := range records {
+		instances = append(instances, &records[i])
 	}
-
+	if len(instances) == 0 {
+		return nil, nil
+	}
 	return instances, nil
 }
 
@@ -895,30 +697,12 @@ func (m *JetStreamManager) ListStoppedInstances() ([]*vm.VM, error) {
 // record instead of replacing it wholesale should use
 // UpdateTerminatedInstance.
 func (m *JetStreamManager) WriteTerminatedInstance(instanceID string, instance *vm.VM) error {
-	if m.terminatedKV == nil {
+	if m.term == nil {
 		return errors.New("terminated instance KV bucket not initialized")
 	}
 
-	jsonData, err := json.Marshal(instance)
-	if err != nil {
-		return err
-	}
-
 	key := TerminatedInstancePrefix + instanceID
-	err = kvutil.Put(context.Background(), m.terminatedKV, key, kvutil.CASConfig{CreateIfAbsent: true}, jsonData)
-	if err != nil {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "WriteTerminatedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
-			if recoverErr != nil {
-				return err
-			}
-			if retryErr := kvutil.Put(context.Background(), kv, key, kvutil.CASConfig{CreateIfAbsent: true}, jsonData); retryErr != nil {
-				return retryErr
-			}
-			slog.Debug("Wrote terminated instance to JetStream KV (after recovery)", "key", key, "instanceId", instanceID)
-			return nil
-		}
+	if err := m.term.Replace(context.Background(), key, instance); err != nil {
 		return err
 	}
 
@@ -933,105 +717,28 @@ func (m *JetStreamManager) WriteTerminatedInstance(instanceID string, instance *
 // progress without clobbering marks written by a concurrent update to the
 // same record. Returns jetstream.ErrKeyNotFound if no record exists yet.
 func (m *JetStreamManager) UpdateTerminatedInstance(instanceID string, mutate func(*vm.VM)) (*vm.VM, error) {
-	if m.terminatedKV == nil {
+	if m.term == nil {
 		return nil, errors.New("terminated instance KV bucket not initialized")
 	}
-
-	key := TerminatedInstancePrefix + instanceID
-	apply := func(v *vm.VM) (bool, error) { mutate(v); return true, nil }
-	updated, err := kvutil.Update(context.Background(), m.terminatedKV, key, kvutil.CASConfig{}, apply)
-	if err != nil {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "UpdateTerminatedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, err
-			}
-			return kvutil.Update(context.Background(), kv, key, kvutil.CASConfig{}, apply)
-		}
-		return nil, err
-	}
-	return updated, nil
+	return mutateVM(m.term, TerminatedInstancePrefix+instanceID, mutate)
 }
 
 // ListTerminatedInstances returns all terminated instances from the terminated KV bucket.
 func (m *JetStreamManager) ListTerminatedInstances() ([]*vm.VM, error) {
-	if m.terminatedKV == nil {
+	if m.term == nil {
 		return nil, errors.New("terminated instance KV bucket not initialized")
 	}
-
-	keys, err := m.terminatedKV.Keys(context.Background())
-	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return nil, nil
-		}
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "ListTerminatedInstances", "err", err)
-			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, err
-			}
-			keys, err = kv.Keys(context.Background())
-			if err != nil {
-				if errors.Is(err, jetstream.ErrNoKeysFound) {
-					return nil, nil
-				}
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
-	}
-
-	var instances []*vm.VM
-	for _, key := range keys {
-		if key == utils.VersionKey {
-			continue
-		}
-		if !strings.HasPrefix(key, TerminatedInstancePrefix) {
-			continue
-		}
-
-		entry, err := m.terminatedKV.Get(context.Background(), key)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
-				continue
-			}
-			return nil, err
-		}
-
-		var instance vm.VM
-		if err := json.Unmarshal(entry.Value(), &instance); err != nil {
-			slog.Error("Failed to unmarshal terminated instance", "key", key, "err", err)
-			continue
-		}
-
-		instances = append(instances, &instance)
-	}
-
-	return instances, nil
+	return listVMs(m.term, TerminatedInstancePrefix)
 }
 
 // DeleteTerminatedInstance removes a terminated instance from the terminated KV bucket.
 func (m *JetStreamManager) DeleteTerminatedInstance(instanceID string) error {
-	if m.terminatedKV == nil {
+	if m.term == nil {
 		return errors.New("terminated instance KV bucket not initialized")
 	}
 
 	key := TerminatedInstancePrefix + instanceID
-	err := m.terminatedKV.Delete(context.Background(), key)
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "DeleteTerminatedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
-			if recoverErr != nil {
-				return err
-			}
-			if retryErr := kv.Delete(context.Background(), key); retryErr != nil && !errors.Is(retryErr, jetstream.ErrKeyNotFound) {
-				return retryErr
-			}
-			return nil
-		}
+	if err := m.term.Delete(context.Background(), key); err != nil {
 		return err
 	}
 
@@ -1042,38 +749,16 @@ func (m *JetStreamManager) DeleteTerminatedInstance(instanceID string) error {
 // LoadTerminatedInstance loads a single terminated instance from the terminated KV bucket.
 // Returns nil, nil if the key does not exist.
 func (m *JetStreamManager) LoadTerminatedInstance(instanceID string) (*vm.VM, error) {
-	if m.terminatedKV == nil {
+	if m.term == nil {
 		return nil, errors.New("terminated instance KV bucket not initialized")
 	}
 
-	key := TerminatedInstancePrefix + instanceID
-	entry, err := m.terminatedKV.Get(context.Background(), key)
+	instance, _, err := m.term.Get(context.Background(), TerminatedInstancePrefix+instanceID)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
+		if errors.Is(err, kvstore.ErrNotFound) {
 			return nil, nil
 		}
-		if kvutil.IsStreamUnavailable(err) {
-			slog.Warn("KV stream unavailable, attempting recovery", "operation", "LoadTerminatedInstance", "key", key, "err", err)
-			kv, recoverErr := m.recoverTerminatedKVBucket(context.Background())
-			if recoverErr != nil {
-				return nil, err
-			}
-			entry, err = kv.Get(context.Background(), key)
-			if err != nil {
-				if errors.Is(err, jetstream.ErrKeyNotFound) {
-					return nil, nil
-				}
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
-	}
-
-	var instance vm.VM
-	if err := json.Unmarshal(entry.Value(), &instance); err != nil {
 		return nil, err
 	}
-
-	return &instance, nil
+	return instance, nil
 }

--- a/spinifex/daemon/jetstream_test.go
+++ b/spinifex/daemon/jetstream_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
@@ -104,8 +105,11 @@ func TestJetStreamManager_BucketCreation(t *testing.T) {
 	err = jsm.InitKVBucket()
 	require.NoError(t, err, "Should create bucket without error")
 
-	// Verify the bucket exists by checking jsm.kv is set
-	assert.NotNil(t, jsm.kv, "KV bucket should be initialized")
+	// Verify the bucket exists by checking the store is wired to an open handle
+	require.NotNil(t, jsm.stateB, "KV bucket should be initialized")
+	kv, err := jsm.stateB.KV(t.Context())
+	require.NoError(t, err)
+	assert.NotNil(t, kv, "KV bucket should be initialized")
 }
 
 // TestJetStreamManager_BucketReconnection tests that InitKVBucket connects to existing bucket.
@@ -1010,6 +1014,10 @@ func TestJetStreamManager_ListStoppedInstances_RecoverAfterStreamLost(t *testing
 // non-JetStream NATS server. The original kv handle still targets the JS server
 // (where the stream was deleted), so operations fail with stream-unavailable errors.
 // Recovery then also fails because the non-JS server has no JetStream support.
+// swapToNonJSContext repoints the manager at a NATS server with no JetStream,
+// keeping the buckets' current handles. An operation then fails on the stale
+// handle and the recovery that follows it cannot succeed, which is the shape
+// these tests exist to pin.
 func swapToNonJSContext(t *testing.T, jsm *JetStreamManager) {
 	t.Helper()
 	nc, err := nats.Connect(sharedNATSURL)
@@ -1018,6 +1026,17 @@ func swapToNonJSContext(t *testing.T, jsm *JetStreamManager) {
 	js, err := jetstream.New(nc)
 	require.NoError(t, err)
 	jsm.js = js
+
+	if jsm.stateB != nil {
+		kv, err := jsm.stateB.KV(t.Context())
+		require.NoError(t, err)
+		jsm.setInstanceStateBucket(kvstore.NewOpenBucket(js, kv, instanceStateConfig(jsm.replicas)))
+	}
+	if jsm.term != nil {
+		kv, err := jsm.term.KV(t.Context())
+		require.NoError(t, err)
+		jsm.term = kvstore.Over[vm.VM](js, kv, terminatedInstanceConfig(jsm.replicas))
+	}
 }
 
 func TestJetStreamManager_WriteState_RecoveryFailure(t *testing.T) {
@@ -1503,7 +1522,12 @@ func TestJetStreamManager_InitBuckets_WritesVersion(t *testing.T) {
 	require.NoError(t, jsm.InitClusterStateBucket())
 	require.NoError(t, jsm.InitTerminatedInstanceBucket())
 
-	v, err := kvutil.ReadVersion(t.Context(), jsm.kv)
+	stateKV, err := jsm.stateB.KV(t.Context())
+	require.NoError(t, err)
+	termKV, err := jsm.term.KV(t.Context())
+	require.NoError(t, err)
+
+	v, err := kvutil.ReadVersion(t.Context(), stateKV)
 	require.NoError(t, err)
 	assert.Equal(t, InstanceStateBucketVersion, v)
 
@@ -1511,7 +1535,7 @@ func TestJetStreamManager_InitBuckets_WritesVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ClusterStateBucketVersion, v)
 
-	v, err = kvutil.ReadVersion(t.Context(), jsm.terminatedKV)
+	v, err = kvutil.ReadVersion(t.Context(), termKV)
 	require.NoError(t, err)
 	assert.Equal(t, TerminatedInstanceBucketVersion, v)
 }
@@ -1719,4 +1743,55 @@ func TestJetStreamManager_UpdateMgmtIPAM_ClusterKVNotInitialized(t *testing.T) {
 	_, err = jsm.UpdateMgmtIPAM("10.97.8.0/24", func(r *MgmtIPRecord) {}, true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cluster state KV not initialized")
+}
+
+// TestJetStreamManager_ListStoppedInstances_FailsOnAnUndecodableRecord pins the
+// behaviour change the kvstore conversion brings. The raw scan this replaced
+// logged an undecodable record and carried on, so the instance simply vanished
+// from DescribeInstances and the caller concluded it was gone. A tenant-facing
+// listing is complete or it fails.
+func TestJetStreamManager_ListStoppedInstances_FailsOnAnUndecodableRecord(t *testing.T) {
+	nc, err := nats.Connect(sharedJSNATSURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	jsm, err := NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, jsm.InitKVBucket())
+
+	require.NoError(t, jsm.WriteStoppedInstance("i-readable", &vm.VM{ID: "i-readable"}))
+
+	kv, err := jsm.stateB.KV(t.Context())
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), StoppedInstancePrefix+"i-corrupt", []byte("{not json"))
+	require.NoError(t, err)
+
+	_, err = jsm.ListStoppedInstances()
+	require.Error(t, err, "a record that will not decode must surface, not disappear")
+	assert.ErrorContains(t, err, "i-corrupt")
+}
+
+// TestJetStreamManager_UpdateStoppedInstance_AbsentKeyKeepsItsSentinel guards
+// the boundary mapping. Store.Mutate reports kvstore.ErrNotFound, but three
+// call sites and both StateStore interfaces are written against
+// jetstream.ErrKeyNotFound, so the manager converts rather than leaking it.
+func TestJetStreamManager_UpdateStoppedInstance_AbsentKeyKeepsItsSentinel(t *testing.T) {
+	nc, err := nats.Connect(sharedJSNATSURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	jsm, err := NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, jsm.InitKVBucket())
+	require.NoError(t, jsm.InitTerminatedInstanceBucket())
+
+	_, err = jsm.UpdateStoppedInstance("i-absent", func(*vm.VM) {
+		t.Error("mutate must not run against an absent key")
+	})
+	require.ErrorIs(t, err, jetstream.ErrKeyNotFound)
+
+	_, err = jsm.UpdateTerminatedInstance("i-absent", func(*vm.VM) {
+		t.Error("mutate must not run against an absent key")
+	})
+	require.ErrorIs(t, err, jetstream.ErrKeyNotFound)
 }

--- a/spinifex/kvstore/bucket.go
+++ b/spinifex/kvstore/bucket.go
@@ -17,13 +17,16 @@ import (
 
 // Config describes the bucket that a Store or Bucket sits over.
 type Config struct {
-	Name      string
-	History   int
-	Replicas  int
-	TTL       time.Duration
-	Missing   string
-	Attempts  int
-	Exhausted func(key string, attempts int) error
+	Name    string
+	History int
+	// Description is set on the bucket at creation, including a recovery
+	// recreate, so a recreated bucket is not left anonymous next to its peers.
+	Description string
+	Replicas    int
+	TTL         time.Duration
+	Missing     string
+	Attempts    int
+	Exhausted   func(key string, attempts int) error
 
 	// RecreateIfMissing allows recovery to create the bucket again when the
 	// stream is not merely unreachable but gone. It governs recovery only —
@@ -208,9 +211,20 @@ func (b *Bucket) Watch(ctx context.Context, filter string) (jetstream.KeyWatcher
 func (b *Bucket) open(ctx context.Context) (jetstream.KeyValue, error) {
 	switch {
 	case b.cfg.TTL > 0:
-		return kvutil.GetOrCreateBucketWithTTL(ctx, b.js, b.cfg.Name, b.cfg.History, b.cfg.TTL)
-	case b.cfg.Replicas > 0:
-		return kvutil.GetOrCreateBucketWithReplicas(ctx, b.js, b.cfg.Name, b.cfg.History, b.cfg.Replicas)
+		return kvutil.GetOrCreateBucketWithOptions(ctx, b.js, kvutil.BucketOptions{
+			Name:        b.cfg.Name,
+			Description: b.cfg.Description,
+			History:     b.cfg.History,
+			Replicas:    b.cfg.Replicas,
+			TTL:         b.cfg.TTL,
+		})
+	case b.cfg.Replicas > 0 || b.cfg.Description != "":
+		return kvutil.GetOrCreateBucketWithOptions(ctx, b.js, kvutil.BucketOptions{
+			Name:        b.cfg.Name,
+			Description: b.cfg.Description,
+			History:     b.cfg.History,
+			Replicas:    b.cfg.Replicas,
+		})
 	default:
 		return kvutil.GetOrCreateBucket(ctx, b.js, b.cfg.Name, b.cfg.History)
 	}

--- a/spinifex/kvstore/recovery_test.go
+++ b/spinifex/kvstore/recovery_test.go
@@ -243,3 +243,141 @@ func TestBucket_ReopenWithoutAJetStreamClientReportsTheConfiguredMessage(t *test
 	_, err := bucket.Reopen(t.Context())
 	require.ErrorContains(t, err, "no JetStream client configured")
 }
+
+// TestOn_TwoTypedViewsShareOneBucket covers the shape a bucket holding more
+// than one record type needs: each view decodes its own records, and they open
+// the bucket once between them rather than once each.
+func TestOn_TwoTypedViewsShareOneBucket(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	var opens atomic.Int32
+	bucket := kvstore.NewBucket(testutil.NewJetStream(t, nc), kvstore.Config{
+		Name:    "kvstore-views-test",
+		History: 1,
+		OnOpen: func(context.Context, jetstream.KeyValue) error {
+			opens.Add(1)
+			return nil
+		},
+	})
+	records := kvstore.On[record](bucket)
+	counters := kvstore.On[counter](bucket)
+
+	require.NoError(t, records.Set(t.Context(), "rec.one", &record{Name: "one"}))
+	require.NoError(t, counters.Set(t.Context(), "cnt.one", &counter{Total: 5}))
+	assert.Equal(t, int32(1), opens.Load(), "both views must share the one open")
+
+	got, _, err := records.Get(t.Context(), "rec.one")
+	require.NoError(t, err)
+	assert.Equal(t, "one", got.Name)
+
+	tally, _, err := counters.Get(t.Context(), "cnt.one")
+	require.NoError(t, err)
+	assert.Equal(t, 5, tally.Total)
+
+	// Each view lists only its own prefix, so neither decodes the other's.
+	mine, err := records.List(t.Context(), "rec.")
+	require.NoError(t, err)
+	assert.Len(t, mine, 1)
+}
+
+// counter is a second record type over the same bucket as record.
+type counter struct {
+	Total int `json:"total"`
+}
+
+// TestOn_RecoveryThroughOneViewRepairsTheOther is the reason the views share a
+// Bucket rather than holding a handle each: a stale handle repaired by one
+// view must not leave the other still pointing at the lost stream.
+func TestOn_RecoveryThroughOneViewRepairsTheOther(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	bucket := kvstore.NewBucket(js, kvstore.Config{
+		Name:              "kvstore-views-recovery-test",
+		History:           1,
+		RecreateIfMissing: true,
+	})
+	records := kvstore.On[record](bucket)
+	counters := kvstore.On[counter](bucket)
+	require.NoError(t, records.Set(t.Context(), "rec.one", &record{Name: "one"}))
+
+	require.NoError(t, js.DeleteKeyValue(t.Context(), "kvstore-views-recovery-test"))
+
+	// Recover through one view.
+	require.NoError(t, records.Set(t.Context(), "rec.two", &record{Name: "two"}))
+	// The other must already be on the repaired handle.
+	require.NoError(t, counters.Set(t.Context(), "cnt.one", &counter{Total: 1}))
+
+	tally, _, err := counters.Get(t.Context(), "cnt.one")
+	require.NoError(t, err)
+	assert.Equal(t, 1, tally.Total)
+}
+
+// TestStore_ReplaceRetriesARevisionConflict is Replace's difference from Set:
+// a write that loses a race is retried against the winner's revision instead of
+// landing out of order.
+func TestStore_ReplaceRetriesARevisionConflict(t *testing.T) {
+	store := newStore(t)
+	mustCreate(t, store, "acct-a/one", record{Name: "one", Count: 1})
+
+	require.NoError(t, store.Replace(t.Context(), "acct-a/one", &record{Name: "replaced", Count: 9}))
+	got, _, err := store.Get(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.Equal(t, record{Name: "replaced", Count: 9}, *got, "Replace overwrites wholesale")
+
+	require.NoError(t, store.Replace(t.Context(), "acct-a/new", &record{Name: "new"}))
+	got, _, err = store.Get(t.Context(), "acct-a/new")
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Name, "Replace on an absent key creates it")
+}
+
+// TestStore_ClaimIsWonOnce pins the delete-as-claim: the first caller gets the
+// record, and every later one is told there was nothing to take rather than
+// handed a second copy.
+func TestStore_ClaimIsWonOnce(t *testing.T) {
+	store := newStore(t)
+	mustCreate(t, store, "acct-a/one", record{Name: "one", Count: 3})
+
+	got, notFound, err := store.Claim(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	require.False(t, notFound)
+	assert.Equal(t, record{Name: "one", Count: 3}, *got)
+
+	_, notFound, err = store.Claim(t.Context(), "acct-a/one")
+	require.NoError(t, err, "a lost claim is an answer, not an error")
+	assert.True(t, notFound)
+
+	present, err := store.Exists(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.False(t, present, "the claim takes the record with it")
+}
+
+// TestStore_ClaimRecoversAfterStreamLost keeps Claim on the recovery path. The
+// recreated bucket holds nothing, so notFound is the correct answer — what must
+// not happen is the stream error reaching the caller.
+func TestStore_ClaimRecoversAfterStreamLost(t *testing.T) {
+	_, js, store := newRecoverableStore(t, kvstore.Config{RecreateIfMissing: true})
+	require.NoError(t, store.Set(t.Context(), "acct-a/one", &record{Name: "one"}))
+	loseStream(t, js)
+
+	_, notFound, err := store.Claim(t.Context(), "acct-a/one")
+	require.NoError(t, err)
+	assert.True(t, notFound)
+}
+
+// TestBucket_DescriptionReachesTheCreatedBucket covers Config.Description,
+// which exists so a bucket recreated by recovery is not left anonymous.
+func TestBucket_DescriptionReachesTheCreatedBucket(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	bucket := kvstore.NewBucket(js, kvstore.Config{
+		Name:              "kvstore-description-test",
+		Description:       "a bucket that says what it is",
+		History:           1,
+		RecreateIfMissing: true,
+	})
+	kv, err := bucket.KV(t.Context())
+	require.NoError(t, err)
+
+	status, err := kv.Status(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "a bucket that says what it is", status.(*jetstream.KeyValueBucketStatus).StreamInfo().Config.Description)
+}

--- a/spinifex/kvstore/store.go
+++ b/spinifex/kvstore/store.go
@@ -191,6 +191,56 @@ func Over[T any](js jetstream.JetStream, kv jetstream.KeyValue, cfg Config) *Sto
 	return &Store[T]{Bucket: NewOpenBucket(js, kv, cfg)}
 }
 
+// On returns a Store for records of type T over an existing bucket, for a
+// bucket holding more than one record type. Every view shares the bucket's
+// handle, so they open once between them and one view's recovery repairs all.
+func On[T any](b *Bucket) *Store[T] {
+	return &Store[T]{Bucket: b}
+}
+
+// Claim atomically reads a record and deletes it, so at most one caller across
+// the cluster can win it. notFound reports that there was nothing to claim,
+// which is the losing racer's answer rather than an error.
+func (s *Store[T]) Claim(ctx context.Context, key string) (v *T, notFound bool, err error) {
+	// Safe to re-run: the read and the revision-guarded delete both happen
+	// inside kvutil.Claim, so a second attempt starts from the reopened bucket.
+	err = s.withKV(ctx, func(kv jetstream.KeyValue) error {
+		var claimErr error
+		v, notFound, claimErr = kvutil.Claim[T](ctx, kv, key, kvutil.CASConfig{
+			Attempts:  s.cfg.Attempts,
+			Exhausted: s.cfg.Exhausted,
+		})
+		return claimErr
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return v, notFound, nil
+}
+
+// Replace writes v over whatever key holds, under the store's CAS loop. Unlike
+// Set, which is a plain last-write-wins put, a write that loses a race here is
+// retried against the winner's revision rather than landing out of order. The
+// record is replaced wholesale, so unlike Mutate the caller needs no read and v
+// need not be copyable.
+func (s *Store[T]) Replace(ctx context.Context, key string, v *T) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("kvstore: encode %s: %w", key, err)
+	}
+	// Safe to re-run: kvutil.Put re-reads the revision inside its own loop.
+	return s.withKV(ctx, func(kv jetstream.KeyValue) error {
+		if err := kvutil.Put(ctx, kv, key, kvutil.CASConfig{
+			CreateIfAbsent: true,
+			Attempts:       s.cfg.Attempts,
+			Exhausted:      s.cfg.Exhausted,
+		}, data); err != nil {
+			return fmt.Errorf("kvstore: replace %s: %w", key, err)
+		}
+		return nil
+	})
+}
+
 // Set writes a record whether or not the key exists, for callers whose write
 // is a replacement rather than a claim or a read-modify-write.
 func (s *Store[T]) Set(ctx context.Context, key string, v *T) error {

--- a/spinifex/kvutil/kvutil.go
+++ b/spinifex/kvutil/kvutil.go
@@ -54,6 +54,38 @@ func GetOrCreateBucketWithReplicas(ctx context.Context, js jetstream.KeyValueMan
 	})
 }
 
+// BucketOptions is GetOrCreateBucket's full argument set, for callers needing a
+// combination the three named helpers do not cover. A zero Replicas means the
+// cluster default, matching those helpers.
+type BucketOptions struct {
+	Name        string
+	Description string
+	History     int
+	Replicas    int
+	TTL         time.Duration
+}
+
+// GetOrCreateBucketWithOptions creates or opens a KV bucket from opts. Like the
+// named helpers, every field but Name applies at creation only: an existing
+// bucket is opened with the config it already has.
+func GetOrCreateBucketWithOptions(ctx context.Context, js jetstream.KeyValueManager, opts BucketOptions) (jetstream.KeyValue, error) {
+	replicas := opts.Replicas
+	if replicas == 0 {
+		replicas = DefaultReplicas()
+	}
+	return getOrCreateBucket(ctx, js, jetstream.KeyValueConfig{
+		Bucket:      opts.Name,
+		Description: opts.Description,
+		History:     safecast.IntToUint8(opts.History),
+		Replicas:    max(replicas, 1),
+		TTL:         opts.TTL,
+	})
+}
+
+// DefaultReplicas is the cluster's default KV replica count, exposed so callers
+// building a BucketOptions can tell "unset" from a deliberate 1.
+func DefaultReplicas() int { return utils.DefaultKVReplicas() }
+
 func getOrCreateBucket(ctx context.Context, js jetstream.KeyValueManager, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
 	bucket := cfg.Bucket
 	kv, err := js.CreateKeyValue(ctx, cfg)


### PR DESCRIPTION
## Summary

Converts the two instance-state KV buckets onto `kvstore.Store[T]`. This is change 4 of `docs/development/josh/improvements/instance-state-authority.md`, and the last of the three PRs that unblocked it — #914 moved stream-loss detection into `kvutil`, #915 taught `kvstore` to recover, and this one deletes the hand-rolled version.

`daemon/jetstream.go` goes from 1079 lines to 759. Fifteen `IsStreamUnavailable` branches, three `recover*` helpers and the `kvMu` that guarded them are gone; recovery now comes from the primitive, opted into with `RecreateIfMissing: true` and an `OnOpen` that re-runs the schema migration.

## Why the sequencing mattered

The original plan said this conversion "removes the hand-rolled recovery branches in favour of the bucket's own accessor". That was backwards — `kvstore.Bucket` had no such accessor, it memoised one handle and never invalidated it. `daemon` was the only package in the tree that recovered from stream loss, so converting it as written would have deleted ten tested recovery paths and replaced them with nothing. Hence the two preceding PRs.

The measure of whether that worked: **all ten `_RecoverAfterStreamLost` tests and all seven `_RecoveryFailure` tests pass with their assertions unedited.** The only change to them is the harness — see below.

## Scope

`spinifex-cluster-state` is **not** converted. Heartbeats, shutdown markers, the mgmt-IPAM record and the service manifest live there, none of them has a recovery branch today, and each wants its own answer on whether recreating an emptied bucket is acceptable. That is a third bucket's worth of judgement and does not belong in this diff.

## Four decisions worth reviewing

**One bucket, two record types.** `spinifex-instance-state` holds `node.<id>` as a `{"vms": {...}}` envelope and `instance.<id>` as a bare `VM`. A `Store[T]` is a bucket plus one codec, so this needs two typed views over a **single** `Bucket` — one memoised handle, one recovery path, two decoders. `kvstore` gains `On[T](*Bucket)` for it, and there is a test that recovery driven through one view repairs the other, because the alternative (a handle each) would leave one view pointing at a dead stream.

**The nil-handle guards stay put.** Every method still opens with `if m.stopped == nil { return errors.New("KV bucket not initialized") }`, and the stores are only populated by an explicit `Init*Bucket`. A lazily-opening `Store` would create the bucket on first use instead, which is exactly what `disconnect_test.go`'s `assertNoClusterServicesInitialised` exists to reject: Tier 1 boot must not touch cluster KV. `Init*Bucket` builds the store and forces the open so a failure still surfaces at startup, as it did before.

**`UpdateStoppedInstance` keeps returning `jetstream.ErrKeyNotFound`.** `Store.Mutate` reports `kvstore.ErrNotFound`, but three call sites in `handlers/ec2/instance/service_impl.go`, `vm/mock`, and both `StateStore` interface definitions are written against the JetStream sentinel. `JetStreamManager` maps it back at its own boundary rather than leaking the change into the handlers; re-sentinelling the interface is a mechanical follow-up, not something to bury in a durability change. `kvstore-typed-store.md` lists this as the first trap of a conversion — *"re-read every error path"* — and it caught two real bugs in Phase 3.

**`List` is stricter than the scan it replaces, deliberately.** `ListStoppedInstances`/`ListTerminatedInstances` used to log an undecodable record and `continue`. `Store.List` fails the listing instead. Both feed `DescribeInstances`, so under the old behaviour a corrupt stopped instance silently vanished from a describe and the caller concluded it was terminated. Phase 3 settled this — *"a tenant-facing list is complete or it fails"* — after the same pattern was found undercounting committed capacity in `committedModelUnits`. This is a real behaviour change with a blast radius, hence the new test naming it.

## `kvstore` / `kvutil` additions

| Addition | Why |
| --- | --- |
| `kvstore.On[T](*Bucket)` | Two typed views over one bucket, sharing its handle and its recovery |
| `kvstore.Store[T].Claim` | `ClaimStoppedInstance`'s delete-as-claim is `kvutil.Claim`, which no `Store` method wrapped. Safe to re-run: it re-reads and re-CASes from scratch |
| `kvstore.Store[T].Replace` | CAS-guarded whole-value overwrite. `Set` is a plain last-write-wins put; `WriteStoppedInstance` needs the CAS so a racing update cannot land out of order. Also avoids `*v = *instance`, which `go vet` rejects because `vm.VM` transitively contains a `sync.Mutex` |
| `kvstore.Config.Description` | `InitKVBucket` sets one today; losing it on create or recreate is a silent parity loss |
| `kvutil.GetOrCreateBucketWithOptions` | Description × TTL × Replicas is past the point where another named helper per combination makes sense |

## Testing

`make preflight` passes.

The seventeen existing recovery tests keep their assertions. `swapToNonJSContext` had to change: it broke recovery by repointing `jsm.js` at a JetStream-less server, but the bucket captures its client at construction, so that no longer reached it. It now rebuilds the bucket around the **current handle** with the broken client, which reproduces the original shape more precisely — the operation fails on a stale handle, and the recovery that follows it cannot succeed.

New tests:

- `TestJetStreamManager_ListStoppedInstances_FailsOnAnUndecodableRecord` — pins the strictness change above.
- `TestJetStreamManager_UpdateStoppedInstance_AbsentKeyKeepsItsSentinel` — pins the boundary mapping for both stopped and terminated.
- `kvstore`: two typed views sharing one bucket and one open; recovery through one view repairing the other; `Replace` overwriting and creating; `Claim` won once then reporting `notFound`; `Claim` on the recovery path; `Description` reaching the created bucket.

I checked the two load-bearing ones are real guards rather than tests that pass either way:

- Dropping the `kvstore.ErrNotFound` → `jetstream.ErrKeyNotFound` mapping fails 5 tests, 3 of which are pre-existing (`_NotFound`, `_NoResurrectAfterClaim`).
- Flipping `RecreateIfMissing` to false fails all 7 `_RecoverAfterStreamLost` tests.

Not live-verified. The condition this code exists for is multi-node NATS formation churn, which a single embedded server cannot reproduce; that belongs on a real cluster and is worth doing now that instance state actually depends on the primitive.

## Follow-ups

- Re-sentinel the two `StateStore` interfaces onto `kvstore.ErrNotFound` and drop the boundary mapping. Mechanical, touches `handlers/ec2/instance` and `vm/mock`.
- Change 5 of the plan — converging the `{"vms": {...}}` envelope and the bare-`VM` form — is independent and still open.
- `spinifex-cluster-state` opts in separately, if it wants to.

Bead: `mulga-4vs8t`.
