### PR TITLE
fix: run ping under CAP_NET_RAW instead of escalating it through sudo

### DIFF
--- a/spinifex/utils/sudo.go
+++ b/spinifex/utils/sudo.go
@@ -51,7 +51,7 @@ func capForTool(name string, args []string) (uint, bool) {
 	switch name {
 	case "ip", "iptables", "ip6tables":
 		return capNetAdmin, true
-	case "arping":
+	case "arping", "ping":
 		return capNetRaw, true
 	case EndpointSysctlHelper:
 		// The helper only ever writes net.ipv4.conf.<iface>.<key>, so a holder of

--- a/spinifex/utils/sudo_test.go
+++ b/spinifex/utils/sudo_test.go
@@ -65,7 +65,7 @@ func TestPrivilegedToolsStillEscalate(t *testing.T) {
 		t.Skip("running as root: nothing is escalated, so the policy is not exercised")
 	}
 	withAmbientCaps(t, 0)
-	for _, tool := range []string{"ip", "iptables", "dhcpcd", "sysctl", "arping", "ovs-ofctl"} {
+	for _, tool := range []string{"ip", "iptables", "dhcpcd", "sysctl", "arping", "ping", "ovs-ofctl"} {
 		if !NeedsPrivilege(tool, "net.ipv4.neigh.x=1") {
 			t.Errorf("%s is not escalated, but it needs root or an ambient capability", tool)
 		}
@@ -88,6 +88,9 @@ func TestAmbientCapabilitiesReplaceSudo(t *testing.T) {
 		{"ip", "addr", "replace", "10.0.0.1/24", "dev", "eth0"},
 		{"iptables", "-A", "FORWARD", "-j", "ACCEPT"},
 		{"arping", "-U", "-c", "2", "-I", "br-wan", "10.0.0.1"},
+		// The nexthop-MAC seed primes the neigh table with this. vpcd holds no
+		// sudoers rule for ping, so escalating it kills the fallback outright.
+		{"ping", "-c", "1", "-W", "1", "100.127.0.1"},
 		{"sysctl", "-w", "net.ipv4.neigh.br-wan.proxy_delay=0"},
 		{EndpointSysctlHelper, "ime-12345678", "rp_filter", "0"},
 	}


### PR DESCRIPTION
## Problem

vpcd's nexthop-MAC seed primes the kernel neigh table with one `ping` when `ip neigh` has no entry for the upstream gateway, then re-reads. `capForTool` mapped `arping` to `CAP_NET_RAW` but had no `ping` case, so `NeedsPrivilege` escalated it.

vpcd holds no sudoers rules at all — `build/systemd/spinifex-vpcd.service` grants `CAP_NET_ADMIN` and `CAP_NET_RAW` ambiently instead, and `TestRG10_VPCDHoldsNoSudoersGrant` pins that. So the escalation could never succeed: every call was denied, the re-read found nothing, and the seed gave up.

From e2e nightly run 32060970254, cell-19 — the only two sudo denials in the entire 356 KB journal:

```
sudo[5430]: spinifex-vpcd : user NOT in sudoers ; PWD=/ ; USER=root ; COMMAND=/usr/bin/ping -c 1 -W 1 100.127.0.1
```

The fallback was dead in every external mode. Bridge mode only worked because the host usually has the upstream gateway cached already.

## Change

Map `ping` to `CAP_NET_RAW` alongside `arping` in `capForTool`, so vpcd runs it directly under the capability it already holds.

## Testing

`ping` added to both halves of the existing policy pair in `sudo_test.go`: unescalated under ambient `CAP_NET_RAW`, still escalated when no capability is held. `make preflight` passes.

## Note

Necessary but not sufficient for the routed-NAT egress failure: pinging the host's own address populates no neigh entry regardless. Tracked separately.

Closes mulga-46z99