### PR TITLE
feat: mirror each node's running set onto the i.<id> key space

### DIFF
--- a/spinifex/daemon/blob_cost_bench_test.go
+++ b/spinifex/daemon/blob_cost_bench_test.go
@@ -1,0 +1,116 @@
+package daemon_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/daemon"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+)
+
+// benchVM approximates a real instance record. The env19 terminated bucket
+// averages ~10KB per record, and Instance is nearly all of it.
+func benchVM(id string) *vm.VM {
+	now := time.Now()
+	tags := make([]*ec2.Tag, 0, 12)
+	for i := range 12 {
+		tags = append(tags, &ec2.Tag{
+			Key:   aws.String(fmt.Sprintf("tag-key-%d", i)),
+			Value: aws.String(fmt.Sprintf("tag-value-%d-with-some-realistic-length", i)),
+		})
+	}
+	enis := make([]*ec2.InstanceNetworkInterface, 0, 2)
+	for i := range 2 {
+		enis = append(enis, &ec2.InstanceNetworkInterface{
+			NetworkInterfaceId: aws.String(fmt.Sprintf("eni-%s-%d", id, i)),
+			MacAddress:         aws.String("02:00:00:00:00:01"),
+			PrivateIpAddress:   aws.String("172.31.0.5"),
+			SubnetId:           aws.String("subnet-0123456789abcdef0"),
+			VpcId:              aws.String("vpc-0123456789abcdef0"),
+			Status:             aws.String("in-use"),
+			Groups: []*ec2.GroupIdentifier{
+				{GroupId: aws.String("sg-0123456789abcdef0"), GroupName: aws.String("default")},
+			},
+		})
+	}
+	return &vm.VM{
+		ID:           id,
+		AccountID:    "111122223333",
+		InstanceType: "t3.micro",
+		Status:       vm.StateRunning,
+		LastNode:     "node-1",
+		DesiredState: vm.DesiredRunning,
+		Instance: &ec2.Instance{
+			InstanceId:         aws.String(id),
+			ImageId:            aws.String("ami-0123456789abcdef0"),
+			InstanceType:       aws.String("t3.micro"),
+			KeyName:            aws.String("my-key"),
+			LaunchTime:         &now,
+			PrivateIpAddress:   aws.String("172.31.0.5"),
+			PrivateDnsName:     aws.String("ip-172-31-0-5.ap-southeast-2.compute.internal"),
+			SubnetId:           aws.String("subnet-0123456789abcdef0"),
+			VpcId:              aws.String("vpc-0123456789abcdef0"),
+			Architecture:       aws.String("x86_64"),
+			RootDeviceName:     aws.String("/dev/sda1"),
+			RootDeviceType:     aws.String("ebs"),
+			VirtualizationType: aws.String("hvm"),
+			Hypervisor:         aws.String("xen"),
+			State:              &ec2.InstanceState{Code: aws.Int64(16), Name: aws.String("running")},
+			Placement:          &ec2.Placement{AvailabilityZone: aws.String("ap-southeast-2a")},
+			Monitoring:         &ec2.Monitoring{State: aws.String("disabled")},
+			MetadataOptions: &ec2.InstanceMetadataOptionsResponse{
+				HttpEndpoint: aws.String("enabled"), HttpTokens: aws.String("required"),
+			},
+			NetworkInterfaces: enis,
+			Tags:              tags,
+		},
+	}
+}
+
+func benchSet(n int) map[string]*vm.VM {
+	set := make(map[string]*vm.VM, n)
+	for i := range n {
+		id := fmt.Sprintf("i-%017d", i)
+		set[id] = benchVM(id)
+	}
+	return set
+}
+
+// What one instance's state change costs while the blob is what gets written:
+// the whole node's set, marshalled every time. Reports the blob size alongside
+// the time so the amplification is readable from the benchmark output.
+func BenchmarkMarshalBlob(b *testing.B) {
+	for _, n := range []int{1, 10, 50, 100} {
+		set := benchSet(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			var blob []byte
+			for b.Loop() {
+				var err error
+				if blob, err = daemon.MarshalLocalState(set); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(len(blob)), "blob_bytes")
+		})
+	}
+}
+
+// The counterpart: what the same state change costs once the record is what
+// gets written. Constant in N, which is the whole point of the split.
+func BenchmarkMarshalOneRecord(b *testing.B) {
+	record := benchVM("i-0").Record()
+	b.ReportAllocs()
+	var blob []byte
+	for b.Loop() {
+		var err error
+		if blob, err = json.Marshal(record); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(len(blob)), "blob_bytes")
+}

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2620,8 +2620,12 @@ func (d *Daemon) persistState(nodeID string, vms map[string]*vm.VM) error {
 		d.stateRevision.Add(1)
 	}
 
+	// The mirror follows the blob it mirrors, so a record on the new key space
+	// is never newer than the running set it belongs to. vms is the caller's
+	// snapshot and cannot change underneath either write.
 	if d.jsManager != nil {
 		d.jsManager.WriteStateBytesBestEffort(nodeID, kvData, kvSyncTimeout)
+		d.jsManager.MirrorRunningSet(nodeID, vms)
 	}
 
 	if localErr != nil {

--- a/spinifex/daemon/instance_records.go
+++ b/spinifex/daemon/instance_records.go
@@ -11,15 +11,19 @@ import (
 )
 
 // InstanceRecordPrefix is the key prefix for the per-resource instance record
-// space. The stopped and terminated key spaces are mirrored onto it; the
-// node.<id> blob is not, and still holds a node's whole running set.
+// space. All three key spaces it replaces are mirrored onto it.
 //
-// It cannot collide with the three prefixes it replaces. Those separate their
-// prefix from the ID with ".", and a key beginning "i/" is neither "instance."
-// nor "node." nor "terminated." — List and DeletePrefix match on a plain
-// string prefix, not on NATS subject tokens, so the two spaces are disjoint
-// while they share a bucket.
-const InstanceRecordPrefix = "i/"
+// It cannot collide with those three. List and DeletePrefix match on a plain
+// string prefix rather than on NATS subject tokens, and "instance.", "node."
+// and "terminated." do not begin "i." — so the spaces stay disjoint while they
+// share a bucket.
+//
+// The separator is a dot rather than a slash because a watch filter is a NATS
+// subject filter, where "*" matches one dot-delimited token. "i/<id>" is a
+// single token, so "i/*" matches nothing and a watch over this space would
+// have to take the whole bucket. "i.<id>" is two, so "i.*" is the filter the
+// DNS reconcile narrows to at the cutover.
+const InstanceRecordPrefix = "i."
 
 // instanceRecordKey is the only place the prefix and the ID are joined, so a
 // reader and a writer cannot disagree about the key shape.

--- a/spinifex/daemon/instance_records_migrate.go
+++ b/spinifex/daemon/instance_records_migrate.go
@@ -17,8 +17,8 @@ import (
 // falling back per key: after this, the only records missing from i/<id> are
 // the ones a node that predates it wrote afterwards.
 //
-// The node.<id> blob is deliberately not copied. It holds a whole node's
-// running set in one record, so moving it is a split rather than a copy.
+// The node.<id> blobs are a separate step, because each holds a whole node's
+// running set in one record and moving one is a split rather than a copy.
 func init() {
 	migrate.DefaultRegistry.RegisterKV(InstanceStateBucket, migrate.KVMigration{
 		FromVersion: 1,
@@ -27,6 +27,12 @@ func init() {
 		Run: func(ctx context.Context, kvc migrate.KVContext) error {
 			return copyInstancesForward(ctx, kvc, StoppedInstancePrefix)
 		},
+	})
+	migrate.DefaultRegistry.RegisterKV(InstanceStateBucket, migrate.KVMigration{
+		FromVersion: 2,
+		ToVersion:   3,
+		Description: "copy each node's running instances forward to the i/<id> key space",
+		Run:         copyRunningSetsForward,
 	})
 	migrate.DefaultRegistry.RegisterKV(TerminatedInstanceBucket, migrate.KVMigration{
 		FromVersion: 1,
@@ -92,5 +98,68 @@ func copyInstancesForward(ctx context.Context, kvc migrate.KVContext, prefix str
 
 	kvc.Logger.Info("Copied instances onto the per-resource key space",
 		"prefix", prefix, "copied", copied)
+	return nil
+}
+
+// copyRunningSetsForward writes an i/<id> record for every instance inside
+// every node's blob, splitting each of those records into as many as it holds.
+//
+// It copies every node's set, not just the one running it. The key space is
+// shared, the migration runs once per bucket rather than once per node, and a
+// node that is down would otherwise have no record of its instances until it
+// came back — which is exactly when a reader most needs one.
+func copyRunningSetsForward(ctx context.Context, kvc migrate.KVContext) error {
+	keys, err := kvc.KV.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil
+		}
+		return fmt.Errorf("list keys: %w", err)
+	}
+
+	copied := 0
+	for _, key := range keys {
+		if !strings.HasPrefix(key, InstanceStatePrefix) {
+			continue
+		}
+
+		entry, err := kvc.KV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return fmt.Errorf("read %s: %w", key, err)
+		}
+
+		var state LocalState
+		if err := json.Unmarshal(entry.Value(), &state); err != nil {
+			return fmt.Errorf("decode %s: %w", key, err)
+		}
+		if err := checkNodeStateVersion(key, state.SchemaVersion); err != nil {
+			return err
+		}
+
+		for id, instance := range state.VMS {
+			if instance == nil {
+				continue
+			}
+			record, err := json.Marshal(instance.Record())
+			if err != nil {
+				return fmt.Errorf("encode record for %s in %s: %w", id, key, err)
+			}
+
+			dest := instanceRecordKey(id)
+			if _, err := kvc.KV.Create(ctx, dest, record); err != nil {
+				if errors.Is(err, jetstream.ErrKeyExists) {
+					continue
+				}
+				return fmt.Errorf("write %s: %w", dest, err)
+			}
+			copied++
+		}
+	}
+
+	kvc.Logger.Info("Copied running instances onto the per-resource key space",
+		"prefix", InstanceStatePrefix, "copied", copied)
 	return nil
 }

--- a/spinifex/daemon/instance_records_migrate.go
+++ b/spinifex/daemon/instance_records_migrate.go
@@ -12,18 +12,22 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
-// The copy-forward onto i/<id>. Running it as a migration rather than lazily on
-// read is what lets a listing merge the two key spaces cheaply instead of
-// falling back per key: after this, the only records missing from i/<id> are
-// the ones a node that predates it wrote afterwards.
+// The copy-forward onto the per-resource key space. Running it as a migration
+// rather than lazily on read is what lets a listing merge the two key spaces
+// cheaply instead of falling back per key: after this, the only records missing
+// from it are the ones a node that predates it wrote afterwards.
 //
 // The node.<id> blobs are a separate step, because each holds a whole node's
 // running set in one record and moving one is a split rather than a copy.
+//
+// The last step of each bucket re-keys "i/<id>" to "i.<id>". The earlier steps
+// write whatever the prefix currently is, so it only has to run where a build
+// that wrote the slash already has.
 func init() {
 	migrate.DefaultRegistry.RegisterKV(InstanceStateBucket, migrate.KVMigration{
 		FromVersion: 1,
 		ToVersion:   2,
-		Description: "copy stopped instances forward to the i/<id> key space",
+		Description: "copy stopped instances forward to the per-resource key space",
 		Run: func(ctx context.Context, kvc migrate.KVContext) error {
 			return copyInstancesForward(ctx, kvc, StoppedInstancePrefix)
 		},
@@ -31,20 +35,83 @@ func init() {
 	migrate.DefaultRegistry.RegisterKV(InstanceStateBucket, migrate.KVMigration{
 		FromVersion: 2,
 		ToVersion:   3,
-		Description: "copy each node's running instances forward to the i/<id> key space",
+		Description: "copy each node's running instances forward to the per-resource key space",
 		Run:         copyRunningSetsForward,
+	})
+	migrate.DefaultRegistry.RegisterKV(InstanceStateBucket, migrate.KVMigration{
+		FromVersion: 3,
+		ToVersion:   4,
+		Description: "re-key instance records from i/<id> to i.<id>",
+		Run:         rekeyRecordSeparator,
 	})
 	migrate.DefaultRegistry.RegisterKV(TerminatedInstanceBucket, migrate.KVMigration{
 		FromVersion: 1,
 		ToVersion:   2,
-		Description: "copy terminated instances forward to the i/<id> key space",
+		Description: "copy terminated instances forward to the per-resource key space",
 		Run: func(ctx context.Context, kvc migrate.KVContext) error {
 			return copyInstancesForward(ctx, kvc, TerminatedInstancePrefix)
 		},
 	})
+	migrate.DefaultRegistry.RegisterKV(TerminatedInstanceBucket, migrate.KVMigration{
+		FromVersion: 2,
+		ToVersion:   3,
+		Description: "re-key instance records from i/<id> to i.<id>",
+		Run:         rekeyRecordSeparator,
+	})
 }
 
-// copyInstancesForward writes an i/<id> record for every key under prefix.
+// slashRecordPrefix is the separator the per-resource key space first shipped
+// with. It is here only so the re-key can find what that build wrote; nothing
+// else may use it.
+const slashRecordPrefix = "i/"
+
+// rekeyRecordSeparator moves every record from the slash-separated key space to
+// the dot-separated one, so a watch can filter it by subject token.
+//
+// The old key is deleted rather than left as an orphan. A node still writing
+// slashes reads them too, so what a delete costs it is a fallback to the key
+// the record mirrors — the same degradation as a mirror that was never written,
+// which the shadow rule already makes safe.
+func rekeyRecordSeparator(ctx context.Context, kvc migrate.KVContext) error {
+	keys, err := kvc.KV.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil
+		}
+		return fmt.Errorf("list keys: %w", err)
+	}
+
+	moved := 0
+	for _, key := range keys {
+		if !strings.HasPrefix(key, slashRecordPrefix) {
+			continue
+		}
+
+		entry, err := kvc.KV.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return fmt.Errorf("read %s: %w", key, err)
+		}
+
+		dest := instanceRecordKey(strings.TrimPrefix(key, slashRecordPrefix))
+		if _, err := kvc.KV.Create(ctx, dest, entry.Value()); err != nil {
+			if !errors.Is(err, jetstream.ErrKeyExists) {
+				return fmt.Errorf("write %s: %w", dest, err)
+			}
+		}
+		if err := kvc.KV.Delete(ctx, key); err != nil {
+			return fmt.Errorf("delete %s: %w", key, err)
+		}
+		moved++
+	}
+
+	kvc.Logger.Info("Re-keyed instance records onto the dot separator", "moved", moved)
+	return nil
+}
+
+// copyInstancesForward writes a record for every key under prefix.
 //
 // Two nodes can reach this at once — the version stamp is a read-then-write,
 // not a CAS — and a node that has already upgraded can be writing the
@@ -101,7 +168,7 @@ func copyInstancesForward(ctx context.Context, kvc migrate.KVContext, prefix str
 	return nil
 }
 
-// copyRunningSetsForward writes an i/<id> record for every instance inside
+// copyRunningSetsForward writes a record for every instance inside
 // every node's blob, splitting each of those records into as many as it holds.
 //
 // It copies every node's set, not just the one running it. The key space is

--- a/spinifex/daemon/instance_records_mirror.go
+++ b/spinifex/daemon/instance_records_mirror.go
@@ -84,7 +84,7 @@ func (m *JetStreamManager) MirrorRunningSet(nodeID string, vms map[string]*vm.VM
 // running set, reporting whether the question is settled.
 //
 // It is not settled by deleting unconditionally. The stopped key space shares
-// i/<id>, and an instance that stops leaves the running set at the moment
+// the record key, and an instance that stops leaves the running set as
 // WriteStoppedInstance mirrors it there, so an unconditional delete would race
 // a live write — and would keep deleting, on every state change, the records of
 // instances stopped on this node. Where the stopped key holds the instance the

--- a/spinifex/daemon/instance_records_mirror.go
+++ b/spinifex/daemon/instance_records_mirror.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"hash/fnv"
+	"log/slog"
+	"sync"
+
+	"github.com/mulgadc/spinifex/spinifex/vm"
+)
+
+// mirrorState tracks what this node last put on the per-resource key space, so
+// a change to one instance writes one record.
+//
+// Without it every state change would rewrite the whole running set one key at
+// a time, which is worse than the single blob it replaces rather than better:
+// splitting the blob exists to stop two instances on a node serialising against
+// each other.
+type mirrorState struct {
+	mu     sync.Mutex
+	seeded bool
+	digest map[string]uint64
+}
+
+// MirrorRunningSet reconciles this node's running instances onto the
+// per-resource key space, after the blob it mirrors has been written.
+//
+// Best-effort, like that blob write: the local state file is the source of
+// truth, the blob still decides which instances are running here, and a read
+// that finds no mirror answers from the blob member. So a failure degrades a
+// read rather than breaking one, and is logged rather than returned.
+func (m *JetStreamManager) MirrorRunningSet(nodeID string, vms map[string]*vm.VM) {
+	if m.records == nil || m.stopped == nil {
+		return
+	}
+
+	m.mirror.mu.Lock()
+	defer m.mirror.mu.Unlock()
+
+	if !m.mirror.seeded {
+		if err := m.seedRunningMirror(nodeID); err != nil {
+			slog.Warn("Could not read the existing instance records; the next state write retries",
+				"node", nodeID, "err", err)
+			return
+		}
+	}
+
+	for id, instance := range vms {
+		if instance == nil {
+			continue
+		}
+		sum, err := recordDigest(instance.Record())
+		if err != nil {
+			slog.Error("Could not encode an instance record", "instanceId", id, "err", err)
+			continue
+		}
+		if current, ok := m.mirror.digest[id]; ok && current == sum {
+			continue
+		}
+
+		// A failed mirror forgets its digest as well as its record, so the next
+		// state write repeats the attempt rather than reading the failure as
+		// already mirrored.
+		if err := mirrorRecord(m.records, id, instance); err != nil {
+			slog.Error("Could not mirror an instance record", "instanceId", id, "err", err)
+			delete(m.mirror.digest, id)
+			continue
+		}
+		m.mirror.digest[id] = sum
+	}
+
+	for id := range m.mirror.digest {
+		if _, ok := vms[id]; ok {
+			continue
+		}
+		if m.retireMirror(id) {
+			delete(m.mirror.digest, id)
+		}
+	}
+}
+
+// retireMirror drops the record of an instance that has left this node's
+// running set, reporting whether the question is settled.
+//
+// It is not settled by deleting unconditionally. The stopped key space shares
+// i/<id>, and an instance that stops leaves the running set at the moment
+// WriteStoppedInstance mirrors it there, so an unconditional delete would race
+// a live write — and would keep deleting, on every state change, the records of
+// instances stopped on this node. Where the stopped key holds the instance the
+// record is handed over rather than retired, which is also what it becomes at
+// the cutover, when the two key spaces are one.
+func (m *JetStreamManager) retireMirror(instanceID string) bool {
+	stopped, err := loadRecord(m.stopped, StoppedInstancePrefix+instanceID)
+	if err != nil {
+		slog.Warn("Could not tell whether a departed instance is stopped; leaving its record in place",
+			"instanceId", instanceID, "err", err)
+		return false
+	}
+	if stopped != nil {
+		return true
+	}
+
+	if err := m.records.Delete(context.Background(), instanceRecordKey(instanceID)); err != nil {
+		slog.Error("Could not remove the record of an instance that left this node",
+			"instanceId", instanceID, "err", err)
+		return false
+	}
+	return true
+}
+
+// seedRunningMirror primes the digest map from the records already on the key
+// space for this node, so the first state write after boot rewrites only what
+// actually changed while the node was down — and so a record left behind by a
+// previous process is still a candidate for retirement.
+//
+// Ownership is read from status.LastNode, the same field the GC uses to decide
+// whose records a node may touch.
+func (m *JetStreamManager) seedRunningMirror(nodeID string) error {
+	existing, err := listRecords(m.records, InstanceRecordPrefix)
+	if err != nil {
+		return err
+	}
+
+	digest := make(map[string]uint64, len(existing))
+	for _, record := range existing {
+		if record.Status.LastNode != nodeID {
+			continue
+		}
+		sum, err := recordDigest(record)
+		if err != nil {
+			return err
+		}
+		digest[record.Metadata.Name] = sum
+	}
+
+	m.mirror.digest = digest
+	m.mirror.seeded = true
+	slog.Debug("Seeded the instance record mirror", "node", nodeID, "records", len(digest))
+	return nil
+}
+
+// recordDigest identifies a record by its wire form, so a state change that
+// leaves an instance untouched does not become a KV write. encoding/json sorts
+// map keys, so the same record always encodes to the same bytes.
+func recordDigest(record *vm.InstanceRecord) (uint64, error) {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return 0, err
+	}
+	h := fnv.New64a()
+	_, _ = h.Write(data)
+	return h.Sum64(), nil
+}
+
+// answerFromMirrors replaces each member of a node's running set with its
+// mirror where there is one. The blob still decides membership — see
+// loadPreferringRecord for why a mirror cannot be trusted to — so a record with
+// no member behind it is ignored here.
+func (m *JetStreamManager) answerFromMirrors(vms map[string]*vm.VM) error {
+	if m.records == nil || len(vms) == 0 {
+		return nil
+	}
+
+	mirrored, err := listRecords(m.records, InstanceRecordPrefix)
+	if err != nil {
+		return err
+	}
+	for _, record := range mirrored {
+		if _, ok := vms[record.Metadata.Name]; !ok {
+			continue
+		}
+		vms[record.Metadata.Name] = vm.VMFromRecord(record)
+	}
+	return nil
+}

--- a/spinifex/daemon/instance_records_mirror_test.go
+++ b/spinifex/daemon/instance_records_mirror_test.go
@@ -1,0 +1,314 @@
+package daemon_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/daemon"
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const mirrorNode = "node-1"
+
+func runningVM(id, instanceType string) *vm.VM {
+	return &vm.VM{ID: id, InstanceType: instanceType, Status: vm.StateRunning, LastNode: mirrorNode}
+}
+
+func runningSet(vms ...*vm.VM) map[string]*vm.VM {
+	set := make(map[string]*vm.VM, len(vms))
+	for _, v := range vms {
+		set[v.ID] = v
+	}
+	return set
+}
+
+// writeRunningSet does what persistState does: commit the blob, then mirror
+// what it committed.
+func writeRunningSet(t *testing.T, m *daemon.JetStreamManager, vms ...*vm.VM) {
+	t.Helper()
+	require.NoError(t, m.WriteState(mirrorNode, runningSet(vms...)))
+}
+
+// recordRevision reads the revision of a record straight from the bucket, so a
+// test can tell a write that did nothing from one that did not happen.
+func recordRevision(t *testing.T, nc *nats.Conn, instanceID string) uint64 {
+	t.Helper()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	kv, err := js.KeyValue(context.Background(), daemon.InstanceStateBucket)
+	require.NoError(t, err)
+	entry, err := kv.Get(context.Background(), daemon.InstanceRecordPrefix+instanceID)
+	require.NoError(t, err)
+	return entry.Revision()
+}
+
+func TestMirrorRunningSet_WritesARecordPerMember(t *testing.T) {
+	m := newRecordManager(t)
+
+	writeRunningSet(t, m, runningVM("i-1", "t3.nano"), runningVM("i-2", "t3.micro"))
+
+	records, err := m.ListInstanceRecords()
+	require.NoError(t, err)
+	byID := make(map[string]string, len(records))
+	for _, record := range records {
+		byID[record.Metadata.Name] = record.Spec.InstanceType
+	}
+	assert.Equal(t, map[string]string{"i-1": "t3.nano", "i-2": "t3.micro"}, byID,
+		"one blob of two instances must become two records")
+}
+
+func TestLoadState_AnswersFromTheMirrorWhereThereIsOne(t *testing.T) {
+	m := newRecordManager(t)
+	require.NoError(t, m.WriteState(mirrorNode, runningSet(runningVM("i-1", "t3.nano"))))
+
+	// Written directly rather than through the mirror, standing in for a record
+	// committed after the blob it belongs to.
+	require.NoError(t, m.WriteInstanceRecord("i-1", runningVM("i-1", "m7i.large").Record()))
+
+	loaded, found, err := m.LoadState(mirrorNode)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Contains(t, loaded, "i-1")
+	assert.Equal(t, "m7i.large", loaded["i-1"].InstanceType, "the record must win over the blob member")
+}
+
+func TestLoadState_FallsBackToTheBlobMember(t *testing.T) {
+	m := newRecordManager(t)
+	require.NoError(t, m.WriteState(mirrorNode, runningSet(runningVM("i-1", "t3.nano"))))
+
+	loaded, found, err := m.LoadState(mirrorNode)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Contains(t, loaded, "i-1", "an instance only the blob holds must still be found")
+	assert.Equal(t, "t3.nano", loaded["i-1"].InstanceType)
+}
+
+// The blob decides which instances are running here. A record with no member
+// behind it is what a node predating the key space leaves when it stops an
+// instance, and reading it as running is the fault env19 found.
+func TestLoadState_IgnoresARecordWithNoBlobMember(t *testing.T) {
+	m := newRecordManager(t)
+	require.NoError(t, m.WriteState(mirrorNode, runningSet(runningVM("i-1", "t3.nano"))))
+	require.NoError(t, m.WriteInstanceRecord("i-orphan", runningVM("i-orphan", "m7i.large").Record()))
+
+	loaded, found, err := m.LoadState(mirrorNode)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.NotContains(t, loaded, "i-orphan")
+	assert.Len(t, loaded, 1)
+}
+
+// The conversion's totality is guarded in the vm package; what this adds is
+// that the running-set path actually routes through it, on fields from both
+// halves of the record rather than the instance type alone.
+func TestMirrorRunningSet_CarriesBothHalvesOfTheRecord(t *testing.T) {
+	m := newRecordManager(t)
+	instance := runningVM("i-1", "t3.nano")
+	instance.DesiredState = vm.DesiredRunning
+	instance.PublicIP = "10.0.0.9"
+	instance.ENIId = "eni-1"
+	instance.HostfwdPorts = []int{2222}
+
+	writeRunningSet(t, m, instance)
+
+	loaded, _, err := m.LoadState(mirrorNode)
+	require.NoError(t, err)
+	require.Contains(t, loaded, "i-1")
+	got := loaded["i-1"]
+	assert.Equal(t, vm.DesiredRunning, got.DesiredState)
+	assert.Equal(t, []int{2222}, got.HostfwdPorts)
+	assert.Equal(t, "10.0.0.9", got.PublicIP)
+	assert.Equal(t, "eni-1", got.ENIId)
+	assert.Equal(t, mirrorNode, got.LastNode)
+}
+
+func TestMirrorRunningSet_RetiresAMemberThatLeft(t *testing.T) {
+	m := newRecordManager(t)
+	writeRunningSet(t, m, runningVM("i-1", "t3.nano"), runningVM("i-2", "t3.micro"))
+
+	writeRunningSet(t, m, runningVM("i-1", "t3.nano"))
+
+	gone, err := m.LoadInstanceRecord("i-2")
+	require.NoError(t, err)
+	assert.Nil(t, gone, "a record left behind by a terminated instance never expires from this bucket")
+
+	kept, err := m.LoadInstanceRecord("i-1")
+	require.NoError(t, err)
+	assert.NotNil(t, kept)
+}
+
+// An instance that stops leaves the running set at the moment the stopped key
+// space takes it over, and that path has already written the record. Retiring
+// it here would race a live write and would keep re-deleting the records of
+// every instance ever stopped on this node.
+func TestMirrorRunningSet_HandsOverAMemberThatStopped(t *testing.T) {
+	m := newRecordManager(t)
+	writeRunningSet(t, m, runningVM("i-1", "t3.nano"))
+
+	require.NoError(t, m.WriteStoppedInstance("i-1", &vm.VM{ID: "i-1", InstanceType: "t3.nano", Status: vm.StateStopped}))
+	writeRunningSet(t, m)
+
+	record, err := m.LoadInstanceRecord("i-1")
+	require.NoError(t, err)
+	require.NotNil(t, record, "the stopped key space owns this record now")
+
+	stopped, err := m.ListStoppedInstances()
+	require.NoError(t, err)
+	require.Len(t, stopped, 1)
+	assert.Equal(t, "i-1", stopped[0].ID)
+}
+
+// Rewriting every record on every state change would reintroduce, one key at a
+// time, the contention splitting the blob exists to remove.
+func TestMirrorRunningSet_WritesOnlyWhatChanged(t *testing.T) {
+	m, nc := newRecordManagerConn(t)
+	writeRunningSet(t, m, runningVM("i-1", "t3.nano"), runningVM("i-2", "t3.micro"))
+	before1, before2 := recordRevision(t, nc, "i-1"), recordRevision(t, nc, "i-2")
+
+	writeRunningSet(t, m, runningVM("i-1", "t3.nano"), runningVM("i-2", "t3.micro"))
+
+	assert.Equal(t, before1, recordRevision(t, nc, "i-1"), "an unchanged instance must not be rewritten")
+	assert.Equal(t, before2, recordRevision(t, nc, "i-2"))
+
+	changed := runningVM("i-1", "t3.nano")
+	changed.PublicIP = "10.0.0.9"
+	writeRunningSet(t, m, changed, runningVM("i-2", "t3.micro"))
+
+	assert.Greater(t, recordRevision(t, nc, "i-1"), before1, "a changed instance must be rewritten")
+	assert.Equal(t, before2, recordRevision(t, nc, "i-2"), "and only that instance")
+}
+
+// A restarted process has no memory of what it last wrote, so it primes itself
+// from the bucket rather than rewriting every record to find out.
+func TestMirrorRunningSet_SeedsFromWhatIsAlreadyThere(t *testing.T) {
+	first, nc := newRecordManagerConn(t)
+	writeRunningSet(t, first, runningVM("i-1", "t3.nano"))
+	before := recordRevision(t, nc, "i-1")
+
+	second, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, second.InitKVBucket())
+	writeRunningSet(t, second, runningVM("i-1", "t3.nano"))
+
+	assert.Equal(t, before, recordRevision(t, nc, "i-1"))
+}
+
+// Ownership is read from status.LastNode, the same field the GC uses. A node
+// must not retire a record for an instance that is running somewhere else.
+func TestMirrorRunningSet_LeavesAnotherNodesRecordsAlone(t *testing.T) {
+	m := newRecordManager(t)
+	elsewhere := &vm.VM{ID: "i-elsewhere", InstanceType: "t3.nano", Status: vm.StateRunning, LastNode: "node-2"}
+	require.NoError(t, m.WriteInstanceRecord("i-elsewhere", elsewhere.Record()))
+
+	writeRunningSet(t, m, runningVM("i-1", "t3.nano"))
+
+	record, err := m.LoadInstanceRecord("i-elsewhere")
+	require.NoError(t, err)
+	assert.NotNil(t, record)
+}
+
+// seedNodeBlobBucket creates the instance-state bucket at the version before
+// the blob split, holding one node's running set as a single record.
+func seedNodeBlobBucket(t *testing.T, nc *nats.Conn, nodeID string, vms map[string]*vm.VM) jetstream.KeyValue {
+	t.Helper()
+	ctx := context.Background()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: daemon.InstanceStateBucket, History: 1})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(daemon.LocalState{SchemaVersion: daemon.LocalStateSchemaVersion, VMS: vms})
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, daemon.InstanceStatePrefix+nodeID, data)
+	require.NoError(t, err)
+
+	require.NoError(t, kvutil.WriteVersion(ctx, kv, 2))
+	return kv
+}
+
+func TestInstanceStateMigration_SplitsTheNodeBlob(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	seedNodeBlobBucket(t, nc, mirrorNode, runningSet(runningVM("i-1", "t3.nano"), runningVM("i-2", "t3.micro")))
+
+	m, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, m.InitKVBucket())
+
+	records, err := m.ListInstanceRecords()
+	require.NoError(t, err)
+	byID := make(map[string]string, len(records))
+	for _, record := range records {
+		byID[record.Metadata.Name] = record.Spec.InstanceType
+	}
+	assert.Equal(t, map[string]string{"i-1": "t3.nano", "i-2": "t3.micro"}, byID)
+}
+
+// Release 1 keeps writing the blob, so the split must copy it rather than
+// consume it: a node still on the previous release reads nothing else.
+func TestInstanceStateMigration_KeepsTheNodeBlob(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	seedNodeBlobBucket(t, nc, mirrorNode, runningSet(runningVM("i-1", "t3.nano")))
+
+	m, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, m.InitKVBucket())
+
+	loaded, found, err := m.LoadState(mirrorNode)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Contains(t, loaded, "i-1")
+}
+
+// Every node's set is copied, not just the one running the migration: it runs
+// once per bucket, and a node that is down would otherwise have no records
+// until it came back.
+func TestInstanceStateMigration_SplitsEveryNodesBlob(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	kv := seedNodeBlobBucket(t, nc, mirrorNode, runningSet(runningVM("i-1", "t3.nano")))
+
+	other := &vm.VM{ID: "i-2", InstanceType: "t3.micro", Status: vm.StateRunning, LastNode: "node-2"}
+	data, err := json.Marshal(daemon.LocalState{
+		SchemaVersion: daemon.LocalStateSchemaVersion,
+		VMS:           map[string]*vm.VM{other.ID: other},
+	})
+	require.NoError(t, err)
+	_, err = kv.Put(context.Background(), daemon.InstanceStatePrefix+"node-2", data)
+	require.NoError(t, err)
+
+	m, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, m.InitKVBucket())
+
+	record, err := m.LoadInstanceRecord("i-2")
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	assert.Equal(t, "node-2", record.Status.LastNode)
+}
+
+func TestInstanceStateMigration_BlobSplitIsSafeToRunTwice(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	kv := seedNodeBlobBucket(t, nc, mirrorNode, runningSet(runningVM("i-1", "t3.nano")))
+
+	first, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, first.InitKVBucket())
+	before := recordRevision(t, nc, "i-1")
+
+	require.NoError(t, kvutil.WriteVersion(context.Background(), kv, 2))
+	second, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, second.InitKVBucket())
+
+	assert.Equal(t, before, recordRevision(t, nc, "i-1"), "a second run must not overwrite what the first copied")
+}

--- a/spinifex/daemon/instance_records_rekey_test.go
+++ b/spinifex/daemon/instance_records_rekey_test.go
@@ -1,0 +1,158 @@
+package daemon_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/daemon"
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The separator the per-resource key space first shipped with, before a dot
+// made it filterable by subject token. Spelled out here rather than imported so
+// the test still describes the old shape once the constant is gone.
+const slashPrefix = "i/"
+
+// seedSlashRecord creates bucket at version, holding one record at the
+// slash-separated key a build of that version wrote.
+func seedSlashRecord(t *testing.T, nc *nats.Conn, bucket string, version int, instance *vm.VM) jetstream.KeyValue {
+	t.Helper()
+	ctx := context.Background()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket, History: 1})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(instance.Record())
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, slashPrefix+instance.ID, data)
+	require.NoError(t, err)
+
+	require.NoError(t, kvutil.WriteVersion(ctx, kv, version))
+	return kv
+}
+
+func TestRekey_MovesInstanceStateRecordsOntoTheDot(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	kv := seedSlashRecord(t, nc, daemon.InstanceStateBucket, 3,
+		&vm.VM{ID: "i-1", InstanceType: "t3.nano", LastNode: "node-1"})
+
+	m, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, m.InitKVBucket())
+
+	record, err := m.LoadInstanceRecord("i-1")
+	require.NoError(t, err)
+	require.NotNil(t, record, "the record must be readable at its new key")
+	assert.Equal(t, "t3.nano", record.Spec.InstanceType)
+
+	_, err = kv.Get(context.Background(), slashPrefix+"i-1")
+	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound, "the old key must not be left as an orphan")
+}
+
+func TestRekey_MovesTerminatedRecordsOntoTheDot(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	kv := seedSlashRecord(t, nc, daemon.TerminatedInstanceBucket, 2,
+		&vm.VM{ID: "i-1", InstanceType: "t3.nano", LastNode: "node-1"})
+
+	m, err := daemon.NewJetStreamManager(nc, 1)
+	require.NoError(t, err)
+	require.NoError(t, m.InitTerminatedInstanceBucket())
+
+	record, err := m.LoadTerminatedInstanceRecord("i-1")
+	require.NoError(t, err)
+	require.NotNil(t, record)
+
+	_, err = kv.Get(context.Background(), slashPrefix+"i-1")
+	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
+}
+
+// A bucket that never held the slash separator must come out the same as one
+// that did, so a fresh install is not a special case.
+func TestRekey_IsANoOpWithNothingToMove(t *testing.T) {
+	m := newRecordManager(t)
+	require.NoError(t, m.WriteStoppedInstance("i-1", &vm.VM{ID: "i-1", InstanceType: "t3.nano"}))
+
+	record, err := m.LoadInstanceRecord("i-1")
+	require.NoError(t, err)
+	require.NotNil(t, record)
+}
+
+// The dot separator is the whole reason for the re-key: a reconciler Filter is
+// a NATS subject filter, "*" matches one dot-delimited token, and "i/<id>" is a
+// single token — so "i/*" matched nothing. This asserts the new shape is
+// actually watchable, rather than trusting the reasoning that chose it.
+func TestRecordKeys_AreWatchableByASubjectFilter(t *testing.T) {
+	m, nc := newRecordManagerConn(t)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	kv, err := js.KeyValue(context.Background(), daemon.InstanceStateBucket)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	watcher, err := kv.Watch(ctx, daemon.InstanceRecordPrefix+"*")
+	require.NoError(t, err)
+	defer func() { _ = watcher.Stop() }()
+
+	// Drain the initial replay up to the end-of-initial-values marker, so what
+	// the assertion sees is the write below rather than history.
+	for entry := range watcher.Updates() {
+		if entry == nil {
+			break
+		}
+	}
+
+	require.NoError(t, m.WriteInstanceRecord("i-watched", testRecord("i-watched")))
+
+	select {
+	case entry := <-watcher.Updates():
+		require.NotNil(t, entry, "the filter must deliver the record write")
+		assert.Equal(t, daemon.InstanceRecordPrefix+"i-watched", entry.Key())
+	case <-ctx.Done():
+		t.Fatal("no watch event for a record write: the prefix is not filterable")
+	}
+}
+
+// The counterpart: the separator that shipped first is not watchable, which is
+// what this change exists to fix. If this ever stops failing to deliver, the
+// re-key was unnecessary and the reasoning above is wrong.
+func TestRecordKeys_SlashSeparatorWasNotWatchable(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	kv, err := js.CreateKeyValue(context.Background(),
+		jetstream.KeyValueConfig{Bucket: "rekey-watch-probe", History: 1})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	watcher, err := kv.Watch(ctx, slashPrefix+"*")
+	require.NoError(t, err)
+	defer func() { _ = watcher.Stop() }()
+
+	for entry := range watcher.Updates() {
+		if entry == nil {
+			break
+		}
+	}
+
+	_, err = kv.Put(context.Background(), slashPrefix+"i-1", []byte("{}"))
+	require.NoError(t, err)
+
+	select {
+	case entry := <-watcher.Updates():
+		t.Fatalf("the slash separator delivered a watch event for %q, so the re-key was not needed", entry.Key())
+	case <-time.After(2 * time.Second):
+	}
+}

--- a/spinifex/daemon/instance_records_transition_test.go
+++ b/spinifex/daemon/instance_records_transition_test.go
@@ -290,14 +290,16 @@ func TestInstanceStateMigration_CopiesStoppedInstancesForward(t *testing.T) {
 	assert.Equal(t, "t3.nano", record.Spec.InstanceType)
 }
 
-// The node blob holds a whole node's running set in one record, so it is a
-// split rather than a copy and is not this migration's to make.
-func TestInstanceStateMigration_LeavesTheNodeBlobAlone(t *testing.T) {
+// A bucket old enough to need both steps gets both, and the node blob is split
+// by the second rather than swept up by the first. The blob's own members are
+// covered by TestInstanceStateMigration_SplitsTheNodeBlob; what this pins is
+// that an empty one does not make the stopped copy-forward skip or duplicate.
+func TestInstanceStateMigration_RunsEveryStepFromTheOldestVersion(t *testing.T) {
 	_, nc, _ := testutil.StartTestJetStream(t)
 	kv := seedLegacyBucket(t, nc, daemon.InstanceStateBucket, daemon.StoppedInstancePrefix,
 		&vm.VM{ID: "i-1", InstanceType: "t3.nano"})
 
-	blob, err := json.Marshal(map[string]any{"instances": map[string]any{}})
+	blob, err := json.Marshal(daemon.LocalState{SchemaVersion: daemon.LocalStateSchemaVersion})
 	require.NoError(t, err)
 	_, err = kv.Put(context.Background(), daemon.InstanceStatePrefix+"node-1", blob)
 	require.NoError(t, err)

--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -33,11 +33,12 @@ const (
 	TerminatedInstancePrefix = "terminated."
 
 	// Schema versions for daemon KV buckets. Both instance buckets copied their
-	// per-instance keys forward onto i/<id> at 2; instance-state is at 3 for the
-	// running sets inside the node blobs. See instance_records_migrate.go.
-	InstanceStateBucketVersion      = 3
+	// per-instance keys onto the record space at 2; instance-state took the node
+	// blobs at 3; both re-keyed that space from "i/" to "i." last. See
+	// instance_records_migrate.go.
+	InstanceStateBucketVersion      = 4
 	ClusterStateBucketVersion       = 1
-	TerminatedInstanceBucketVersion = 2
+	TerminatedInstanceBucketVersion = 3
 )
 
 // KVSyncObserver receives best-effort KV sync outcomes from

--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -32,9 +32,10 @@ const (
 	// TerminatedInstancePrefix is the key prefix for terminated instances.
 	TerminatedInstancePrefix = "terminated."
 
-	// Schema versions for daemon KV buckets. The two instance buckets are at 2
-	// for the copy-forward onto i/<id>; see instance_records_migrate.go.
-	InstanceStateBucketVersion      = 2
+	// Schema versions for daemon KV buckets. Both instance buckets copied their
+	// per-instance keys forward onto i/<id> at 2; instance-state is at 3 for the
+	// running sets inside the node blobs. See instance_records_migrate.go.
+	InstanceStateBucketVersion      = 3
 	ClusterStateBucketVersion       = 1
 	TerminatedInstanceBucketVersion = 2
 )
@@ -68,6 +69,7 @@ type JetStreamManager struct {
 	clusterKV   jetstream.KeyValue                // spinifex-cluster-state
 	replicas    int
 	obs         KVSyncObserver
+	mirror      mirrorState
 }
 
 // checkNodeStateVersion reports whether a node record read from KV is one this
@@ -403,8 +405,13 @@ func (m *JetStreamManager) WriteServiceManifest(nodeID string, services []string
 	return err
 }
 
-// WriteState writes the instance state to the KV store for the given node.
+// WriteState writes the instance state to the KV store for the given node and
+// mirrors it onto the per-resource key space.
 // vms must be a snapshot owned by the caller — JetStreamManager does not lock.
+//
+// It mirrors even though persistState is the path production takes, because a
+// blob writer that skips the mirror leaves a record staler than the blob it
+// belongs to, and reads answer from the record.
 func (m *JetStreamManager) WriteState(nodeID string, vms map[string]*vm.VM) error {
 	if m.nodeState == nil {
 		return errors.New("KV bucket not initialized")
@@ -415,6 +422,7 @@ func (m *JetStreamManager) WriteState(nodeID string, vms map[string]*vm.VM) erro
 	if err := m.nodeState.Set(context.Background(), key, &record); err != nil {
 		return err
 	}
+	m.MirrorRunningSet(nodeID, vms)
 
 	slog.Debug("Wrote state to JetStream KV", "key", key, "instances", len(vms))
 	return nil
@@ -467,11 +475,13 @@ func marshalInstanceState(vms map[string]*vm.VM) ([]byte, error) {
 	return MarshalLocalState(vms)
 }
 
-// LoadState loads the instance state from the KV store for the given node.
+// LoadState loads the instance state from the KV store for the given node,
+// answering each member from its i/<id> mirror where there is one.
+//
 // The bool reports whether a record exists at all. A node that has never
 // written state and a node whose record was lost both read as empty, and a
 // caller that would drop instances on the strength of that must tell them
-// apart.
+// apart — so it stays the blob's answer, not the mirrors'.
 func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, bool, error) {
 	if m.nodeState == nil {
 		return nil, false, errors.New("KV bucket not initialized")
@@ -491,6 +501,9 @@ func (m *JetStreamManager) LoadState(nodeID string) (map[string]*vm.VM, bool, er
 	}
 	if state.VMS == nil {
 		state.VMS = make(map[string]*vm.VM)
+	}
+	if err := m.answerFromMirrors(state.VMS); err != nil {
+		return nil, false, err
 	}
 
 	slog.Debug("Loaded state from JetStream KV", "key", key, "instances", len(state.VMS))

--- a/spinifex/migrate/VERSIONS.md
+++ b/spinifex/migrate/VERSIONS.md
@@ -19,7 +19,7 @@ Single source of truth for the current schema version of every config file Spini
 
 | Bucket | Current version | Constant |
 |---|---|---|
-| `spinifex-instance-state` | `2` | `daemon.InstanceStateBucketVersion` |
+| `spinifex-instance-state` | `3` | `daemon.InstanceStateBucketVersion` |
 | `spinifex-cluster-state` | `1` | `daemon.ClusterStateBucketVersion` |
 | `spinifex-terminated-instances` | `2` | `daemon.TerminatedInstanceBucketVersion` |
 
@@ -27,7 +27,7 @@ Single source of truth for the current schema version of every config file Spini
 
 **Config:** none. The migrations that used to live here predated a breaking change that required `spx admin init --force`, so no install can reach the current versions by migrating and the steps were dropped rather than left as dead code. `spinifex.toml` is still registered as a config target in `migrate.go` so `spx admin upgrade` reports its on-disk version.
 
-**KV:** `spinifex-instance-state` and `spinifex-terminated-instances` each carry a `1`→`2` step registered from `daemon/instance_records_migrate.go`, copying instance records onto the `i/<id>` per-resource key space. Every other bucket has none, so `RunKV` stamps its target version directly on first init.
+**KV:** `spinifex-instance-state` and `spinifex-terminated-instances` each carry a `1`→`2` step registered from `daemon/instance_records_migrate.go`, copying their per-instance keys onto the `i/<id>` per-resource key space. `spinifex-instance-state` carries a `2`→`3` step from the same file for the node blobs, which hold a whole node's running set in one record and so split rather than copy. Every other bucket has none, so `RunKV` stamps its target version directly on first init.
 
 **Object store:** none, so `RunObject` stamps directly too.
 

--- a/spinifex/migrate/VERSIONS.md
+++ b/spinifex/migrate/VERSIONS.md
@@ -19,15 +19,27 @@ Single source of truth for the current schema version of every config file Spini
 
 | Bucket | Current version | Constant |
 |---|---|---|
-| `spinifex-instance-state` | `3` | `daemon.InstanceStateBucketVersion` |
+| `spinifex-instance-state` | `4` | `daemon.InstanceStateBucketVersion` |
 | `spinifex-cluster-state` | `1` | `daemon.ClusterStateBucketVersion` |
-| `spinifex-terminated-instances` | `2` | `daemon.TerminatedInstanceBucketVersion` |
+| `spinifex-terminated-instances` | `3` | `daemon.TerminatedInstanceBucketVersion` |
 
 ## Registered migrations
 
 **Config:** none. The migrations that used to live here predated a breaking change that required `spx admin init --force`, so no install can reach the current versions by migrating and the steps were dropped rather than left as dead code. `spinifex.toml` is still registered as a config target in `migrate.go` so `spx admin upgrade` reports its on-disk version.
 
-**KV:** `spinifex-instance-state` and `spinifex-terminated-instances` each carry a `1`→`2` step registered from `daemon/instance_records_migrate.go`, copying their per-instance keys onto the `i/<id>` per-resource key space. `spinifex-instance-state` carries a `2`→`3` step from the same file for the node blobs, which hold a whole node's running set in one record and so split rather than copy. Every other bucket has none, so `RunKV` stamps its target version directly on first init.
+**KV:** `spinifex-instance-state` and `spinifex-terminated-instances` are both migrated from `daemon/instance_records_migrate.go`, onto the per-resource instance record key space.
+
+| Bucket | Step | What it does |
+|---|---|---|
+| `spinifex-instance-state` | `1`→`2` | copy the `instance.<id>` keys onto the record space |
+| `spinifex-instance-state` | `2`→`3` | split each `node.<id>` blob, one record per instance in it |
+| `spinifex-instance-state` | `3`→`4` | re-key the record space from `i/<id>` to `i.<id>` |
+| `spinifex-terminated-instances` | `1`→`2` | copy the `terminated.<id>` keys onto the record space |
+| `spinifex-terminated-instances` | `2`→`3` | re-key the record space from `i/<id>` to `i.<id>` |
+
+The re-key steps exist because a watch filter is a NATS subject filter: `*` matches one dot-delimited token, so `i/<id>` is a single token and `i/*` matches nothing. Only a build that shipped the slash has anything for them to move.
+
+Every other bucket has no registered migration, so `RunKV` stamps its target version directly on first init.
 
 **Object store:** none, so `RunObject` stamps directly too.
 


### PR DESCRIPTION
Second half of release 1 of the instance record re-key, after #932 landed the two renames. Plan: `docs/development/josh/improvements/instance-record-rekey.md`, bead `mulga-yf718`.

`node.<nodeID>` holds one record per node containing every VM running there, so a single instance changing state rewrites the whole node's set and two instances on one node serialise against each other for no reason. This mirrors each member onto `i.<id>` while the blob keeps being written whole, so a node still on the previous release is unaffected.

## The shadow rule carries over

Same as #932, for the same reason env19 found: the blob decides which instances are running on this node, and each member's value comes from its mirror. A record with no member behind it is not an instance. Every read still goes through the conversion — that is the point of a transition release — only the existence question waits for the cutover.

## What reading the code changed

Three things, all of which moved the design away from the plan's sketch.

**The surface is much narrower than "one record into N".** `JetStreamManager.WriteState` and `DeleteState` have no non-test callers, so the only production path that writes the blob is `WriteStateBytesBestEffort` from `persistState`. The readers are `vm/restore.go` at startup and `Daemon.nodeRunningVMs` on the EKS reaper's reconcile, both via `vm.StateStore.LoadRunningState`, and both for this node only. Nothing reads another node's blob.

**The mirror set has to be reconciled, not just written.** An instance leaves the running set from six places — `vm/migrate.go`, `vm/shutdown.go`, two rollback paths in `StartStoppedInstance`, and the wholesale `Replace`/`AdoptClusterState` on restore — so deleting the mirror at each removal would mean six edits and still miss the two that swap the whole map. `persistState` is the single funnel all six reach and it holds the full map, so the reconcile lives there.

It writes only what changed. Rewriting all N mirrors per state change would reintroduce, one key at a time, the contention this step exists to remove — today a state change is one Put. `persistState` keeps the digest of what it last mirrored under the lock it already holds, and primes it from one prefix scan on the first call after boot.

**A departed member is not always a deletable mirror.** `i.<id>` is shared with the stopped key space from #932, in the same bucket, and an instance that stops leaves the running set at the moment `WriteStoppedInstance` mirrors it. A blind delete would race that write and would re-delete the record of every instance ever stopped on this node. So a departed member's mirror is retired only when `instance.<id>` does not hold it; otherwise it is handed over, which is what it becomes permanently at the cutover.

## One thing the tests caught

`WriteState` writes the blob without mirroring, which leaves a record staler than the blob it belongs to — and reads answer from the record. `TestRestoreInstances_ClusterRecordWinsForSharedInstance` failed on exactly that. It is test-only today, which is what makes it a trap rather than a non-issue, so the fix is in the writer: every path that writes the blob now mirrors it.

## The separator had to be a dot

The plan's Files-to-Modify table said the DNS watch filter moves from `node.*` to `i/*`. It cannot. A reconciler `Filter` is a NATS subject filter, `*` matches one dot-delimited token, and `i/i-abc` is a single token — so `i/*` matches nothing rather than every record. Post-cutover the watch would have had to take the whole bucket with `>`, which is worse than today's `node.*`: it wakes on every key in the bucket rather than on instance state.

`i.<id>` is two tokens, so `i.*` is a working filter, and it stays prefix-disjoint from the three key spaces it replaces for exactly the reason the slash was: `List` and `DeletePrefix` match a plain string prefix, and `"instance.i-1"` does not begin `"i."`. The change costs one constant and a bucket version now; after the cutover it would cost another migration.

Because #932 already merged with the slash, each bucket carries a re-key step that moves `i/<id>` to `i.<id>` and deletes the old key. Deleting is safe under the shadow rule: a node still writing slashes also reads them, so what it loses is a mirror, and a missing mirror is a fallback to the key it mirrors rather than an error.

## Migration

`spinifex-instance-state` goes to schema version 4, `spinifex-terminated-instances` to 3.

| Bucket | Step | What it does |
|---|---|---|
| `spinifex-instance-state` | `2`→`3` | split each `node.<id>` blob, one record per instance in it |
| `spinifex-instance-state` | `3`→`4` | re-key the record space from `i/<id>` to `i.<id>` |
| `spinifex-terminated-instances` | `2`→`3` | re-key the record space from `i/<id>` to `i.<id>` |

The split runs over every node's blob, not just the one running it: it runs once per bucket, and a node that is down would otherwise have no records until it came back — which is exactly when a reader most needs one. Every step creates rather than puts, for the same reason as #932's 1→2: the version stamp is a read-then-write rather than a CAS, so every step must be safe to re-execute.

## Testing

Twelve new tests in `daemon/instance_records_mirror_test.go` covering the mirror (a record per member, only what changed, seeding after a restart, retiring a departed member, handing over a stopped one, leaving another node's records alone), the read (mirror preferred, blob fallback, orphan ignored, both halves carried), and the migration (splits one blob, splits every node's, keeps the blob, safe to run twice).

Three of them were checked against a reverted implementation rather than assumed to be load-bearing: removing the digest check fails `WritesOnlyWhatChanged`, removing the hand-over gate fails `HandsOverAMemberThatStopped`, and removing the membership test fails `IgnoresARecordWithNoBlobMember`.

Five more in `daemon/instance_records_rekey_test.go` cover the separator: the re-key moves instance-state and terminated records onto the dot and leaves no orphan behind, it is a no-op on a bucket that never held a slash, and a pair asserts both halves of the reasoning that chose the shape — that `i.*` delivers a record write, and that `i/*` does not. If the second ever stops failing to deliver, the re-key was unnecessary and the argument above is wrong.

`TestInstanceStateMigration_LeavesTheNodeBlobAlone` was renamed and rewritten: its premise was that the blob is not the migration's to split, which stopped being true here.

`make preflight` passes.

## What the blob actually costs

The case for the split was asserted rather than measured, so `daemon/blob_cost_bench_test.go` measures both sides on a record sized from env19 (its terminated bucket averages ~10KB per record):

```
BenchmarkMarshalBlob/N=1        24517 ns/op      4370 blob_bytes    17 allocs/op
BenchmarkMarshalBlob/N=10      374638 ns/op     43446 blob_bytes    45 allocs/op
BenchmarkMarshalBlob/N=50     1797367 ns/op    217125 blob_bytes   205 allocs/op
BenchmarkMarshalBlob/N=100    3093102 ns/op    434217 blob_bytes   405 allocs/op
BenchmarkMarshalOneRecord       18749 ns/op      4191 blob_bytes     6 allocs/op
```

One instance changing state costs the whole node's set: at 100 instances that is 434KB and 3.1ms of marshalling to record a change worth 4KB. The record is flat in N.

Worth being straight about what that means for this PR: release 1 is a net cost, not a win. It writes the blob *and* the mirror, so the amplification above is still paid and a per-instance write is added on top. The win arrives at the cutover when the blob write goes away, and it is N-dependent — on a three-instance node it is nothing.

There is no assertion, because there is no threshold worth failing a build on. Benchmarks compile in CI and run only when asked.

## env19

Verified on the three-node env19 from a pre-#932 baseline, so the run covers release 1 whole rather than this PR alone.

The migration ran once, on the first node up: 1→2 copied 2 stopped instances, 2→3 copied 1 running blob member, terminated 1→2 copied 1 — KV message counts 6→9 and 2→3, exactly the predicted deltas. `DescribeInstances` output was field-identical across the upgrade except `LaunchTime` on the one running instance, which matched the QEMU process start to the second and was a genuine deploy relaunch, not a record change.

Lifecycle on the upgraded cluster — start, stop, terminate-from-running, terminate-from-stopped — produced single rows with all three nodes agreeing, no duplicates and no mirror warnings in the logs. An accidental mixed cluster (two upgraded nodes against one still reading an already-migrated bucket at the older version) also agreed on all four instances, which is the case the shadow rule exists for.

The re-key then went through the same env from the state that run left behind: instance-state at 3, terminated at 2, four slash records between the two buckets. Both steps ran once, on the first node to roll, moving 1 and 3 records:

```
"msg":"Running KV migration","bucket":"spinifex-instance-state","from":3,"to":4
"msg":"Re-keyed instance records onto the dot separator","moved":1
"msg":"Running KV migration","bucket":"spinifex-terminated-instances","from":2,"to":3
"msg":"Re-keyed instance records onto the dot separator","moved":3
```

Every `i/<id>` became `i.<id>` at the same byte length with no orphan left behind, `DescribeInstances` was identical across the roll once normalised for reservation order, and all three nodes agreed. The lifecycle then re-ran on the dot keys: start dropped `instance.<id>` and refreshed the mirror, stop reinstated `instance.<id>` and left the mirror in place rather than deleting it — the hand-over case, live — and terminate removed both keys from instance-state and wrote both into the terminated bucket.

One thing worth recording for the cutover, not a defect here: the terminated bucket's one-hour TTL applies per key, so the re-key's fresh record can outlive the key it mirrors. One instance's `terminated.<id>` expired while its `i.<id>` was still current, and the orphan correctly did not appear in `DescribeInstances` on any node — which is what the shadow rule is for. It only matters for a cutover that reads existence from the record while legacy keys are still expiring underneath. The reverse cannot happen: the mirror is always written after the key it mirrors, so it always expires later.

Key names came from a throwaway binary run on a node, since KV key names still are not observable on a live cluster (`mulga-q3zi9`).
