### PR TITLE
refactor: store the node instance-state record in the local state envelope

### DIFF
--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -51,21 +51,28 @@ type KVSyncObserver interface {
 //
 // The instance-state bucket carries two record types, so it is one kvstore
 // bucket with two typed views over it: they share its handle, and a recovery
-// driven through either repairs both.
+// driven through either repairs both. A node's running set is stored as
+// LocalState, the same envelope the local state file uses.
 type JetStreamManager struct {
 	js        jetstream.JetStream
-	stateB    *kvstore.Bucket           // spinifex-instance-state
-	nodeState *kvstore.Store[nodeState] // node.<id> records
-	stopped   *kvstore.Store[vm.VM]     // instance.<id> records
-	term      *kvstore.Store[vm.VM]     // spinifex-terminated-instances
-	clusterKV jetstream.KeyValue        // spinifex-cluster-state
+	stateB    *kvstore.Bucket            // spinifex-instance-state
+	nodeState *kvstore.Store[LocalState] // node.<id> records
+	stopped   *kvstore.Store[vm.VM]      // instance.<id> records
+	term      *kvstore.Store[vm.VM]      // spinifex-terminated-instances
+	clusterKV jetstream.KeyValue         // spinifex-cluster-state
 	replicas  int
 	obs       KVSyncObserver
 }
 
-// nodeState is the envelope a node's running set is stored in.
-type nodeState struct {
-	VMS map[string]*vm.VM `json:"vms"`
+// checkNodeStateVersion reports whether a node record read from KV is one this
+// binary can parse. Version 0 predates record versioning and reads as current;
+// a version above current was written by a newer node and is not guessed at.
+func checkNodeStateVersion(key string, version int) error {
+	if version > LocalStateSchemaVersion {
+		return fmt.Errorf("instance state %s: record schema_version %d is newer than this node understands (%d)",
+			key, version, LocalStateSchemaVersion)
+	}
+	return nil
 }
 
 // SetSyncObserver registers obs to receive best-effort KV sync outcomes. Pass
@@ -138,7 +145,7 @@ func terminatedInstanceConfig(replicas int) kvstore.Config {
 // handle, so a recovery driven through either repairs both.
 func (m *JetStreamManager) setInstanceStateBucket(b *kvstore.Bucket) {
 	m.stateB = b
-	m.nodeState = kvstore.On[nodeState](b)
+	m.nodeState = kvstore.On[LocalState](b)
 	m.stopped = kvstore.On[vm.VM](b)
 }
 
@@ -394,7 +401,8 @@ func (m *JetStreamManager) WriteState(nodeID string, vms map[string]*vm.VM) erro
 	}
 
 	key := InstanceStatePrefix + nodeID
-	if err := m.nodeState.Set(context.Background(), key, &nodeState{VMS: vms}); err != nil {
+	record := LocalState{SchemaVersion: LocalStateSchemaVersion, VMS: vms}
+	if err := m.nodeState.Set(context.Background(), key, &record); err != nil {
 		return err
 	}
 
@@ -442,9 +450,11 @@ func (m *JetStreamManager) WriteStateBytesBestEffort(nodeID string, jsonData []b
 }
 
 // marshalInstanceState produces the JSON wire form of vms, for the best-effort
-// path that marshals under the caller's lock and commits lock-free.
+// path that marshals under the caller's lock and commits lock-free. The KV
+// record and the local state file are the same envelope, so this is the same
+// marshaller: the two cannot drift.
 func marshalInstanceState(vms map[string]*vm.VM) ([]byte, error) {
-	return json.Marshal(nodeState{VMS: vms})
+	return MarshalLocalState(vms)
 }
 
 // LoadState loads the instance state from the KV store for the given node.
@@ -464,6 +474,9 @@ func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, bool, er
 			slog.Debug("No existing state in JetStream KV", "key", key)
 			return make(map[string]*vm.VM), false, nil
 		}
+		return nil, false, err
+	}
+	if err := checkNodeStateVersion(key, state.SchemaVersion); err != nil {
 		return nil, false, err
 	}
 	if state.VMS == nil {

--- a/spinifex/daemon/jetstream_test.go
+++ b/spinifex/daemon/jetstream_test.go
@@ -1795,3 +1795,105 @@ func TestJetStreamManager_UpdateStoppedInstance_AbsentKeyKeepsItsSentinel(t *tes
 	})
 	require.ErrorIs(t, err, jetstream.ErrKeyNotFound)
 }
+
+// seedNodeRecord writes raw bytes at a node's key, bypassing the typed view, so
+// a test can present a record shape this binary would never write itself.
+func seedNodeRecord(t *testing.T, jsm *JetStreamManager, nodeID string, raw []byte) {
+	t.Helper()
+	kv, err := jsm.stateB.KV(t.Context())
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), InstanceStatePrefix+nodeID, raw)
+	require.NoError(t, err)
+}
+
+// A node record predates schema versioning, so it carries no version at all.
+// Reading it as current is what makes an in-place upgrade need no migration.
+func TestJetStreamManager_LoadState_UnversionedRecordStillReads(t *testing.T) {
+	nc, err := nats.Connect(sharedJSNATSURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	jsm, err := NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, jsm.InitKVBucket())
+
+	seedNodeRecord(t, jsm, "legacy-node",
+		[]byte(`{"vms":{"i-legacy-001":{"id":"i-legacy-001","status":"running"}}}`))
+
+	loaded, found, err := jsm.LoadState("legacy-node")
+	require.NoError(t, err, "A record written before versioning must still read")
+	require.True(t, found)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, vm.StateRunning, loaded["i-legacy-001"].Status)
+}
+
+// A record from a newer binary is refused rather than parsed on a guess: this
+// is the per-record guard the bucket-level version key cannot provide, since
+// that is checked once at open by whichever node opened it.
+func TestJetStreamManager_LoadState_FutureRecordIsRefused(t *testing.T) {
+	nc, err := nats.Connect(sharedJSNATSURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	jsm, err := NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, jsm.InitKVBucket())
+
+	seedNodeRecord(t, jsm, "future-node",
+		[]byte(`{"schema_version":99,"vms":{"i-future-001":{"id":"i-future-001"}}}`))
+
+	_, _, err = jsm.LoadState("future-node")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema_version 99")
+	assert.Contains(t, err.Error(), "newer than this node understands")
+}
+
+// Both writers stamp the version: the typed WriteState and the best-effort
+// pre-marshalled path, which is the one that would silently skip it.
+func TestJetStreamManager_WriteState_StampsSchemaVersion(t *testing.T) {
+	nc, err := nats.Connect(sharedJSNATSURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	jsm, err := NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, jsm.InitKVBucket())
+
+	vms := map[string]*vm.VM{"i-stamp-001": {ID: "i-stamp-001", Status: vm.StateRunning}}
+	require.NoError(t, jsm.WriteState("stamp-node", vms))
+
+	kv, err := jsm.stateB.KV(t.Context())
+	require.NoError(t, err)
+
+	read := func(nodeID string) LocalState {
+		t.Helper()
+		entry, err := kv.Get(t.Context(), InstanceStatePrefix+nodeID)
+		require.NoError(t, err)
+		var got LocalState
+		require.NoError(t, json.Unmarshal(entry.Value(), &got))
+		return got
+	}
+
+	assert.Equal(t, LocalStateSchemaVersion, read("stamp-node").SchemaVersion)
+
+	data, err := marshalInstanceState(vms)
+	require.NoError(t, err)
+	jsm.WriteStateBytesBestEffort("bytes-node", data, 5*time.Second)
+	assert.Equal(t, LocalStateSchemaVersion, read("bytes-node").SchemaVersion,
+		"the best-effort path marshals its own bytes and must stamp the same version")
+}
+
+// The KV node record and the local state file are one envelope. Asserted on the
+// bytes rather than the type, because a second marshaller is how they drift.
+func TestMarshalInstanceState_MatchesLocalStateFileBytes(t *testing.T) {
+	vms := map[string]*vm.VM{
+		"i-envelope-001": {ID: "i-envelope-001", Status: vm.StateRunning, InstanceType: "t3.micro"},
+	}
+
+	kvBytes, err := marshalInstanceState(vms)
+	require.NoError(t, err)
+	fileBytes, err := MarshalLocalState(vms)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(fileBytes), string(kvBytes))
+}

--- a/spinifex/daemon/local_state.go
+++ b/spinifex/daemon/local_state.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	// LocalStateSchemaVersion guards on-disk compatibility; bump on breaking changes.
+	// LocalStateSchemaVersion guards compatibility of a node's instance state
+	// record, on disk and in KV; bump on breaking changes.
 	LocalStateSchemaVersion = 1
 
 	// DefaultLocalStateDir is the default directory under DataDir for local state files.
@@ -25,8 +26,9 @@ const (
 	DefaultDataDir = "/var/lib/spinifex"
 )
 
-// LocalState is the on-disk representation of a node's instance state.
-// SchemaVersion gates compatibility; unknown versions are rejected.
+// LocalState is a node's instance state, both on disk and as the node.<id>
+// record in the instance-state KV bucket. SchemaVersion gates compatibility;
+// unknown versions are rejected.
 type LocalState struct {
 	SchemaVersion int               `json:"schema_version"`
 	VMS           map[string]*vm.VM `json:"vms"`
@@ -110,6 +112,9 @@ func ReadLocalState(path string) (*LocalState, error) {
 		return nil, fmt.Errorf("parse local state %s: %w", path, err)
 	}
 
+	// Stricter than the KV read, deliberately: the file has carried a version
+	// since it was introduced, so a 0 here is corruption rather than an old
+	// record, and reading it as current would be a guess.
 	if state.SchemaVersion != LocalStateSchemaVersion {
 		return nil, fmt.Errorf("local state %s: unknown schema_version %d (expected %d)",
 			path, state.SchemaVersion, LocalStateSchemaVersion)


### PR DESCRIPTION
## Summary

Change 5 of `instance-state-authority.md`: the `node.<id>` KV record and `instance-state.json` become one envelope, versioned and guarded on read.

Two of the plan's three envelopes converge here. **The third deliberately does not**, and that is the more useful half of this PR — see below.

## What converges

`daemon.nodeState` and `daemon.LocalState` were the same two fields over the same map, written by the same node from the same snapshot, differing only in that the file carried a `schema_version` and the KV record did not. `nodeState` is deleted; `LocalState` is now the type of both, and `marshalInstanceState` collapses into the existing `MarshalLocalState`.

One marshaller means one version stamp and no second place to forget it — including on `WriteStateBytesBestEffort`, which marshals its own bytes outside the typed view and is exactly the path that would have skipped it.

The wire change is additive: `node.<id>` gains `schema_version` next to the `vms` it already had.

## Two read guards, deliberately different

**KV accepts an unversioned record.** Every `node.<id>` written before this change has no version, so 0 means "predates versioning" and reads as current. Without that, an in-place upgrade would fail its first boot on a real cluster. It is also why this needs no migration.

**The file does not.** `ReadLocalState` still rejects anything but the current version, 0 included — the file has been versioned since it was introduced, so a 0 there is corruption, not an old record.

**Both refuse a record from the future.** A version above what the binary understands is an error, not a best-effort parse. This guard does not exist today: the bucket-level version key is checked once at open by whichever node happened to open it, so a node on an older binary reading a migrated bucket has nothing checking the records it gets back.

## What does not converge, and why

`instance.<id>` and `terminated.<id>` stay bare. Wrapping them is a shape change, not an additive one, and that is not safe to ship in a single release:

- `cluster-deploy` restarts nodes one at a time, so old and new binaries read each other's records for the length of the rollout. An old binary decoding `{"schema_version":1,"vms":{...}}` into a `vm.VM` **does not fail** — `vm.VM` has neither field, `encoding/json` ignores unknown keys, and the result is a zero VM with no error. `ListStoppedInstances` and `ClaimStoppedInstance` both read these keys cluster-wide, so the failure mode is a stopped instance reading as blank, or being claimed with empty data. A migration does not help: it fixes the records, not the old readers still writing the old shape alongside it.
- Versioning them additively instead would mean a field on `vm.VM`, which is the in-memory domain type and nests inside both envelopes — the version would land on every VM in every record and anywhere else one is marshalled. That is persistence leaking into the domain type to buy a guard on two keys.
- **Phase 6 re-keys these buckets per resource, which converges on the bare form** — the opposite direction. Wrapping now means one fleet-wide migration into the envelope and a second back out of it, to land where a single migration would.

So they wait for Phase 6 and converge once, the way Phase 6 needs. What Phase 6 inherits is the constraint written down: a shape change to a cluster-shared instance record needs a transition release, because the silent-zero decode is not detectable by the reader.

The plan doc is updated with all of this rather than left saying all three converge.

## Testing

`make preflight` passes.

Four new tests, each mutation-checked — reverting the guard fails `FutureRecordIsRefused`, and restoring the second marshaller fails both `StampsSchemaVersion` and `MatchesLocalStateFileBytes`:

| Test | Pins |
| --- | --- |
| `LoadState_UnversionedRecordStillReads` | Seeds a raw pre-versioning record; it reads. This is the no-migration claim. |
| `LoadState_FutureRecordIsRefused` | `schema_version: 99` errors rather than parsing |
| `WriteState_StampsSchemaVersion` | Both writers stamp, asserted on the bytes in the bucket |
| `MarshalInstanceState_MatchesLocalStateFileBytes` | KV and file bytes agree — asserted on bytes, since a second marshaller is how they drift |

Bead: `mulga-vbtg7`.
