### PR TITLE
fix: reject PermissionsBoundary on CreateRole and CreateUser

### DIFF
--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -44,6 +44,10 @@ func (s *IAMServiceImpl) CreateRole(accountID string, input *iam.CreateRoleInput
 		return nil, errors.New(awserrors.ErrorIAMInvalidInput)
 	}
 
+	if err := validatePermissionsBoundary(input.PermissionsBoundary); err != nil {
+		return nil, err
+	}
+
 	path := "/"
 	if input.Path != nil {
 		path = *input.Path

--- a/spinifex/handlers/iam/roles_test.go
+++ b/spinifex/handlers/iam/roles_test.go
@@ -108,6 +108,48 @@ func TestCreateRole_InvalidPath(t *testing.T) {
 	assert.Contains(t, err.Error(), awserrors.ErrorIAMInvalidInput)
 }
 
+func TestCreateRole_PermissionsBoundarySet(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.CreateRole(testAccountID, &iam.CreateRoleInput{
+		RoleName:                 aws.String("bounded-role"),
+		AssumeRolePolicyDocument: aws.String(validTrustPolicy()),
+		PermissionsBoundary:      aws.String("arn:aws:iam::" + testAccountID + ":policy/deny-all"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorValidationError)
+	assert.Contains(t, err.Error(), "PermissionsBoundary")
+
+	_, err = svc.GetRole(testAccountID, &iam.GetRoleInput{RoleName: aws.String("bounded-role")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestCreateRole_PermissionsBoundaryAbsent(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	tests := []struct {
+		name     string
+		roleName string
+		boundary *string
+	}{
+		{name: "nil", roleName: "nil-boundary", boundary: nil},
+		{name: "empty string", roleName: "empty-boundary", boundary: aws.String("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := svc.CreateRole(testAccountID, &iam.CreateRoleInput{
+				RoleName:                 aws.String(tt.roleName),
+				AssumeRolePolicyDocument: aws.String(validTrustPolicy()),
+				PermissionsBoundary:      tt.boundary,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.roleName, *out.Role.RoleName)
+		})
+	}
+}
+
 func TestCreateRole_MalformedTrustPolicy_InvalidJSON(t *testing.T) {
 	svc := setupTestIAMService(t)
 

--- a/spinifex/handlers/iam/service_impl.go
+++ b/spinifex/handlers/iam/service_impl.go
@@ -323,6 +323,10 @@ func (s *IAMServiceImpl) CreateUser(accountID string, input *iam.CreateUserInput
 		return nil, errors.New(awserrors.ErrorIAMInvalidInput)
 	}
 
+	if err := validatePermissionsBoundary(input.PermissionsBoundary); err != nil {
+		return nil, err
+	}
+
 	path := "/"
 	if input.Path != nil {
 		path = *input.Path
@@ -1982,6 +1986,17 @@ func validatePolicyName(name string) error {
 		}
 	}
 	return nil
+}
+
+// validatePermissionsBoundary rejects a boundary the evaluator cannot enforce.
+// Storing an identity with an unenforced boundary would widen access silently,
+// so the create fails visibly instead.
+func validatePermissionsBoundary(boundary *string) error {
+	if aws.StringValue(boundary) == "" {
+		return nil
+	}
+	return awserrors.Errorf(awserrors.ErrorValidationError,
+		"PermissionsBoundary is not supported in this release; omit it and scope the identity with its attached policies instead")
 }
 
 func validatePath(path string) error {

--- a/spinifex/handlers/iam/service_impl_test.go
+++ b/spinifex/handlers/iam/service_impl_test.go
@@ -91,6 +91,46 @@ func TestCreateUser_Duplicate(t *testing.T) {
 	assert.Contains(t, err.Error(), awserrors.ErrorIAMEntityAlreadyExists)
 }
 
+func TestCreateUser_PermissionsBoundarySet(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.CreateUser(testAccountID, &iam.CreateUserInput{
+		UserName:            aws.String("boundeduser"),
+		PermissionsBoundary: aws.String("arn:aws:iam::" + testAccountID + ":policy/deny-all"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorValidationError)
+	assert.Contains(t, err.Error(), "PermissionsBoundary")
+
+	_, err = svc.GetUser(testAccountID, &iam.GetUserInput{UserName: aws.String("boundeduser")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestCreateUser_PermissionsBoundaryAbsent(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	tests := []struct {
+		name     string
+		userName string
+		boundary *string
+	}{
+		{name: "nil", userName: "nilboundary", boundary: nil},
+		{name: "empty string", userName: "emptyboundary", boundary: aws.String("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := svc.CreateUser(testAccountID, &iam.CreateUserInput{
+				UserName:            aws.String(tt.userName),
+				PermissionsBoundary: tt.boundary,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.userName, *out.User.UserName)
+		})
+	}
+}
+
 func TestGetUser(t *testing.T) {
 	svc := setupTestIAMService(t)
 	createTestUser(t, svc, "getuser")


### PR DESCRIPTION
## Summary

`CreateRole` and `CreateUser` accepted `PermissionsBoundary` on the AWS SDK input struct and never read it. There is no boundary field on the stored `Role` or `User` record and no reference to the concept anywhere in the tree, so a caller that set a boundary expecting the identity to be capped got an identity whose attached policies applied unrestricted, plus a success response confirming the create.

This inverts the convention the rest of the IAM layer follows. `validateStatementRestrictions` rejects `NotAction`, `NotResource`, `Principal` and any condition outside the supported allowlist precisely so a policy is never stored carrying an inert restriction. The permissions boundary was that same failure one layer up, and the only place in the IAM surface that widened access silently.

Both operations now reject a non-empty boundary with a `ValidationError` naming the parameter, before any ID is generated or record written. An absent or empty-string boundary behaves exactly as before.

`ErrorValidationError` is the code IAM's Query API already returns for a rejected parameter, it is a 400, and `awserrors` classifies it as terminal so a client does not retry it. `awserrors.Errorf` carries the explanatory message through `ResolveErrorDetail` to the response, which a bare `errors.New(code)` would not.

## Scope

Rejection only. Implementing boundary semantics — storage, the `Put*PermissionsBoundary` / `Delete*PermissionsBoundary` operations, and intersecting the boundary with the identity policy set in `GetUserPolicies` / `GetRolePolicies` — is a much larger piece of work and is deliberately out of scope. It should get its own bead and plan doc.

## Testing

Unit tests over both operations for boundary set (asserting the error code, the parameter name in the message, and that a follow-up `GetRole` / `GetUser` returns `NoSuchEntity`), boundary empty string, and boundary nil.

`make preflight` passes.

Bead: `mulga-eonbm`