### PR TITLE
fix: never lower a quota counter from a stale instance view

### DIFF
--- a/spinifex/handlers/quota/records.go
+++ b/spinifex/handlers/quota/records.go
@@ -3,6 +3,7 @@ package handlers_quota
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 
 	"github.com/mulgadc/spinifex/spinifex/instancetypes"
 	"github.com/mulgadc/spinifex/spinifex/kvstore"
@@ -18,27 +19,47 @@ import (
 // which is what zeroes an account that has just released everything.
 //
 // complete reports whether the view is good enough to lower a counter. It is
-// false when the read failed, so a counter may still be raised from whatever
-// was seen but never lowered from a view known to be short.
+// false when the read failed and when the read cannot prove it was current, so
+// a counter may still be raised from whatever was seen but never lowered from
+// a view known to be short or suspected of being stale.
 type InstanceVCPULister func(ctx context.Context) (perAccount map[string]int, complete bool, err error)
+
+// recordSource is the pair of reads the sweep needs: the stream position it
+// must reach, and the snapshot it judges against that position. It exists so a
+// test can hand the sweep a snapshot that is deliberately behind, which a live
+// single-node server never produces.
+type recordSource interface {
+	LastSequence(ctx context.Context, filter string) (uint64, error)
+	Snapshot(ctx context.Context, filter string) ([]kvstore.Item[vm.InstanceRecord], uint64, error)
+}
+
+var _ recordSource = (*kvstore.Store[vm.InstanceRecord])(nil)
 
 // RecordVCPULister totals vCPUs from the per-resource instance record space.
 // The account is on the record and vCPUs derive from the instance type, which
-// is spec, so the whole sweep is one KV list where it used to be a NATS
+// is spec, so the whole sweep is one KV read where it used to be a NATS
 // fan-out of describes costing passes x accounts x (nodes + 2).
 //
 // There is no index by account, so a recompute of one account still reads the
-// whole prefix. That is one list per settled burst, which the debounce already
+// whole prefix. That is one read per settled burst, which the debounce already
 // coalesces, against a fan-out that ran per account on every tick.
-func RecordVCPULister(records *kvstore.Store[vm.InstanceRecord], prefix string) InstanceVCPULister {
+//
+// The watermark is taken before the snapshot, not after. Every record write
+// that had completed when the pass began sits at or below it, so a snapshot
+// reaching it has seen all of them and may lower a counter. A write landing
+// after it belongs to the pass its own watch update triggers.
+func RecordVCPULister(records recordSource, prefix string) InstanceVCPULister {
+	filter := prefix + "*"
 	return func(ctx context.Context) (map[string]int, bool, error) {
-		list, err := records.List(ctx, prefix)
+		watermark, watermarkErr := records.LastSequence(ctx, filter)
+		items, highWater, err := records.Snapshot(ctx, filter)
 		if err != nil {
 			return nil, false, err
 		}
-		totals := make(map[string]int, len(list))
-		for i := range list {
-			record := &list[i]
+
+		totals := make(map[string]int, len(items))
+		for i := range items {
+			record := &items[i].Value
 			accountID := record.Metadata.AccountID
 			if accountID == "" || accountID == utils.GlobalAccountID {
 				continue
@@ -51,6 +72,20 @@ func RecordVCPULister(records *kvstore.Store[vm.InstanceRecord], prefix string) 
 			if vcpus, ok := instancetypes.DefaultVCPUs(record.Spec.InstanceType); ok {
 				totals[accountID] += vcpus
 			}
+		}
+
+		// A snapshot short of the watermark was served by a replica that has
+		// not caught up, and lowering from it would undo a charge for an
+		// instance it never saw. Raising is still safe and still happens.
+		if watermarkErr != nil {
+			slog.WarnContext(ctx, "quota: instance watermark unavailable, counters may not be lowered",
+				"err", watermarkErr)
+			return totals, false, nil
+		}
+		if highWater < watermark {
+			slog.WarnContext(ctx, "quota: instance snapshot behind the stream, counters may not be lowered",
+				"high_water", highWater, "watermark", watermark)
+			return totals, false, nil
 		}
 		return totals, true, nil
 	}

--- a/spinifex/handlers/quota/records_test.go
+++ b/spinifex/handlers/quota/records_test.go
@@ -1,7 +1,9 @@
 package handlers_quota_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	handlers_quota "github.com/mulgadc/spinifex/spinifex/handlers/quota"
@@ -87,6 +89,103 @@ func TestRecordVCPULister_UnknownInstanceTypeContributesNothing(t *testing.T) {
 	totals, _, err := handlers_quota.RecordVCPULister(store, recordPrefix)(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, map[string]int{account: 2}, totals)
+}
+
+// stubSource stands in for the record store so a snapshot can be made
+// deliberately stale, which a single-node server never does on its own.
+type stubSource struct {
+	items         []kvstore.Item[vm.InstanceRecord]
+	highWater     uint64
+	watermark     uint64
+	watermarkErr  error
+	snapshotCalls int
+}
+
+func (s *stubSource) LastSequence(context.Context, string) (uint64, error) {
+	return s.watermark, s.watermarkErr
+}
+
+func (s *stubSource) Snapshot(context.Context, string) ([]kvstore.Item[vm.InstanceRecord], uint64, error) {
+	s.snapshotCalls++
+	return s.items, s.highWater, nil
+}
+
+func stubItem(id, accountID, instanceType string, state vm.InstanceState) kvstore.Item[vm.InstanceRecord] {
+	return kvstore.Item[vm.InstanceRecord]{
+		Key:      recordPrefix + id,
+		Revision: 1,
+		Value: vm.InstanceRecord{
+			Metadata: resource.Metadata{Name: id, AccountID: accountID},
+			Spec:     vm.InstanceSpec{InstanceType: instanceType},
+			Status:   vm.InstanceStatus{Status: state},
+		},
+	}
+}
+
+// A snapshot that reached the watermark saw every write that had completed
+// when the pass began, so it is good enough to lower a counter.
+func TestRecordVCPULister_CompleteWhenTheSnapshotReachesTheWatermark(t *testing.T) {
+	const account = "111111111111"
+	source := &stubSource{
+		items:     []kvstore.Item[vm.InstanceRecord]{stubItem("i-1", account, "m5.xlarge", vm.StateRunning)},
+		highWater: 12,
+		watermark: 12,
+	}
+
+	totals, complete, err := handlers_quota.RecordVCPULister(source, recordPrefix)(t.Context())
+	require.NoError(t, err)
+	require.True(t, complete)
+	require.Equal(t, map[string]int{account: 4}, totals)
+	require.Equal(t, 1, source.snapshotCalls)
+}
+
+// A snapshot behind the watermark was served by a replica that has not caught
+// up. The totals are still returned so the pass can raise; complete is false
+// so it cannot lower and undo a charge for an instance it never saw.
+func TestRecordVCPULister_IncompleteWhenTheSnapshotIsBehindTheWatermark(t *testing.T) {
+	const account = "111111111111"
+	source := &stubSource{
+		items:     []kvstore.Item[vm.InstanceRecord]{stubItem("i-1", account, "m5.xlarge", vm.StateRunning)},
+		highWater: 11,
+		watermark: 12,
+	}
+
+	totals, complete, err := handlers_quota.RecordVCPULister(source, recordPrefix)(t.Context())
+	require.NoError(t, err)
+	require.False(t, complete)
+	require.Equal(t, map[string]int{account: 4}, totals)
+}
+
+// A watermark that cannot be read is not a reason to fail the pass, but it is
+// a reason not to trust the snapshot's currency.
+func TestRecordVCPULister_IncompleteWhenTheWatermarkIsUnavailable(t *testing.T) {
+	const account = "111111111111"
+	source := &stubSource{
+		items:        []kvstore.Item[vm.InstanceRecord]{stubItem("i-1", account, "t3.micro", vm.StateRunning)},
+		highWater:    12,
+		watermarkErr: errors.New("stream leader unavailable"),
+	}
+
+	totals, complete, err := handlers_quota.RecordVCPULister(source, recordPrefix)(t.Context())
+	require.NoError(t, err)
+	require.False(t, complete)
+	require.Equal(t, map[string]int{account: 2}, totals)
+}
+
+// The live pairing is what makes complete reachable at all: against a real
+// bucket the snapshot and the watermark agree, including when the newest
+// event is the delete that releases the quota.
+func TestRecordVCPULister_CompleteAgainstALiveBucketAfterADelete(t *testing.T) {
+	store := recordStore(t)
+	const account = "111111111111"
+	putRecord(t, store, "i-1", account, "m5.xlarge", vm.StateRunning)
+	putRecord(t, store, "i-2", account, "t3.micro", vm.StateRunning)
+	require.NoError(t, store.Delete(t.Context(), recordPrefix+"i-2"))
+
+	totals, complete, err := handlers_quota.RecordVCPULister(store, recordPrefix)(t.Context())
+	require.NoError(t, err)
+	require.True(t, complete)
+	require.Equal(t, map[string]int{account: 4}, totals)
 }
 
 func TestAccountForRecord(t *testing.T) {

--- a/spinifex/kvstore/bucket.go
+++ b/spinifex/kvstore/bucket.go
@@ -5,6 +5,7 @@ package kvstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -102,6 +103,69 @@ func (b *Bucket) KV(ctx context.Context) (jetstream.KeyValue, error) {
 	}
 	b.kv = kv
 	return kv, nil
+}
+
+// jsAPIStreamMsgGet is the non-direct stream read, spelled out rather than
+// reached through nats.go. Every convenience wrapper switches to
+// $JS.API.DIRECT.GET on a stream with AllowDirect, and KV buckets always
+// have it. The default API prefix holds because every caller builds its
+// client with plain jetstream.New, so no domain is in play.
+const jsAPIStreamMsgGet = "$JS.API.STREAM.MSG.GET.KV_%s"
+
+// jsErrCodeMessageNotFound is returned for a filter matching nothing, which is
+// an empty prefix rather than a failure.
+const jsErrCodeMessageNotFound = 10037
+
+// LastSequence reports the stream sequence of the newest message matching
+// filter, or zero when nothing matches. A tombstone is a message, so the
+// sequence follows the stream rather than the surviving key set.
+//
+// The stream leader answers, which is the entire point of the hand-rolled
+// request: nats.go's GetLastMsgForSubject would serve this from any replica,
+// so a reader asking "am I behind?" could be answered by a replica that is
+// equally behind.
+func (b *Bucket) LastSequence(ctx context.Context, filter string) (uint64, error) {
+	b.mu.Lock()
+	js := b.js
+	b.mu.Unlock()
+	if js == nil {
+		if b.cfg.Missing == "" {
+			return 0, errors.New("kvstore: no JetStream client configured")
+		}
+		return 0, errors.New(b.cfg.Missing)
+	}
+
+	req, err := json.Marshal(map[string]string{"last_by_subj": "$KV." + b.cfg.Name + "." + filter})
+	if err != nil {
+		return 0, fmt.Errorf("kvstore: encode last-sequence request for %s: %w", b.cfg.Name, err)
+	}
+	msg, err := js.Conn().RequestWithContext(ctx, fmt.Sprintf(jsAPIStreamMsgGet, b.cfg.Name), req)
+	if err != nil {
+		return 0, fmt.Errorf("kvstore: last sequence %s %s: %w", b.cfg.Name, filter, err)
+	}
+
+	var resp struct {
+		Message *struct {
+			Sequence uint64 `json:"seq"`
+		} `json:"message"`
+		Error *struct {
+			ErrCode     int    `json:"err_code"`
+			Description string `json:"description"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(msg.Data, &resp); err != nil {
+		return 0, fmt.Errorf("kvstore: decode last sequence %s: %w", b.cfg.Name, err)
+	}
+	if resp.Error != nil {
+		if resp.Error.ErrCode == jsErrCodeMessageNotFound {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("kvstore: last sequence %s %s: %s", b.cfg.Name, filter, resp.Error.Description)
+	}
+	if resp.Message == nil {
+		return 0, fmt.Errorf("kvstore: last sequence %s %s: empty response", b.cfg.Name, filter)
+	}
+	return resp.Message.Sequence, nil
 }
 
 // Reopen discards the memoised handle and resolves the bucket again, for a

--- a/spinifex/kvstore/snapshot_test.go
+++ b/spinifex/kvstore/snapshot_test.go
@@ -1,0 +1,98 @@
+package kvstore_test
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type snapRecord struct {
+	Name string `json:"name"`
+}
+
+func snapshotStore(t *testing.T, name string) *kvstore.Store[snapRecord] {
+	t.Helper()
+	_, nc, _ := testutil.StartTestJetStream(t)
+	return kvstore.New[snapRecord](testutil.NewJetStream(t, nc), kvstore.Config{Name: name, History: 1})
+}
+
+func TestSnapshotReturnsMatchingRecordsWithTheirRevisions(t *testing.T) {
+	store := snapshotStore(t, "snapshot-records")
+	require.NoError(t, store.Set(t.Context(), "i.a", &snapRecord{Name: "a"}))
+	require.NoError(t, store.Set(t.Context(), "i.b", &snapRecord{Name: "b"}))
+	require.NoError(t, store.Set(t.Context(), "node.1", &snapRecord{Name: "elsewhere"}))
+
+	items, highWater, err := store.Snapshot(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	byKey := map[string]kvstore.Item[snapRecord]{}
+	for _, item := range items {
+		byKey[item.Key] = item
+		require.NotZero(t, item.Revision)
+	}
+	require.Equal(t, "a", byKey["i.a"].Value.Name)
+	require.Equal(t, "b", byKey["i.b"].Value.Name)
+	require.NotContains(t, byKey, "node.1")
+	require.Equal(t, byKey["i.b"].Revision, highWater)
+}
+
+// The high-water mark tracks the reader's position in the stream, not what
+// survives in it. A delete is a message, so a snapshot whose newest event is a
+// delete still reaches the watermark and can still lower a counter.
+func TestSnapshotCountsATombstoneTowardsTheHighWaterMark(t *testing.T) {
+	store := snapshotStore(t, "snapshot-tombstone")
+	require.NoError(t, store.Set(t.Context(), "i.a", &snapRecord{Name: "a"}))
+	require.NoError(t, store.Set(t.Context(), "i.b", &snapRecord{Name: "b"}))
+	require.NoError(t, store.Delete(t.Context(), "i.b"))
+
+	items, highWater, err := store.Snapshot(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "i.a", items[0].Key)
+
+	watermark, err := store.LastSequence(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Equal(t, watermark, highWater)
+	require.Greater(t, highWater, items[0].Revision)
+}
+
+func TestSnapshotOfNothingIsNotAnError(t *testing.T) {
+	store := snapshotStore(t, "snapshot-empty")
+	require.NoError(t, store.Set(t.Context(), "node.1", &snapRecord{Name: "elsewhere"}))
+
+	items, highWater, err := store.Snapshot(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Empty(t, items)
+	require.Zero(t, highWater)
+}
+
+func TestLastSequenceIsTheNewestMessageMatchingTheFilter(t *testing.T) {
+	store := snapshotStore(t, "watermark-newest")
+	require.NoError(t, store.Set(t.Context(), "i.a", &snapRecord{Name: "a"}))
+	items, highWater, err := store.Snapshot(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	watermark, err := store.LastSequence(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Equal(t, highWater, watermark)
+
+	// A write outside the filter must not move it, which is what makes the
+	// mark comparable to a snapshot of the same filter.
+	require.NoError(t, store.Set(t.Context(), "node.1", &snapRecord{Name: "elsewhere"}))
+	after, err := store.LastSequence(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Equal(t, watermark, after)
+}
+
+func TestLastSequenceIsZeroWhenNothingMatches(t *testing.T) {
+	store := snapshotStore(t, "watermark-empty")
+	require.NoError(t, store.Set(t.Context(), "node.1", &snapRecord{Name: "elsewhere"}))
+
+	watermark, err := store.LastSequence(t.Context(), "i.*")
+	require.NoError(t, err)
+	require.Zero(t, watermark)
+}

--- a/spinifex/kvstore/store.go
+++ b/spinifex/kvstore/store.go
@@ -163,6 +163,66 @@ func (s *Store[T]) List(ctx context.Context, prefix string) ([]T, error) {
 	return out, nil
 }
 
+// Item is one record from a Snapshot, carrying the revision it was read at so
+// the caller can CAS against it.
+type Item[T any] struct {
+	Key      string
+	Value    T
+	Revision uint64
+}
+
+// Snapshot reads every record matching filter in one ordered pass and reports
+// the highest stream sequence it saw. Filter takes NATS subject wildcards.
+//
+// One consumer answers the whole read, so the keys and the values are
+// mutually consistent. List is not: it enumerates keys through a consumer and
+// then fetches each value through a direct get, and each of those gets is
+// routed independently, so no two of them need come from the same replica.
+//
+// A deleted key is not returned, but its revision still counts towards
+// highWater. That is deliberate: the mark says how far this reader got
+// through the stream, not what survives in it, and a delete is how far a
+// reader gets when the newest thing that happened was a delete.
+func (s *Store[T]) Snapshot(ctx context.Context, filter string) (items []Item[T], highWater uint64, err error) {
+	// Pure read, so it is safe for withKV to run it twice; the results are
+	// reset on entry rather than appended to across a retry.
+	err = s.withKV(ctx, func(kv jetstream.KeyValue) error {
+		items, highWater = nil, 0
+
+		watcher, err := kv.Watch(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("kvstore: snapshot %s %s: %w", s.cfg.Name, filter, err)
+		}
+		defer func() { _ = watcher.Stop() }()
+
+		for entry := range watcher.Updates() {
+			// nil marks the end of the existing values, which is the whole
+			// snapshot: anything after it is a live update, not state.
+			if entry == nil {
+				return nil
+			}
+			if entry.Revision() > highWater {
+				highWater = entry.Revision()
+			}
+			if entry.Operation() != jetstream.KeyValuePut {
+				continue
+			}
+			var v T
+			if err := json.Unmarshal(entry.Value(), &v); err != nil {
+				return fmt.Errorf("kvstore: decode %s: %w", entry.Key(), err)
+			}
+			items = append(items, Item[T]{Key: entry.Key(), Value: v, Revision: entry.Revision()})
+		}
+		// The channel closed without the marker, so the watcher died mid-pass
+		// and what was collected is a partial view rather than a snapshot.
+		return fmt.Errorf("kvstore: snapshot %s %s: watcher closed early", s.cfg.Name, filter)
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, highWater, nil
+}
+
 // DeletePrefix removes every key carrying the given prefix. An empty prefix
 // purges the bucket. Idempotent, like Delete.
 func (s *Store[T]) DeletePrefix(ctx context.Context, prefix string) error {


### PR DESCRIPTION
## Summary

`Reconcile` is the only path that lowers a vCPU counter, and it lowered to a total computed from a KV read that may be served by a lagging replica. A read that misses a just-charged launch lowers the counter below reality, which lifts the account's cap — the exact failure the raise-but-never-lower invariant exists to prevent, arriving through replica lag rather than through a failed read.

#940 closed the *mid-scan* window: the lower is written under CAS on the counter revision read before the scan, so a `ChargeLaunch` landing during the scan wins. This closes the *before-scan* one. Fixes `mulga-2ephc`.

## Where the staleness actually entered

`Store.List` is two different reads stitched together, and only the first is coherent:

1. `kv.Keys(ctx)` — an ordered consumer, so one server, delivered in stream order.
2. one `kv.Get` per key — a **direct get**, independently routed, so no two keys need come from the same replica.

Both can under-count, and it is worth being exact, because the bead's original framing assumed only the key set mattered:

- **A missing key** is the launch case: an instance that exists is not counted.
- **A stale value** is the retype case: an instance retyped up from `t3.micro` (2) to `m5.xlarge` (4) reads as 2 from a replica that has not applied the retype. `EnforceRetype` charged the delta and the sweep overwrites it away.

A stale *status* is safe in the other direction — an old `running` for a now-terminated instance over-counts, and over-counting only tightens the cap.

Because the per-key gets are routed independently, fencing any one of them says nothing about the others. The read has to become a single ordered pass before it can be reasoned about at all.

## The change

**`Store.Snapshot(ctx, filter)`** reads the whole prefix through one watcher and returns the items plus the highest stream sequence it observed. One consumer answers the whole read, so keys and values are mutually consistent. It is also strictly cheaper than what it replaces — one consumer instead of one consumer plus N direct gets.

**`Bucket.LastSequence(ctx, filter)`** reports the newest sequence matching a filter, **from the stream leader**.

Stream sequences are applied in order, so a reader that has observed sequence N has applied everything at or before N. That reduces freshness to one comparison:

```go
watermark, watermarkErr := records.LastSequence(ctx, filter)  // leader, before the scan
items, highWater, err := records.Snapshot(ctx, filter)
complete := watermarkErr == nil && highWater >= watermark
```

Taking the watermark **before** the snapshot is what makes it sound: every record write that had completed when the pass began sits at or below it, so `highWater >= watermark` proves the snapshot saw all of them. A write landing after it belongs to the pass its own watch update triggers.

The counter-revision CAS from #940 is untouched. It closes the mid-scan window; this closes the one before it.

## The one trap worth reading the comment for

`LastSequence` issues a raw `$JS.API.STREAM.MSG.GET` request instead of calling `Stream.GetLastMsgForSubject`, and that is not incidental. `nats.go`'s `stream.getMsg` switches to `$JS.API.DIRECT.GET` whenever the stream has `AllowDirect`:

```go
// handle direct gets
if s.info.Config.AllowDirect {
    if mreq.LastFor != "" {
        gmSubj = fmt.Sprintf(apiDirectMsgGetLastBySubjectT, s.name, mreq.LastFor)
```

KV buckets always have `AllowDirect` (`handlers/ec2/vpc/eni.go:310` records the same fact for reads). So the convenience method would answer a question *about* replica lag *from* a lagging replica, and the guard would agree with itself and pass. The comment on `LastSequence` says so, because the obvious tidy-up reintroduces the bug silently.

## The tombstone objection, retested

The analysis on the bead rejected a watermark on the grounds that a delete would break it: the newest message could be a tombstone, which a scan does not return, so the mark could never be reached and the pass would refuse to lower forever — precisely on the terminate path where lowering is the point, and precisely the release-latency regression the acceptance criteria forbid.

That was assumed, not measured. A watcher **does** deliver tombstones:

```
stream last_seq=4 msgs=3
Q2 entry key=i.a rev=1 op=KeyValuePutOp
Q2 entry key=i.b rev=4 op=KeyValueDeleteOp
Q2 end-of-initial marker reached, high=4
```

So `Snapshot` counts a delete's revision towards the high-water mark while excluding it from the returned items, the mark reaches the watermark, and a terminate still lowers on the same pass. That split is the whole trick, and it is why the two are returned separately. `TestSnapshotCountsATombstoneTowardsTheHighWaterMark` and `TestRecordVCPULister_CompleteAgainstALiveBucketAfterADelete` hold it.

## Testing

`make preflight` passes. Existing quota tests pass unedited — `InstanceVCPULister` keeps its signature, so `Reconcile` and `ReconcileAccount` are untouched.

New: snapshot returns only matching live records with revisions; a tombstone counts towards the mark and matches the watermark; an empty prefix is not an error; `LastSequence` ignores writes outside the filter and is 0 when nothing matches; complete is true when the snapshot reaches the watermark, false when it is behind, false when the watermark is unavailable — and in both false cases the totals are still returned, so the pass can still raise.

The guard was mutation-checked. Neutering the comparison to `if false && highWater < watermark` fails `TestRecordVCPULister_IncompleteWhenTheSnapshotIsBehindTheWatermark` with `Should be false`; the mutation was reverted before the committed tree was gated.

`RecordVCPULister` now takes an unexported `recordSource` interface rather than the concrete store. A single-node test server never produces a lagging replica, so without a seam the decline path could not be tested at all — and it is the entire point of the change. `var _ recordSource = (*kvstore.Store[vm.InstanceRecord])(nil)` keeps the production type honest.

## Not in scope

`Store.List` keeps its current shape and its other callers. Only quota needs a coherent read today, and converting the rest is separate work.

## Verification

Verified on env19 (3 nodes, R3), deployed twice so the delta is exactly this commit. No regression: idle describes 0 both before and after, launch and terminate each move the counter in 1ms on both builds.

The guard was checked for the failure mode that looks green — a watermark stuck at zero passes `highWater >= watermark` vacuously. Live it reads **356, against a newest surviving record at rev 189**: the gap is a tombstone, so the live cluster exercised exactly the case the bead predicted would deadlock the guard, and the snapshot still reached it. Zero freshness warnings across ~26 passes per node. Full numbers in the comment below.
