### PR TITLE
refactor: replace persisted command attributes with desired state

### DIFF
--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -708,20 +708,20 @@ func TestDaemon_BootAllocation(t *testing.T) {
 			InstanceType: getTestInstanceType(t),
 			Status:       vm.StateRunning,
 			AccountID:    testAccountID,
-			Attributes:   types.EC2CommandAttributes{StopInstance: false},
+			DesiredState: vm.DesiredRunning,
 		},
 		"i-stopped": {
 			ID:           "i-stopped",
 			InstanceType: getTestInstanceType(t),
 			Status:       vm.StateStopped,
 			AccountID:    testAccountID,
-			Attributes:   types.EC2CommandAttributes{StopInstance: true},
+			DesiredState: vm.DesiredStopped,
 		},
 		"i-terminated": {
 			ID:           "i-terminated",
 			InstanceType: getTestInstanceType(t),
 			Status:       vm.StateTerminated,
-			Attributes:   types.EC2CommandAttributes{StopInstance: false},
+			DesiredState: vm.DesiredRunning,
 		},
 	}
 
@@ -756,7 +756,7 @@ func TestDaemon_BootAllocation(t *testing.T) {
 
 	// Simulate the allocation loop in Start()
 	for _, instance := range daemon.vmMgr.Snapshot() {
-		if instance.Status != vm.StateTerminated && !instance.Attributes.StopInstance {
+		if instance.Status != vm.StateTerminated && instance.DesiredState != vm.DesiredStopped {
 			instanceType, ok := daemon.resourceMgr.instanceTypes[instance.InstanceType]
 			if ok {
 				err := daemon.resourceMgr.allocate(instanceType)

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -878,11 +878,9 @@ func TestRestoreInstances_UserStoppedMigratedToSharedKV(t *testing.T) {
 	daemon := createDaemonWithJetStream(t)
 
 	daemon.vmMgr.Insert(&vm.VM{
-		ID:     "i-restore-userstop",
-		Status: vm.StateStopped,
-		Attributes: types.EC2CommandAttributes{
-			StopInstance: true,
-		},
+		ID:           "i-restore-userstop",
+		Status:       vm.StateStopped,
+		DesiredState: vm.DesiredStopped,
 	})
 	require.NoError(t, daemon.WriteState())
 
@@ -974,7 +972,7 @@ func TestRestoreInstances_MixedStates(t *testing.T) {
 	})
 	daemon.vmMgr.Insert(&vm.VM{
 		ID: "i-mix-stopped", Status: vm.StateStopped,
-		Attributes: types.EC2CommandAttributes{StopInstance: true},
+		DesiredState: vm.DesiredStopped,
 	})
 	require.NoError(t, daemon.WriteState())
 
@@ -1112,10 +1110,7 @@ func TestStatePersistence_RoundTrip(t *testing.T) {
 		ID:           "i-roundtrip",
 		Status:       vm.StateRunning,
 		InstanceType: "t3.micro",
-		Attributes: types.EC2CommandAttributes{
-			StopInstance:      false,
-			TerminateInstance: false,
-		},
+		DesiredState: vm.DesiredRunning,
 	}
 	daemon.vmMgr.Insert(original)
 	require.NoError(t, daemon.WriteState())
@@ -1131,7 +1126,7 @@ func TestStatePersistence_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.ID, loaded.ID)
 	assert.Equal(t, original.Status, loaded.Status)
 	assert.Equal(t, original.InstanceType, loaded.InstanceType)
-	assert.Equal(t, original.Attributes.StopInstance, loaded.Attributes.StopInstance)
+	assert.Equal(t, original.DesiredState, loaded.DesiredState)
 }
 
 // TestWriteState_LocalFailureStillWritesKV guards against a launch-window data
@@ -1174,7 +1169,7 @@ func TestRestoreInstances_StoppedInstanceMigratedToSharedKV(t *testing.T) {
 		ID:           instanceID,
 		InstanceType: "t3.micro",
 		Status:       vm.StateStopped,
-		Attributes:   types.EC2CommandAttributes{StopInstance: true},
+		DesiredState: vm.DesiredStopped,
 	})
 	require.NoError(t, daemon.WriteState())
 

--- a/spinifex/handlers/ec2/instance/dns_hook_test.go
+++ b/spinifex/handlers/ec2/instance/dns_hook_test.go
@@ -57,6 +57,29 @@ func TestNeedsDNSWithdrawal(t *testing.T) {
 	}
 }
 
+// The race the check exists for: terminate lands while the deferred launch is
+// still publishing the UPSERT, so Status has not caught up and only the
+// deletion mark says the record is going away.
+func TestTerminateRacedLaunch(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name string
+		v    *vm.VM
+		want bool
+	}{
+		{name: "running, not marked", v: &vm.VM{ID: "i-1", Status: vm.StateRunning}, want: false},
+		{name: "running, marked for deletion", v: &vm.VM{ID: "i-1", Status: vm.StateRunning, DeletionTimestamp: &now}, want: true},
+		{name: "settled terminated", v: &vm.VM{ID: "i-1", Status: vm.StateTerminated}, want: true},
+		{name: "operator stopped", v: &vm.VM{ID: "i-1", Status: vm.StateStopped, DesiredState: vm.DesiredStopped}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &InstanceServiceImpl{vmMgr: mgrWith(map[string]*vm.VM{tt.v.ID: tt.v})}
+			require.Equal(t, tt.want, svc.terminateRacedLaunch(tt.v))
+		})
+	}
+}
+
 func TestPrepareRunInstancesDoesNotPublishDNS(t *testing.T) {
 	eni := &fakeENICreator{
 		defaultSubnet: &SubnetInfo{SubnetID: "subnet-default", VpcID: "vpc-1"},

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -1041,7 +1041,7 @@ func needsDNSWithdrawal(status vm.InstanceState) bool {
 func (s *InstanceServiceImpl) terminateRacedLaunch(instance *vm.VM) bool {
 	withdraw := false
 	s.vmMgr.Inspect(instance, func(v *vm.VM) {
-		withdraw = v.Attributes.TerminateInstance || needsDNSWithdrawal(v.Status)
+		withdraw = v.DeletionTimestamp != nil || needsDNSWithdrawal(v.Status)
 	})
 	return withdraw
 }
@@ -1101,9 +1101,9 @@ func (s *InstanceServiceImpl) StartInstance(ctx context.Context, instance *vm.VM
 		}
 	}
 
-	// Clear stop attribute before launch; a stale StopInstance=true would
-	// cause the daemon to skip QEMU reconnect on restart.
-	s.vmMgr.UpdateState(instance.ID, func(v *vm.VM) { v.Attributes = command.Attributes })
+	// Clear the stop intent before launch; a stale DesiredStopped would cause
+	// the daemon to skip QEMU reconnect on restart.
+	s.vmMgr.UpdateState(instance.ID, func(v *vm.VM) { v.DesiredState = vm.DesiredRunning })
 
 	if err := s.vmMgr.Start(ctx, instance.ID); err != nil {
 		if ok {
@@ -1159,7 +1159,12 @@ func (s *InstanceServiceImpl) StopOrTerminateInstance(ctx context.Context, insta
 			stateMismatch = true
 			return
 		}
-		v.Attributes = command.Attributes
+		if isTerminate {
+			now := time.Now().UTC()
+			v.DeletionTimestamp = &now
+		} else {
+			v.DesiredState = vm.DesiredStopped
+		}
 		// Auto-disassociate IAM profile on terminate (AWS parity; stop/start preserves it).
 		// Done under the same lock so DescribeInstances never sees a terminated
 		// instance advertising a profile.
@@ -2345,8 +2350,8 @@ func (s *InstanceServiceImpl) StartStoppedInstance(ctx context.Context, input *S
 		return nil, errors.New(awserrors.ErrorInsufficientInstanceCapacity)
 	}
 
-	// Add to local map + clear stop attribute before launch.
-	instance.Attributes = spxtypes.EC2CommandAttributes{StartInstance: true}
+	// Add to local map + clear the stop intent before launch.
+	instance.DesiredState = vm.DesiredRunning
 	s.vmMgr.Insert(instance)
 
 	// Claim GPU for GPU instance types.

--- a/spinifex/vm/desired_state_test.go
+++ b/spinifex/vm/desired_state_test.go
@@ -1,0 +1,109 @@
+package vm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A record written before DesiredState existed carries the operator stop in the
+// command it was stamped with. Losing that on upgrade would relaunch an
+// instance the operator deliberately stopped.
+func TestVMUnmarshal_LegacyOperatorStopFolds(t *testing.T) {
+	var v VM
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"id":"i-1","status":"stopped","attributes":{"stop_instance":true}}`), &v))
+
+	assert.Equal(t, DesiredStopped, v.DesiredState)
+	assert.Nil(t, v.LegacyAttributes, "the legacy field is read once and dropped")
+}
+
+// A drain stop never stamped StopInstance, so a legacy drain-stopped record
+// must stay desired-running and be relaunched.
+func TestVMUnmarshal_LegacyDrainStopStaysRunning(t *testing.T) {
+	var v VM
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"id":"i-1","status":"stopped","attributes":{"stop_instance":false}}`), &v))
+
+	assert.Equal(t, DesiredRunning, v.DesiredState)
+}
+
+// Only StopInstance folds. TerminateInstance was a launch-race latch, not a
+// persisted intent, and a terminated record is already settled by Status.
+func TestVMUnmarshal_LegacyTerminateDoesNotFold(t *testing.T) {
+	var v VM
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"id":"i-1","status":"terminated","attributes":{"delete_instance":true}}`), &v))
+
+	assert.Equal(t, DesiredRunning, v.DesiredState)
+	assert.Nil(t, v.DeletionTimestamp)
+}
+
+// A record carrying both must take the new field: the legacy one is only a
+// fallback for records written before it existed.
+func TestVMUnmarshal_ExplicitDesiredStateWins(t *testing.T) {
+	var v VM
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"id":"i-1","desired_state":"stopped","attributes":{"stop_instance":false}}`), &v))
+
+	assert.Equal(t, DesiredStopped, v.DesiredState)
+}
+
+// The point of the change is that the command stops being persisted at all.
+// Round-tripping a legacy record must emit desired_state and no attributes.
+func TestVMMarshal_LegacyAttributesNotWrittenBack(t *testing.T) {
+	var v VM
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"id":"i-1","status":"stopped","attributes":{"stop_instance":true}}`), &v))
+
+	out, err := json.Marshal(&v)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &raw))
+	assert.NotContains(t, raw, "attributes", "the command must not be written back")
+	assert.Contains(t, raw, "desired_state")
+}
+
+// The other twelve command booleans had nowhere to go because nothing read them
+// back. A record must carry none of them, so they are gone rather than unread.
+func TestVMMarshal_CommandBooleansAreNotPersisted(t *testing.T) {
+	legacy, err := json.Marshal(map[string]any{
+		"id": "i-1", "status": StateRunning,
+		"attributes": types.EC2CommandAttributes{
+			AttachVolume:                true,
+			DetachVolume:                true,
+			DrainVolume:                 true,
+			StartInstance:               true,
+			RebootInstance:              true,
+			AttachENI:                   true,
+			DetachENI:                   true,
+			AssociateIamInstanceProfile: true,
+			SetSpotLineage:              true,
+			SetInstanceTags:             true,
+			RemoveInstanceTags:          true,
+			SetInstanceMonitoring:       true,
+		},
+	})
+	require.NoError(t, err)
+
+	var v VM
+	require.NoError(t, json.Unmarshal(legacy, &v))
+	require.Nil(t, v.LegacyAttributes)
+
+	out, err := json.Marshal(&v)
+	require.NoError(t, err)
+
+	for _, field := range []string{
+		"attach_volume", "detach_volume", "drain_volume", "start_instance",
+		"reboot_instance", "attach_eni", "detach_eni",
+		"associate_iam_instance_profile", "set_spot_lineage", "set_instance_tags",
+		"remove_instance_tags", "set_instance_monitoring",
+	} {
+		assert.NotContains(t, string(out), field,
+			"command boolean %q must not reach the persisted record", field)
+	}
+}

--- a/spinifex/vm/restore.go
+++ b/spinifex/vm/restore.go
@@ -120,7 +120,7 @@ func (m *Manager) classifyRestoredInstances() []*VM {
 		}
 
 		if instance.Status == StateStopped {
-			if instance.Attributes.StopInstance {
+			if instance.DesiredState == DesiredStopped {
 				if !m.MigrateStoppedToSharedKV(instance) {
 					// KV write failed — keep in local state so the next restart
 					// retries the migration. Deleting here would create a "void":
@@ -132,7 +132,7 @@ func (m *Manager) classifyRestoredInstances() []*VM {
 				continue
 			}
 
-			// StateStopped with no operator StopInstance intent means the
+			// StateStopped that nobody asked for means the
 			// host DRAIN sequence stopped it for a coordinated reboot/shutdown,
 			// not the operator. Treat it like a running instance whose QEMU
 			// exited: reset to Pending and relaunch.
@@ -232,11 +232,11 @@ func (m *Manager) classifyRestoredInstances() []*VM {
 
 // markUnschedulable flips an instance to Stopped with InsufficientInstanceCapacity
 // so DescribeInstances reports a useful error when the node can no longer host the type.
-// StopInstance is stamped so a future restore's drain-relaunch path (which
-// resumes StateStopped without operator intent) does not try to relaunch it.
+// DesiredStopped is stamped so a future restore's drain-relaunch path (which
+// resumes a StateStopped nobody asked for) does not try to relaunch it.
 func markUnschedulable(instance *VM, reason string) {
 	instance.Status = StateStopped
-	instance.Attributes.StopInstance = true
+	instance.DesiredState = DesiredStopped
 	if instance.Instance != nil {
 		instance.Instance.StateReason = &ec2.StateReason{}
 		instance.Instance.StateReason.SetCode("Server.InsufficientInstanceCapacity")

--- a/spinifex/vm/restore_test.go
+++ b/spinifex/vm/restore_test.go
@@ -134,7 +134,7 @@ func TestClassifyRestoredInstances_TerminatedMigrates(t *testing.T) {
 }
 
 // TestClassifyRestoredInstances_StoppedMigrates covers the operator-stopped
-// case: Attributes.StopInstance=true is the signal stamped only by the
+// case: DesiredStopped is the signal stamped only by the
 // operator StopInstances path, so classify must honour it and never relaunch.
 func TestClassifyRestoredInstances_StoppedMigrates(t *testing.T) {
 	m, store, _ := classifyTestManager(t)
@@ -142,7 +142,7 @@ func TestClassifyRestoredInstances_StoppedMigrates(t *testing.T) {
 		ID:           "i-stopped",
 		Status:       StateStopped,
 		InstanceType: "t3.micro",
-		Attributes:   types.EC2CommandAttributes{StopInstance: true},
+		DesiredState: DesiredStopped,
 	}
 	m.Replace(map[string]*VM{v.ID: v})
 
@@ -156,7 +156,7 @@ func TestClassifyRestoredInstances_StoppedMigrates(t *testing.T) {
 
 // TestClassifyRestoredInstances_DrainStoppedRelaunches covers the
 // coordinated-shutdown DRAIN case: a VM left StateStopped with no operator
-// StopInstance intent (Attributes zero value) must be queued for relaunch,
+// stop intent (DesiredState zero value) must be queued for relaunch,
 // not migrated to the stopped bucket, exactly like a running instance whose
 // QEMU exited.
 func TestClassifyRestoredInstances_DrainStoppedRelaunches(t *testing.T) {
@@ -165,7 +165,7 @@ func TestClassifyRestoredInstances_DrainStoppedRelaunches(t *testing.T) {
 		ID:           "i-drain-stopped",
 		Status:       StateStopped,
 		InstanceType: "t3.micro",
-		Attributes:   types.EC2CommandAttributes{},
+		DesiredState: DesiredRunning,
 		Instance:     &ec2.Instance{},
 	}
 	m.Replace(map[string]*VM{v.ID: v})
@@ -195,8 +195,8 @@ func TestClassifyRestoredInstances_UnschedulableInstanceNotRelaunched(t *testing
 		Instance:     &ec2.Instance{},
 	}
 	markUnschedulable(v, "insufficient resources")
-	require.True(t, v.Attributes.StopInstance,
-		"markUnschedulable must stamp StopInstance so a later restore does not resume it")
+	require.Equal(t, DesiredStopped, v.DesiredState,
+		"markUnschedulable must stamp DesiredStopped so a later restore does not resume it")
 	m.Replace(map[string]*VM{v.ID: v})
 
 	toLaunch := m.classifyRestoredInstances()
@@ -391,7 +391,7 @@ func TestRestore_HappyPath(t *testing.T) {
 			"i-term": {ID: "i-term", Status: StateTerminated, InstanceType: "t3.micro"},
 			"i-stopped": {
 				ID: "i-stopped", Status: StateStopped, InstanceType: "t3.micro",
-				Attributes: types.EC2CommandAttributes{StopInstance: true},
+				DesiredState: DesiredStopped,
 			},
 		},
 	}

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -64,7 +64,7 @@ func (m *Manager) stopOne(instance *VM) (bool, error) {
 		slog.Error("Failed to transition to stopped", "instanceId", instance.ID, "err", err)
 	}
 
-	if !instance.Attributes.StopInstance {
+	if instance.DesiredState != DesiredStopped {
 		// Host DRAIN stop (not operator): keep the VM in the local running
 		// map at StateStopped so Restore relaunches it on the next boot. Do
 		// not migrate to the operator-stopped shared bucket or fire

--- a/spinifex/vm/shutdown_test.go
+++ b/spinifex/vm/shutdown_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/gpu"
 	"github.com/mulgadc/spinifex/spinifex/qmp"
-	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -278,7 +277,7 @@ func TestStopAll_FiresOnInstanceDownAndMigratesPerVM(t *testing.T) {
 			Status:       StateRunning,
 			InstanceType: "t3.micro",
 			Instance:     &ec2.Instance{},
-			Attributes:   types.EC2CommandAttributes{StopInstance: true},
+			DesiredState: DesiredStopped,
 		})
 	}
 
@@ -328,7 +327,7 @@ func TestStopAll_DrainStopKeepsLocalNoMigrate(t *testing.T) {
 			Status:       StateRunning,
 			InstanceType: "t3.micro",
 			Instance:     &ec2.Instance{},
-			Attributes:   types.EC2CommandAttributes{},
+			DesiredState: DesiredRunning,
 		})
 	}
 
@@ -432,7 +431,7 @@ func TestStopAll_WriteRunningStateFailure(t *testing.T) {
 			Status:       StateRunning,
 			InstanceType: "t3.micro",
 			Instance:     &ec2.Instance{},
-			Attributes:   types.EC2CommandAttributes{StopInstance: true},
+			DesiredState: DesiredStopped,
 		})
 	}
 
@@ -557,7 +556,7 @@ func TestStop_FiresOnInstanceDownExactlyOnce(t *testing.T) {
 		Status:       StateRunning,
 		InstanceType: "t3.micro",
 		Instance:     &ec2.Instance{},
-		Attributes:   types.EC2CommandAttributes{StopInstance: true},
+		DesiredState: DesiredStopped,
 	}
 	m.Insert(v)
 
@@ -597,7 +596,7 @@ func TestStop_DoesNotFireOnInstanceDown_OnSlotReclaim(t *testing.T) {
 		Status:       StateRunning,
 		InstanceType: "t3.micro",
 		Instance:     &ec2.Instance{},
-		Attributes:   types.EC2CommandAttributes{StopInstance: true},
+		DesiredState: DesiredStopped,
 	}
 	m.Insert(v)
 

--- a/spinifex/vm/vm.go
+++ b/spinifex/vm/vm.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -48,6 +49,22 @@ type ExtraENI struct {
 	Gateway       string `json:"gateway,omitempty"`
 }
 
+// DesiredState is the state an operator has asked an instance to be in. It is
+// deliberately narrower than InstanceState: only a settled state can be desired,
+// so "desired: stopping" cannot be expressed and the two enums cannot drift into
+// meaning the same thing.
+type DesiredState string
+
+const (
+	// DesiredRunning is the zero value, so an instance nobody has asked to stop
+	// is one that should be running.
+	DesiredRunning DesiredState = ""
+
+	// DesiredStopped means the instance must stay stopped across a restart,
+	// rather than being relaunched the way a drain-stopped one is.
+	DesiredStopped DesiredState = "stopped"
+)
+
 type VM struct {
 	ID           string        `json:"id"`
 	Status       InstanceState `json:"status"`
@@ -66,8 +83,19 @@ type VM struct {
 	// Manager hands out a stable *VM, so the lock is shared across calls.
 	attachMu sync.Mutex `json:"-"`
 
-	// User attributes (user initiated stop/delete)
-	Attributes types.EC2CommandAttributes `json:"attributes"`
+	// DesiredState is the state this instance has been asked to be in, as
+	// opposed to Status, which is the state it is observed to be in.
+	DesiredState DesiredState `json:"desired_state,omitempty"`
+
+	// DeletionTimestamp is stamped when a terminate is accepted, before the
+	// status transition lands. It is the marked-for-deletion signal a caller
+	// needs during the window where Status has not caught up yet.
+	DeletionTimestamp *time.Time `json:"deletion_timestamp,omitempty"`
+
+	// LegacyAttributes is the command last stamped onto records written before
+	// DesiredState existed. Read on decode to recover the operator-stop signal,
+	// then dropped; never written.
+	LegacyAttributes *types.EC2CommandAttributes `json:"attributes,omitempty"`
 
 	// EC2 API metadata stored for AWS API compatibility.
 	RunInstancesInput *ec2.RunInstancesInput `json:"run_instances_input,omitempty"`
@@ -178,6 +206,21 @@ type VM struct {
 	// tolerated by migrate.
 	InstanceLifecycle     string `json:"instance_lifecycle,omitempty"`
 	SpotInstanceRequestId string `json:"spot_instance_request_id,omitempty"`
+}
+
+// UnmarshalJSON folds a legacy record's operator-stop signal into DesiredState.
+// Done on decode so every read path inherits it and none has to remember, and
+// so the legacy field is dropped rather than written back out.
+func (v *VM) UnmarshalJSON(data []byte) error {
+	type alias VM
+	if err := json.Unmarshal(data, (*alias)(v)); err != nil {
+		return err
+	}
+	if v.DesiredState == DesiredRunning && v.LegacyAttributes != nil && v.LegacyAttributes.StopInstance {
+		v.DesiredState = DesiredStopped
+	}
+	v.LegacyAttributes = nil
+	return nil
 }
 
 // ResetNodeLocalState zeroes node-specific fields after deserializing a VM


### PR DESCRIPTION
## Summary

Retires `types.EC2CommandAttributes` from the persisted instance record. The
command an instance was last handled with was being stored on `vm.VM`, but only
two of its fourteen booleans were ever read back, and both of those are
properly spec/status fields rather than a command echo.

This is step 1 of the instance spec/status split, and the largest single
simplification in it: the persisted record stops carrying a wire dispatch
struct.

## What changed

`vm.VM.Attributes` is replaced by two purpose-built fields:

- `DesiredState` — the state an operator asked the instance to be in. A
  distinct two-value type (`DesiredRunning` / `DesiredStopped`) rather than a
  reuse of `InstanceState`, so "desired: stopping" cannot be expressed and the
  two enums cannot drift into meaning the same thing.
- `DeletionTimestamp` — stamped when a terminate is accepted, before the status
  transition lands. This is the marked-for-deletion signal `terminateRacedLaunch`
  needs during the window where `Status` has not caught up.

The two read sites move across directly:

- `restore.go` — a `StateStopped` record with `DesiredStopped` is an operator
  stop and is not relaunched; without it, the host drain stopped it and it is
  reset to `Pending` and relaunched.
- `shutdown.go` — the same distinction decides whether `stopOne` migrates to
  the shared stopped bucket and fires `OnInstanceDown`.

The other twelve booleans had no reader and are simply gone.

## Upgrade path

Records written before this change carry the operator stop only inside
`attributes`. `VM.UnmarshalJSON` folds `attributes.stop_instance` into
`DesiredState` on decode, so every read path inherits it and none has to
remember, then drops the legacy field so it is never written back.

Only `stop_instance` folds. `delete_instance` was a latch for an in-process
launch/terminate race, not a persisted intent — a settled terminated record is
already covered by `needsDNSWithdrawal(v.Status)`.

The change is additive on the wire in both directions: an old binary reading a
new record sees no `attributes` and treats the instance as desired-running,
which for a rolling deploy means at worst a drain-stopped instance is
relaunched. The command struct itself is unchanged; it remains the NATS
dispatch type on `types.EC2InstanceCommand`.

## Testing

`make preflight` passes.

New tests cover the fold in both directions (operator stop folds, drain stop
and terminate do not, an explicit `desired_state` wins), that a round-tripped
legacy record emits `desired_state` and no `attributes`, and that none of the
twelve command booleans reach the persisted record. `terminateRacedLaunch` gains
a test for the race window it exists for: marked for deletion while still
`Running`.

The existing restore and shutdown tests that asserted on `Attributes.StopInstance`
were translated site by site to `DesiredState`. `gc_invariants_test.go` and
`lifecycle_invariants_test.go` pass unedited.
