### PR TITLE
fix: make the SG default-deny ACLs match every ethertype

### DIFF
--- a/spinifex/network/policy/acl.go
+++ b/spinifex/network/policy/acl.go
@@ -21,6 +21,11 @@ const (
 	// ACLPriorityTenantAllow: tenant ingress/egress allows. Not logged.
 	ACLPriorityTenantAllow = 1000
 
+	// ACLPriorityAllowARP sits above the default-denies, which match every
+	// ethertype. ACL tables run before the L2 lookup, so without this the
+	// denies black-hole ARP and take IPv4 with it.
+	ACLPriorityAllowARP = 950
+
 	// ACLPriorityDefaultDenyIngress: logged drop. CMMC SC.L1-3.13.1.
 	ACLPriorityDefaultDenyIngress = 900
 
@@ -43,13 +48,16 @@ type Rule struct {
 }
 
 // InfrastructureACLs returns the platform ACLs every PG carries: logged
-// 900/800 default-denies (CMMC SC.L1-3.13.1) and 1050 DHCPv4 allows.
+// 900/800 default-denies (CMMC SC.L1-3.13.1), 1050 DHCPv4 allows and the 950
+// ARP allows the denies would otherwise swallow.
 func InfrastructureACLs(portGroupName string) []ovn.ACLSpec {
 	return []ovn.ACLSpec{
 		denyIngressACL(portGroupName),
 		denyEgressACL(portGroupName),
 		dhcpEgressACL(portGroupName),
 		dhcpIngressACL(portGroupName),
+		arpEgressACL(portGroupName),
+		arpIngressACL(portGroupName),
 	}
 }
 
@@ -151,11 +159,13 @@ func appendPortMatch(parts []string, proto string, fromPort, toPort int64) []str
 	return parts
 }
 
+// denyIngressACL carries no ethertype qualifier: OVN allows on no-match, so an
+// ip4-scoped deny lets every other ethertype through. ARP is exempted at 950.
 func denyIngressACL(portGroupName string) ovn.ACLSpec {
 	return ovn.ACLSpec{
 		Direction: "to-lport",
 		Priority:  ACLPriorityDefaultDenyIngress,
-		Match:     fmt.Sprintf("outport == @%s && ip4", portGroupName),
+		Match:     fmt.Sprintf("outport == @%s", portGroupName),
 		Action:    "drop",
 		Name:      portGroupName + "-deny-ingress",
 		Log:       true,
@@ -163,15 +173,41 @@ func denyIngressACL(portGroupName string) ovn.ACLSpec {
 	}
 }
 
+// denyEgressACL is unqualified for the same reason as denyIngressACL.
 func denyEgressACL(portGroupName string) ovn.ACLSpec {
 	return ovn.ACLSpec{
 		Direction: "from-lport",
 		Priority:  ACLPriorityDefaultDenyEgress,
-		Match:     fmt.Sprintf("inport == @%s && ip4", portGroupName),
+		Match:     fmt.Sprintf("inport == @%s", portGroupName),
 		Action:    "drop",
 		Name:      portGroupName + "-deny-egress",
 		Log:       true,
 		Severity:  denyACLSeverity,
+	}
+}
+
+// arpEgressACL: ARP out. No IPv6 counterpart — nothing in the stack assigns a
+// guest a routable IPv6 address, so ND and DHCPv6 stay denied rather than
+// becoming an unpoliced side channel.
+func arpEgressACL(portGroupName string) ovn.ACLSpec {
+	return ovn.ACLSpec{
+		Direction: "from-lport",
+		Priority:  ACLPriorityAllowARP,
+		Match:     fmt.Sprintf("inport == @%s && arp", portGroupName),
+		Action:    "allow",
+		Name:      portGroupName + "-allow-arp-egress",
+	}
+}
+
+// arpIngressACL: ARP in. "allow" not "allow-related" — ARP is not an IP
+// protocol and has no conntrack state to relate to.
+func arpIngressACL(portGroupName string) ovn.ACLSpec {
+	return ovn.ACLSpec{
+		Direction: "to-lport",
+		Priority:  ACLPriorityAllowARP,
+		Match:     fmt.Sprintf("outport == @%s && arp", portGroupName),
+		Action:    "allow",
+		Name:      portGroupName + "-allow-arp-ingress",
 	}
 }
 

--- a/spinifex/network/policy/acl_test.go
+++ b/spinifex/network/policy/acl_test.go
@@ -137,8 +137,8 @@ func TestRuleACLSpecs_UnsupportedProtocolErrors(t *testing.T) {
 
 func TestInfrastructureACLs_Shape(t *testing.T) {
 	specs := InfrastructureACLs("sg_test")
-	if assert.Len(t, specs, 4) {
-		// Priorities: deny-ingress 900, deny-egress 800, dhcp-egress 1050, dhcp-ingress 1050
+	if assert.Len(t, specs, 6) {
+		// Priorities: deny-ingress 900, deny-egress 800, dhcp 1050 x2, arp 950 x2
 		assert.Equal(t, ACLPriorityDefaultDenyIngress, specs[0].Priority)
 		assert.Equal(t, "drop", specs[0].Action)
 		assert.True(t, specs[0].Log)
@@ -147,6 +147,52 @@ func TestInfrastructureACLs_Shape(t *testing.T) {
 		assert.Equal(t, ACLPriorityAllowDHCP, specs[2].Priority)
 		assert.Equal(t, "allow", specs[2].Action)
 		assert.Equal(t, ACLPriorityAllowDHCP, specs[3].Priority)
+		assert.Equal(t, ACLPriorityAllowARP, specs[4].Priority)
+		assert.Equal(t, "allow", specs[4].Action)
+		assert.Equal(t, ACLPriorityAllowARP, specs[5].Priority)
+		assert.Equal(t, "allow", specs[5].Action)
+	}
+}
+
+// The default-denies are the backstop and must match every ethertype. OVN
+// allows on no-match, so an ip4-scoped deny lets IPv6 and any other ethertype
+// through untouched — the allows are meant to be narrow, the denies are not.
+func TestInfrastructureACLs_DenyCarriesNoEthertypeQualifier(t *testing.T) {
+	for _, spec := range InfrastructureACLs("sg_test") {
+		if spec.Action != "drop" {
+			continue
+		}
+		assert.NotContains(t, spec.Match, "ip4", "deny %q must not be IPv4-scoped", spec.Name)
+		assert.NotContains(t, spec.Match, "ip6", "deny %q must not be IPv6-scoped", spec.Name)
+	}
+}
+
+// ACL tables run before the L2 lookup, so the unqualified denies would drop
+// ARP without an explicit allow above them, taking the IPv4 datapath down.
+func TestInfrastructureACLs_ARPAllowedAboveDenies(t *testing.T) {
+	assert.Greater(t, ACLPriorityAllowARP, ACLPriorityDefaultDenyIngress)
+	assert.Less(t, ACLPriorityAllowARP, ACLPriorityTenantAllow)
+
+	byDirection := map[string]string{}
+	for _, spec := range InfrastructureACLs("sg_test") {
+		if spec.Priority == ACLPriorityAllowARP {
+			byDirection[spec.Direction] = spec.Match
+		}
+	}
+	assert.Equal(t, "inport == @sg_test && arp", byDirection["from-lport"])
+	assert.Equal(t, "outport == @sg_test && arp", byDirection["to-lport"])
+}
+
+// IPv6 is not merely unused: no ENI is assigned a routable IPv6 address, IPv6
+// CIDRs are rejected upstream and the derived address sets are _ip4. So ND and
+// DHCPv6 stay under the deny rather than becoming an unpoliced side channel.
+func TestInfrastructureACLs_NoIPv6Exemption(t *testing.T) {
+	for _, spec := range InfrastructureACLs("sg_test") {
+		if spec.Action == "drop" {
+			continue
+		}
+		assert.NotContains(t, spec.Match, "nd", "allow %q must not exempt neighbour discovery", spec.Name)
+		assert.NotContains(t, spec.Match, "icmp6", "allow %q must not exempt ICMPv6", spec.Name)
 	}
 }
 

--- a/spinifex/network/policy/sg_test.go
+++ b/spinifex/network/policy/sg_test.go
@@ -39,8 +39,8 @@ func TestSGManager_EnsureSG_AppliesInfraPlusTenantACLs(t *testing.T) {
 
 	storedPG, ok := m.PortGroups[pg]
 	require.True(t, ok)
-	// 4 infra + 2 ingress + 1 egress = 7 ACLs.
-	assert.Len(t, storedPG.ACLs, 7)
+	// 6 infra + 2 ingress + 1 egress = 9 ACLs.
+	assert.Len(t, storedPG.ACLs, 9)
 }
 
 func TestSGManager_UpdateSG_ReplacesACLSet(t *testing.T) {
@@ -53,7 +53,7 @@ func TestSGManager_UpdateSG_ReplacesACLSet(t *testing.T) {
 		IngressRules: []Rule{{IPProtocol: "tcp", FromPort: 22, ToPort: 22, CIDR: "10.0.0.0/8"}},
 	}))
 	firstCount := len(m.PortGroups[pg].ACLs)
-	assert.Equal(t, 5, firstCount) // 4 infra + 1 tenant
+	assert.Equal(t, 7, firstCount) // 6 infra + 1 tenant
 
 	// Replace with a different set — wider ingress, no egress.
 	require.NoError(t, sg.UpdateSG(ctx, SGSpec{
@@ -64,7 +64,7 @@ func TestSGManager_UpdateSG_ReplacesACLSet(t *testing.T) {
 			{IPProtocol: "icmp", CIDR: "0.0.0.0/0"},
 		},
 	}))
-	assert.Len(t, m.PortGroups[pg].ACLs, 7) // 4 infra + 3 tenant
+	assert.Len(t, m.PortGroups[pg].ACLs, 9) // 6 infra + 3 tenant
 }
 
 func TestSGManager_DeleteSG_ClearsACLsKeepsPortGroup(t *testing.T) {

--- a/spinifex/network/reconcile/testdata/kitchen_sink_nb.golden
+++ b/spinifex/network/reconcile/testdata/kitchen_sink_nb.golden
@@ -11,7 +11,7 @@ port {UUID:lsp:port-eni-priv Name:port-eni-priv Type: Addresses:[02:00:00:00:00:
 port {UUID:lsp:port-eni-pub Name:port-eni-pub Type: Addresses:[02:00:00:00:00:01 10.0.1.10] PortSecurity:[02:00:00:00:00:01 10.0.1.10] DHCPv4Options:PTR Enabled:<nil> Up:<nil> ExternalIDs:map[spinifex:eni_id:eni-pub spinifex:subnet_id:subnet-pub spinifex:vpc_id:vpc-a] Options:map[]}
 port {UUID:lsp:rtr-port-subnet-priv Name:rtr-port-subnet-priv Type:router Addresses:[router] PortSecurity:[] DHCPv4Options:<nil> Enabled:<nil> Up:<nil> ExternalIDs:map[spinifex:subnet_id:subnet-priv spinifex:vpc_id:vpc-a] Options:map[router-port:rtr-subnet-priv]}
 port {UUID:lsp:rtr-port-subnet-pub Name:rtr-port-subnet-pub Type:router Addresses:[router] PortSecurity:[] DHCPv4Options:<nil> Enabled:<nil> Up:<nil> ExternalIDs:map[spinifex:subnet_id:subnet-pub spinifex:vpc_id:vpc-a] Options:map[router-port:rtr-subnet-pub]}
-portgroup {UUID:pg:sg_a Name:sg_a Ports:[lsp:port-eni-priv lsp:port-eni-pub] ACLs:[X X X X X X X] ExternalIDs:map[]}
+portgroup {UUID:pg:sg_a Name:sg_a Ports:[lsp:port-eni-priv lsp:port-eni-pub] ACLs:[X X X X X X X X X] ExternalIDs:map[]}
 router {UUID:lr:vpc-vpc-a Name:vpc-vpc-a Ports:[X X X] StaticRoutes:[X] NAT:[X X] Policies:[X X X X X] Enabled:<nil> ExternalIDs:map[spinifex:cidr:10.0.0.0/16 spinifex:vpc_id:vpc-a] Options:map[]}
 switch {UUID:ls:ext-shared Name:ext-shared Ports:[lsp:ext-port-shared lsp:gw-port-vpc-a] ACLs:[] DNSRecords:[] ExternalIDs:map[spinifex:role:external] OtherConfig:map[]}
 switch {UUID:ls:subnet-subnet-priv Name:subnet-subnet-priv Ports:[lsp:port-eni-priv lsp:rtr-port-subnet-priv] ACLs:[] DNSRecords:[] ExternalIDs:map[spinifex:subnet_id:subnet-priv spinifex:vpc_id:vpc-a] OtherConfig:map[]}

--- a/tests/e2e/single/datapath_test.go
+++ b/tests/e2e/single/datapath_test.go
@@ -4,14 +4,17 @@ package single
 
 import (
 	"encoding/base64"
+	"encoding/csv"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/network/policy"
 	"github.com/mulgadc/spinifex/tests/e2e/harness"
 	"github.com/stretchr/testify/require"
 )
@@ -86,6 +89,10 @@ func sgDatapathRevokeRounds() int {
 //     actually worked, "traffic is now blocked after revoke" would trivially
 //     and misleadingly pass for the wrong reason. So AllowedTraffic gates the
 //     revoke rounds.
+//   - DeniedTrafficNonIPv4 is read-only with respect to SG and ENI state, so
+//     it can sit anywhere before SameSGComms. It would in fact still hold
+//     after it — the default SG's -1 self-ingress is ip4-scoped like every
+//     tenant allow, so joining it cannot permit a non-IPv4 ethertype.
 //   - Each revoke round's restore half only depends on the revoke API call
 //     having actually removed the rule (tracked separately from the
 //     ICMP-style "verify blocked" assertion) — a flaky drop-detection
@@ -343,40 +350,99 @@ func runSGPolicyDatapath(t *testing.T, fix *Fixture) {
 		harness.Detail(t, "step5", "denied_traffic_ok")
 	})
 
-	// --- DeniedTrafficIPv6: the default-deny is not IPv4-only ---
+	// --- DeniedTrafficNonIPv4: the default-deny is not ethertype-scoped ---
 	//
-	// Every tenant allow is ip4-scoped and IPv6 rules are rejected at the API,
-	// so nothing here can permit IPv6. The denies used to be ip4-scoped too and
-	// OVN allows on no-match, which let link-local IPv6 through untouched.
-	t.Run("DeniedTrafficIPv6", func(t *testing.T) {
-		harness.Step(t, "8e-5b denied traffic client -> target IPv6 link-local")
+	// A guest-level IPv6 probe cannot test this on its own: every guest LSP
+	// carries port_security "<MAC> <IPv4>", and ovn-nb(5) makes that IPv4-only,
+	// so IPv6 dies two tables before the ACL. The first two subtests attribute
+	// the drop to the ACL; the third is the end-to-end backstop.
+	t.Run("DeniedTrafficNonIPv4", func(t *testing.T) {
+		targetPG := strings.ReplaceAll(targetSG, "-", "_")
 
-		targetLL := linkLocalFromENIMAC(t, fix, targetENI)
+		// What OVN actually holds, not what the policy layer intended.
+		t.Run("DenyIsNotEthertypeScoped", func(t *testing.T) {
+			harness.Step(t, "8e-5b %s denies carry no ethertype qualifier", targetPG)
+			rows := portGroupACLs(t, targetPG)
 
-		// Positive control: without a working IPv6 stack on the client the
-		// assertion below would pass for the wrong reason.
-		iface, err := runSSHCombined(clientTgt, "ip -o -4 route show default | awk '{print $5; exit}'")
-		require.NoError(t, err, "client could not report its default-route interface")
-		iface = strings.TrimSpace(iface)
-		require.NotEmpty(t, iface, "client has no default-route interface")
+			denies := map[string]aclRow{}
+			arps := map[string]aclRow{}
+			for _, r := range rows {
+				switch {
+				case r.Action == "drop":
+					denies[r.Direction] = r
+				case strings.Contains(r.Match, "arp"):
+					arps[r.Direction] = r
+				}
+			}
+			require.Lenf(t, denies, 2,
+				"expected one default-deny per direction on %s, got %d (acls=%v)", targetPG, len(denies), rows)
+			for dir, r := range denies {
+				require.NotContainsf(t, r.Match, "ip4", "%s deny on %s is IPv4-scoped: %q", dir, targetPG, r.Match)
+				require.NotContainsf(t, r.Match, "ip6", "%s deny on %s is IPv6-scoped: %q", dir, targetPG, r.Match)
+			}
 
-		clientLL, err := runSSHCombined(clientTgt,
-			fmt.Sprintf("ip -6 -o addr show dev %s scope link | awk '{print $4; exit}' | cut -d/ -f1", iface))
-		require.NoError(t, err, "client could not report its own link-local address")
-		clientLL = strings.TrimSpace(clientLL)
-		require.NotEmptyf(t, clientLL,
-			"client has no IPv6 link-local on %s, so a failed ping to the target would prove nothing about the ACL", iface)
+			// An unqualified deny black-holes ARP without this, since the ACL
+			// tables run before the L2 lookup.
+			require.Lenf(t, arps, 2, "expected an ARP allow per direction on %s (acls=%v)", targetPG, rows)
+			for dir, r := range arps {
+				require.Equalf(t, "allow", r.Action, "%s ARP rule on %s must allow, got %q", dir, targetPG, r.Action)
+				require.Greaterf(t, r.Priority, denies[dir].Priority,
+					"%s ARP allow (priority %d) must outrank the deny (priority %d)", dir, r.Priority, denies[dir].Priority)
+			}
+			harness.Detail(t, "step5b", "deny_unscoped_ok")
+		})
 
-		if _, err := runSSHCombined(clientTgt,
-			fmt.Sprintf("ping -6 -c 2 -W 3 %s%%%s", clientLL, iface)); err != nil {
-			t.Fatalf("client cannot ping its own link-local %s%%%s (%v) — IPv6 is unusable in the guest, so this stage cannot test the deny", clientLL, iface, err)
-		}
+		// RARP is the ethertype that proves the point: ovn-nb(5) says port
+		// security does not restrict it, so it is the one thing that crosses
+		// port security and reaches the ACL.
+		t.Run("NonIPEthertypeDropsAtTheACL", func(t *testing.T) {
+			harness.Step(t, "8e-5c ovn-trace RARP client -> target must hit the egress deny")
+			ls := "subnet-" + def.SubnetID
+			clientMAC := eniMAC(t, fix, clientENI)
+			targetMAC := eniMAC(t, fix, targetENI)
 
-		if _, err := runSSHCombined(clientTgt,
-			fmt.Sprintf("ping -6 -c 3 -W 3 %s%%%s", targetLL, iface)); err == nil {
-			t.Fatalf("FAIL: client reached target over IPv6 at %s — default-deny is IPv4-only", targetLL)
-		}
-		harness.Detail(t, "step5b", "denied_ipv6_ok", "target_link_local", targetLL)
+			flow := fmt.Sprintf(`inport == "port-%s" && eth.src == %s && eth.dst == %s && eth.type == 0x8035`,
+				clientENI, clientMAC, targetMAC)
+			trace := harness.OvnTrace(t, ls, flow)
+			require.Containsf(t, trace, "drop;",
+				"RARP client -> target was not dropped; the default-deny is still ethertype-scoped\n%s", trace)
+			require.Containsf(t, trace, fmt.Sprintf("priority %d", policy.ACLPriorityDefaultDenyEgress),
+				"RARP was dropped, but not by the egress default-deny — the attribution this stage exists for is missing\n%s", trace)
+
+			// Control: the same trace for ARP must NOT reach the deny, or the
+			// widened deny has taken the IPv4 datapath down with it.
+			arpFlow := fmt.Sprintf(`inport == "port-%s" && eth.src == %s && eth.dst == %s && eth.type == 0x0806`,
+				clientENI, clientMAC, targetMAC)
+			arpTrace := harness.OvnTrace(t, ls, arpFlow)
+			require.NotContainsf(t, arpTrace, fmt.Sprintf("priority %d", policy.ACLPriorityDefaultDenyEgress),
+				"ARP from the client hit the egress default-deny — the ARP allow is missing or mis-prioritised\n%s", arpTrace)
+			harness.Detail(t, "step5c", "non_ip_dropped_ok")
+		})
+
+		// Port security drops this before the ACL sees it, so it cannot
+		// attribute the drop. It is here because "no layer lets IPv6 between
+		// two instances" is worth a regression test in its own right.
+		t.Run("IPv6BlockedEndToEnd", func(t *testing.T) {
+			harness.Step(t, "8e-5d IPv6 client -> target blocked end to end")
+			iface, clientLL := guestLinkLocal(t, clientTgt)
+
+			// Validates the EUI-64 formula and the ENI-MAC -> guest-NIC
+			// mapping. Without it a wrong derivation below would make the
+			// probe fail for the wrong reason and pass forever.
+			require.Equalf(t, linkLocalFromMAC(eniMAC(t, fix, clientENI)), clientLL,
+				"EUI-64 derivation does not match the client's actual link-local on %s, so the derived target address cannot be trusted", iface)
+
+			targetLL := linkLocalFromMAC(eniMAC(t, fix, targetENI))
+			out, err := runSSHCombined(clientTgt, fmt.Sprintf("ping -6 -c 3 -W 3 %s%%%s", targetLL, iface))
+			require.Errorf(t, err, "FAIL: client reached target over IPv6 at %s\n%s", targetLL, out)
+
+			// A non-zero exit alone also covers a broken ssh session, a missing
+			// ping binary and a bad address literal. Only a loss summary proves
+			// the probe ran and the traffic was dropped.
+			require.Truef(t, pingDroppedRE.MatchString(out),
+				"ping -6 to %s produced no packet-loss summary — the probe never ran (out=%q)", targetLL, out)
+			harness.Detail(t, "step5d", "ipv6_blocked_ok", "target_link_local", targetLL)
+		})
 	})
 
 	// --- Revoke / re-authorize round-trip ---
@@ -550,24 +616,80 @@ func runSGEInstance(t *testing.T, fix *Fixture, subnetID, sgID, userData string)
 	return id
 }
 
-// linkLocalFromENIMAC derives an ENI's IPv6 link-local address from its MAC by
-// EUI-64. The target SG has no SSH ingress, so the address cannot be read off
-// the guest; deriving it needs no channel into the instance at all.
-func linkLocalFromENIMAC(t *testing.T, fix *Fixture, eniID string) string {
+// aclRow is one NB ACL as OVN holds it, read back rather than rebuilt.
+type aclRow struct {
+	Priority  int
+	Direction string
+	Match     string
+	Action    string
+}
+
+// portGroupACLs returns the ACL set OVN actually holds for a port group. The
+// policy layer's intent is unit-tested; this is what landed in NB.
+func portGroupACLs(t *testing.T, pg string) []aclRow {
 	t.Helper()
-	out, err := fix.AWS.EC2.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
-		NetworkInterfaceIds: aws.StringSlice([]string{eniID}),
-	})
-	require.NoError(t, err, "describe-network-interfaces %s", eniID)
-	require.Len(t, out.NetworkInterfaces, 1, "describe-network-interfaces %s returned %d interfaces", eniID, len(out.NetworkInterfaces))
+	acls := harness.OvnNbctl(t, "--no-leader-only", "--bare", "--columns=acls",
+		"find", "port_group", "name="+pg)
+	uuids := strings.Fields(acls)
+	require.NotEmptyf(t, uuids, "port_group %s carries no ACLs", pg)
 
-	mac, err := net.ParseMAC(aws.StringValue(out.NetworkInterfaces[0].MacAddress))
-	require.NoErrorf(t, err, "ENI %s has an unparseable MacAddress %q", eniID, aws.StringValue(out.NetworkInterfaces[0].MacAddress))
+	args := append([]string{"--no-leader-only", "--format=csv", "--no-headings",
+		"--columns=priority,direction,match,action", "list", "acl"}, uuids...)
+	out := harness.OvnNbctl(t, args...)
+
+	recs, err := csv.NewReader(strings.NewReader(out)).ReadAll()
+	require.NoErrorf(t, err, "parsing ovn-nbctl csv for %s: %q", pg, out)
+
+	rows := make([]aclRow, 0, len(recs))
+	for _, r := range recs {
+		require.Lenf(t, r, 4, "unexpected ovn-nbctl acl record %q", r)
+		prio, err := strconv.Atoi(strings.TrimSpace(r[0]))
+		require.NoErrorf(t, err, "unparseable ACL priority %q", r[0])
+		rows = append(rows, aclRow{
+			Priority:  prio,
+			Direction: strings.TrimSpace(r[1]),
+			Match:     strings.TrimSpace(r[2]),
+			Action:    strings.TrimSpace(r[3]),
+		})
+	}
+	return rows
+}
+
+// eniMAC returns an ENI's MAC. The target SG has no SSH ingress, so this is
+// the only channel to its addressing.
+func eniMAC(t *testing.T, fix *Fixture, eniID string) net.HardwareAddr {
+	t.Helper()
+	eni, err := describeENI(fix.AWS, eniID)
+	require.NoError(t, err, "describe ENI %s", eniID)
+	raw := aws.StringValue(eni.MacAddress)
+	mac, err := net.ParseMAC(raw)
+	require.NoErrorf(t, err, "ENI %s has an unparseable MacAddress %q", eniID, raw)
 	require.Lenf(t, mac, 6, "ENI %s MacAddress is not EUI-48: %s", eniID, mac)
+	return mac
+}
 
-	// EUI-64: invert the universal/local bit, then insert ff:fe mid-MAC.
+// linkLocalFromMAC derives the IPv6 link-local a guest generates from an
+// EUI-48 MAC: invert the universal/local bit, then insert ff:fe mid-MAC.
+func linkLocalFromMAC(mac net.HardwareAddr) string {
 	return fmt.Sprintf("fe80::%02x%02x:%02xff:fe%02x:%02x%02x",
 		mac[0]^0x02, mac[1], mac[2], mac[3], mac[4], mac[5])
+}
+
+// guestLinkLocal returns a guest's default-route interface and the IPv6
+// link-local address configured on it.
+func guestLinkLocal(t *testing.T, tgt harness.SSHTarget) (string, string) {
+	t.Helper()
+	iface, err := runSSHCombined(tgt, "ip -o -4 route show default | awk '{print $5; exit}'")
+	require.NoError(t, err, "guest could not report its default-route interface")
+	iface = strings.TrimSpace(iface)
+	require.NotEmpty(t, iface, "guest has no default-route interface")
+
+	ll, err := runSSHCombined(tgt,
+		fmt.Sprintf("ip -6 -o addr show dev %s scope link | awk '{print $4; exit}' | cut -d/ -f1", iface))
+	require.NoError(t, err, "guest could not report its link-local address")
+	ll = strings.TrimSpace(ll)
+	require.NotEmptyf(t, ll, "guest has no IPv6 link-local on %s", iface)
+	return iface, ll
 }
 
 // primaryENI returns the NetworkInterfaceId of an instance's first ENI.

--- a/tests/e2e/single/datapath_test.go
+++ b/tests/e2e/single/datapath_test.go
@@ -5,6 +5,7 @@ package single
 import (
 	"encoding/base64"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -342,6 +343,42 @@ func runSGPolicyDatapath(t *testing.T, fix *Fixture) {
 		harness.Detail(t, "step5", "denied_traffic_ok")
 	})
 
+	// --- DeniedTrafficIPv6: the default-deny is not IPv4-only ---
+	//
+	// Every tenant allow is ip4-scoped and IPv6 rules are rejected at the API,
+	// so nothing here can permit IPv6. The denies used to be ip4-scoped too and
+	// OVN allows on no-match, which let link-local IPv6 through untouched.
+	t.Run("DeniedTrafficIPv6", func(t *testing.T) {
+		harness.Step(t, "8e-5b denied traffic client -> target IPv6 link-local")
+
+		targetLL := linkLocalFromENIMAC(t, fix, targetENI)
+
+		// Positive control: without a working IPv6 stack on the client the
+		// assertion below would pass for the wrong reason.
+		iface, err := runSSHCombined(clientTgt, "ip -o -4 route show default | awk '{print $5; exit}'")
+		require.NoError(t, err, "client could not report its default-route interface")
+		iface = strings.TrimSpace(iface)
+		require.NotEmpty(t, iface, "client has no default-route interface")
+
+		clientLL, err := runSSHCombined(clientTgt,
+			fmt.Sprintf("ip -6 -o addr show dev %s scope link | awk '{print $4; exit}' | cut -d/ -f1", iface))
+		require.NoError(t, err, "client could not report its own link-local address")
+		clientLL = strings.TrimSpace(clientLL)
+		require.NotEmptyf(t, clientLL,
+			"client has no IPv6 link-local on %s, so a failed ping to the target would prove nothing about the ACL", iface)
+
+		if _, err := runSSHCombined(clientTgt,
+			fmt.Sprintf("ping -6 -c 2 -W 3 %s%%%s", clientLL, iface)); err != nil {
+			t.Fatalf("client cannot ping its own link-local %s%%%s (%v) — IPv6 is unusable in the guest, so this stage cannot test the deny", clientLL, iface, err)
+		}
+
+		if _, err := runSSHCombined(clientTgt,
+			fmt.Sprintf("ping -6 -c 3 -W 3 %s%%%s", targetLL, iface)); err == nil {
+			t.Fatalf("FAIL: client reached target over IPv6 at %s — default-deny is IPv4-only", targetLL)
+		}
+		harness.Detail(t, "step5b", "denied_ipv6_ok", "target_link_local", targetLL)
+	})
+
 	// --- Revoke / re-authorize round-trip ---
 	//
 	// Only meaningful against a proven-working baseline: if AllowedTraffic
@@ -511,6 +548,26 @@ func runSGEInstance(t *testing.T, fix *Fixture, subnetID, sgID, userData string)
 	id := aws.StringValue(out.Instances[0].InstanceId)
 	require.NotEmpty(t, id, "run-instances sg=%s returned empty InstanceId", sgID)
 	return id
+}
+
+// linkLocalFromENIMAC derives an ENI's IPv6 link-local address from its MAC by
+// EUI-64. The target SG has no SSH ingress, so the address cannot be read off
+// the guest; deriving it needs no channel into the instance at all.
+func linkLocalFromENIMAC(t *testing.T, fix *Fixture, eniID string) string {
+	t.Helper()
+	out, err := fix.AWS.EC2.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: aws.StringSlice([]string{eniID}),
+	})
+	require.NoError(t, err, "describe-network-interfaces %s", eniID)
+	require.Len(t, out.NetworkInterfaces, 1, "describe-network-interfaces %s returned %d interfaces", eniID, len(out.NetworkInterfaces))
+
+	mac, err := net.ParseMAC(aws.StringValue(out.NetworkInterfaces[0].MacAddress))
+	require.NoErrorf(t, err, "ENI %s has an unparseable MacAddress %q", eniID, aws.StringValue(out.NetworkInterfaces[0].MacAddress))
+	require.Lenf(t, mac, 6, "ENI %s MacAddress is not EUI-48: %s", eniID, mac)
+
+	// EUI-64: invert the universal/local bit, then insert ff:fe mid-MAC.
+	return fmt.Sprintf("fe80::%02x%02x:%02xff:fe%02x:%02x%02x",
+		mac[0]^0x02, mac[1], mac[2], mac[3], mac[4], mac[5])
 }
 
 // primaryENI returns the NetworkInterfaceId of an instance's first ENI.

--- a/tests/e2e/single/datapath_test.go
+++ b/tests/e2e/single/datapath_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/mulgadc/spinifex/spinifex/network/policy"
 	"github.com/mulgadc/spinifex/tests/e2e/harness"
 	"github.com/stretchr/testify/require"
 )
@@ -401,21 +400,27 @@ func runSGPolicyDatapath(t *testing.T, fix *Fixture) {
 			clientMAC := eniMAC(t, fix, clientENI)
 			targetMAC := eniMAC(t, fix, targetENI)
 
+			// The deny is a from-lport ACL, so it is the CLIENT's port group that
+			// names it. Assert on the log record rather than the trace's own
+			// syntax: a logged ACL emits no `drop;` token (northd splits it into
+			// acl_eval + acl_action) and northd offsets NB priorities by +1000.
+			denyEgress := strings.ReplaceAll(clientSG, "-", "_") + "-deny-egress"
+
 			flow := fmt.Sprintf(`inport == "port-%s" && eth.src == %s && eth.dst == %s && eth.type == 0x8035`,
 				clientENI, clientMAC, targetMAC)
 			trace := harness.OvnTrace(t, ls, flow)
-			require.Containsf(t, trace, "drop;",
+			require.Containsf(t, trace, "verdict=drop",
 				"RARP client -> target was not dropped; the default-deny is still ethertype-scoped\n%s", trace)
-			require.Containsf(t, trace, fmt.Sprintf("priority %d", policy.ACLPriorityDefaultDenyEgress),
-				"RARP was dropped, but not by the egress default-deny — the attribution this stage exists for is missing\n%s", trace)
+			require.Containsf(t, trace, denyEgress,
+				"RARP was dropped, but not by %s — the attribution this stage exists for is missing\n%s", denyEgress, trace)
 
-			// Control: the same trace for ARP must NOT reach the deny, or the
+			// Control: the same trace for ARP must NOT be dropped, or the
 			// widened deny has taken the IPv4 datapath down with it.
 			arpFlow := fmt.Sprintf(`inport == "port-%s" && eth.src == %s && eth.dst == %s && eth.type == 0x0806`,
 				clientENI, clientMAC, targetMAC)
 			arpTrace := harness.OvnTrace(t, ls, arpFlow)
-			require.NotContainsf(t, arpTrace, fmt.Sprintf("priority %d", policy.ACLPriorityDefaultDenyEgress),
-				"ARP from the client hit the egress default-deny — the ARP allow is missing or mis-prioritised\n%s", arpTrace)
+			require.NotContainsf(t, arpTrace, "verdict=drop",
+				"ARP from the client was dropped — the ARP allow is missing or mis-prioritised\n%s", arpTrace)
 			harness.Detail(t, "step5c", "non_ip_dropped_ok")
 		})
 
@@ -426,13 +431,16 @@ func runSGPolicyDatapath(t *testing.T, fix *Fixture) {
 			harness.Step(t, "8e-5d IPv6 client -> target blocked end to end")
 			iface, clientLL := guestLinkLocal(t, clientTgt)
 
-			// Validates the EUI-64 formula and the ENI-MAC -> guest-NIC
-			// mapping. Without it a wrong derivation below would make the
-			// probe fail for the wrong reason and pass forever.
-			require.Equalf(t, linkLocalFromMAC(eniMAC(t, fix, clientENI)), clientLL,
-				"EUI-64 derivation does not match the client's actual link-local on %s, so the derived target address cannot be trusted", iface)
+			// Validates the EUI-64 formula and the ENI-MAC -> guest-NIC mapping.
+			// Without it a wrong derivation below would make the probe fail for
+			// the wrong reason and pass forever. Compared as addresses, not
+			// strings: fe80::0046:... and fe80::46:... are the same address.
+			derived := linkLocalFromMAC(eniMAC(t, fix, clientENI))
+			require.Truef(t, derived.Equal(net.ParseIP(clientLL)),
+				"EUI-64 derivation %s does not match the client's actual link-local %q on %s, so the derived target address cannot be trusted",
+				derived, clientLL, iface)
 
-			targetLL := linkLocalFromMAC(eniMAC(t, fix, targetENI))
+			targetLL := linkLocalFromMAC(eniMAC(t, fix, targetENI)).String()
 			out, err := runSSHCombined(clientTgt, fmt.Sprintf("ping -6 -c 3 -W 3 %s%%%s", targetLL, iface))
 			require.Errorf(t, err, "FAIL: client reached target over IPv6 at %s\n%s", targetLL, out)
 
@@ -670,9 +678,12 @@ func eniMAC(t *testing.T, fix *Fixture, eniID string) net.HardwareAddr {
 
 // linkLocalFromMAC derives the IPv6 link-local a guest generates from an
 // EUI-48 MAC: invert the universal/local bit, then insert ff:fe mid-MAC.
-func linkLocalFromMAC(mac net.HardwareAddr) string {
-	return fmt.Sprintf("fe80::%02x%02x:%02xff:fe%02x:%02x%02x",
-		mac[0]^0x02, mac[1], mac[2], mac[3], mac[4], mac[5])
+// Returns net.IP so callers compare numerically — the textual forms differ.
+func linkLocalFromMAC(mac net.HardwareAddr) net.IP {
+	return net.IP{
+		0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+		mac[0] ^ 0x02, mac[1], mac[2], 0xff, 0xfe, mac[3], mac[4], mac[5],
+	}
 }
 
 // guestLinkLocal returns a guest's default-route interface and the IPv6


### PR DESCRIPTION
## Summary

The 900/800 infrastructure default-deny ACLs every security-group port group carries were qualified with `ip4`. OVN allows on no-match, so any frame that is not IPv4 matched no ACL and was delivered. The tenant allows are correctly `ip4`-scoped; the denies being scoped the same way is the wrong way round.

## What this actually exposes

The bead frames the gap as IPv6 between instances. **That specific case is not reachable**, and the correction matters because it changes what the fix is for.

Every guest LSP is created with `port_security` set to `"<MAC> <IPv4>"` — `network/topology/manager_live.go:314-318` on the live path, `network/reconcile/apply.go:294-298` on the reconciler path, made binding by `TestI1_GuestLSPMustHavePortSecurity`. From `ovn-nb(5)`: *"If an element includes an IPv4 address, but no IPv6 addresses, then IPv6 traffic is not allowed."* Port security is `ls_in_apply_port_sec`, two tables ahead of the ACL stage, so IPv6 between guest ports is already dropped before the deny is consulted.

What the `ip4` scoping does expose is narrower but real:

- **Non-IP ethertypes.** Port security constrains source MAC and L3 addresses, not ethertype — a guest may send arbitrary ethertypes from its own MAC. `ovn-nb(5)` calls one out explicitly: *"(RARP is not restricted.)"* LLDP, RARP and raw ethernet between co-tenants passed port security, matched no ACL, and were delivered.
- **Any port without port security.** `port_security` is written on the LSP *create* branch only and is never converged onto an existing LSP (`manager_live.go:307-313` returns early; `apply.go:315-330` diffs port-group membership alone). A drifted or legacy LSP has the ACL as its only backstop, and that backstop currently cannot fire on anything but IPv4.

One genuine gap, plus a second layer of defence for a layer that is not self-healing.

## The part that is not just deleting `&& ip4`

ACL flows are installed verbatim into `ls_in_acl` (from-lport) and `ls_out_acl` (to-lport). Both run *before* `ls_in_arp_rsp` and the L2 lookup, and every frame traverses them. ovn-northd's built-in priority-34000 bypasses cover the service monitor, its own DHCP replies and DNS replies — there is no built-in ARP exemption. This is the known `default_acl_drop` ARP-breakage; the maintainers' position is that a CMS wanting to exempt traffic must add its own high-priority allow.

So the widened deny is paired with an ARP allow at a new priority 950, between the tenant band (1000) and the denies (900/800). Action `allow`, not `allow-related` — ARP is not an IP protocol and has no conntrack state.

No ND, RA or DHCPv6 exemption: nothing in the stack assigns a guest a routable IPv6 address, `validateSGRule` rejects IPv6 CIDRs, `numericIPProtocols` omits 58/ICMPv6, and the derived address sets are `<pg>_ip4`. Leaving IPv6 under the deny costs no working traffic. DHCPv4 is unaffected — IPv4/UDP, already allowed at 1050.

**RARP is now dropped.** No live migration exists today (`spinifex/vm/migrate.go` is KV-bucket migration), but `scripts/build-microvm-image.sh:211` bakes `net_failover.ko` into the guest image against that plan, and QEMU emits a RARP announcement post-migration to flush peer MAC tables. Flagging so it is not rediscovered.

## Upgrade behaviour

`applyACLs` uses `ReplaceACLs`, and `aclSetUnchanged` short-circuits on `len(pg.ACLs) != len(specs)` — so every existing port group misses and takes the full rewrite path on the first drift pass after deploy, one transaction per SG. It converges to a clean no-op on the second pass. Worth not overlapping the first post-deploy drift pass with other bulk work on a large fleet.

## Changes

- `spinifex/network/policy/acl.go` — `ACLPriorityAllowARP = 950`, both deny matches unqualified, new `arpEgressACL`/`arpIngressACL`. `InfrastructureACLs` goes 4 → 6 specs.
- `spinifex/network/policy/acl_test.go`, `sg_test.go` — denies carry no ethertype qualifier, ARP allows sit above the denies and below the tenant band, no allow exempts ND or ICMPv6. Counts updated.
- `spinifex/network/reconcile/testdata/kitchen_sink_nb.golden` — regenerated. Sole diff is the port group's ACL count, 7 → 9.
- `tests/e2e/single/datapath_test.go` — new `DeniedTrafficNonIPv4` stage.

## Testing

`make preflight` passes.

A guest-level IPv6 ping cannot test this — port security drops IPv6 before the ACL, so it is green on both sides of the fix. The stage is therefore three parts:

1. **`DenyIsNotEthertypeScoped`** reads the target SG's ACL set back out of NB and asserts both denies carry no `ip4`/`ip6` qualifier and that an ARP allow outranks the deny in each direction. This is the part that fails if the fix is reverted, and it covers the whole path from the EC2 API through the policy layer into NB.
2. **`NonIPEthertypeDropsAtTheACL`** runs `ovn-trace` with a RARP microflow from the client LSP — the ethertype port security does not restrict, so the one that reaches the ACL — and attributes the drop to the priority-800 egress deny specifically. The paired ARP trace asserts the opposite, which is the regression check for the ARP allow.
3. **`IPv6BlockedEndToEnd`** keeps a guest `ping -6` as the end-to-end backstop, documented as proof that no layer permits IPv6 rather than attribution to the ACL. The client's link-local is read off the guest and asserted equal to the value derived from its ENI MAC, validating the EUI-64 derivation before the same formula is trusted for the target; and the assertion requires a packet-loss summary rather than a non-zero exit, since exit status alone also covers a broken SSH session or a missing `ping`.

ARP regression coverage comes from `AllowedTraffic` — its curl to `targetPriv:8080` cannot complete without ARP resolving. `SameSGComms` runs later against a cached neighbour entry, so it is not an independent check.