### PR TITLE
refactor: drive the ECS scheduler from the bus and deadlines, not four tickers

### DIFF
--- a/spinifex/handlers/ecs/bus/subjects.go
+++ b/spinifex/handlers/ecs/bus/subjects.go
@@ -37,7 +37,9 @@ func TaskStateSubject(accountID, clusterName, taskID string) string {
 	return fmt.Sprintf("%s.task-state.%s", Prefix(accountID, clusterName), taskID)
 }
 
-// ServiceReconcileSubject is the scheduler-internal reconcile tick.
+// ServiceReconcileSubject wakes the scheduler's service reconcile. It carries no
+// payload — it says only that something the reconcile reads has changed — and it
+// crosses nodes, because the API worker that saw the change is rarely the leader.
 func ServiceReconcileSubject(accountID, clusterName string) string {
 	return fmt.Sprintf("%s.service-reconcile", Prefix(accountID, clusterName))
 }

--- a/spinifex/handlers/ecs/enumeration_failure_test.go
+++ b/spinifex/handlers/ecs/enumeration_failure_test.go
@@ -3,11 +3,21 @@ package handlers_ecs
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/require"
 )
+
+// dropRevisit adapts a pass that also reports its next deadline, so this test
+// stays about the error alone.
+func dropRevisit(pass func(context.Context) (time.Duration, error)) func(context.Context) error {
+	return func(ctx context.Context) error {
+		_, err := pass(ctx)
+		return err
+	}
+}
 
 // TestSchedulerPasses_EnumerationFailureIsReported pins the contract every
 // leader-only sweep depends on: the KV bucket lister closes its channel the same
@@ -22,8 +32,8 @@ func TestSchedulerPasses_EnumerationFailureIsReported(t *testing.T) {
 	require.NoError(t, err)
 
 	passes := map[string]func(context.Context) error{
-		"reap":                 sc.reap,
-		"sweepStoppedTasks":    sc.sweepStoppedTasks,
+		"reap":                 dropRevisit(sc.reap),
+		"sweepStoppedTasks":    dropRevisit(sc.sweepStoppedTasks),
 		"reconcileAllServices": svc.reconcileAllServices,
 	}
 	for name, pass := range passes {

--- a/spinifex/handlers/ecs/enumeration_failure_test.go
+++ b/spinifex/handlers/ecs/enumeration_failure_test.go
@@ -34,7 +34,7 @@ func TestSchedulerPasses_EnumerationFailureIsReported(t *testing.T) {
 	passes := map[string]func(context.Context) error{
 		"reap":                 dropRevisit(sc.reap),
 		"sweepStoppedTasks":    dropRevisit(sc.sweepStoppedTasks),
-		"reconcileAllServices": svc.reconcileAllServices,
+		"reconcileAllServices": dropRevisit(svc.reconcileAllServices),
 	}
 	for name, pass := range passes {
 		t.Run(name+"/reachable", func(t *testing.T) {

--- a/spinifex/handlers/ecs/instances.go
+++ b/spinifex/handlers/ecs/instances.go
@@ -327,6 +327,12 @@ func (s *Service) SubmitTaskStateChange(ctx context.Context, input *ecs.SubmitTa
 	if err := s.recordTaskState(ctx, &msg); err != nil {
 		return nil, err
 	}
+	// A task changing state is what moves a service's running count, so the
+	// scheduler is woken here rather than left to find out on its own deadline.
+	// The worker serving this call is rarely the leader, hence a published wake.
+	if err := s.nc.Publish(bus.ServiceReconcileSubject(accountID, msg.ClusterName), nil); err != nil {
+		slog.Debug("ECS: reconcile wake failed", "cluster", msg.ClusterName, "err", err)
+	}
 	return &ecs.SubmitTaskStateChangeOutput{Acknowledgment: aws.String("OK")}, nil
 }
 

--- a/spinifex/handlers/ecs/revisit_test.go
+++ b/spinifex/handlers/ecs/revisit_test.go
@@ -108,13 +108,15 @@ func TestScheduler_AnIdleServiceIsNotRewritten(t *testing.T) {
 
 	// The first pass is allowed to settle the record; every pass after it has
 	// nothing to say, and an unconditional write would churn KV forever.
-	require.NoError(t, svc.reconcileAllServices(t.Context()))
+	_, err = svc.reconcileAllServices(t.Context())
+	require.NoError(t, err)
 	entry, err := kv.Get(t.Context(), ServiceKey("web", "web"))
 	require.NoError(t, err)
 	settled := entry.Revision()
 
 	for range 3 {
-		require.NoError(t, svc.reconcileAllServices(t.Context()))
+		_, rerr := svc.reconcileAllServices(t.Context())
+		require.NoError(t, rerr)
 	}
 	entry, err = kv.Get(t.Context(), ServiceKey("web", "web"))
 	require.NoError(t, err)
@@ -213,4 +215,52 @@ func TestScheduler_TheTimerPassReturnsTheSoonestOfItsJobs(t *testing.T) {
 	assert.Equal(t, reapDue, reconciler.Earliest(reapDue, sweepDue),
 		"the pass returns the soonest deadline, not the last one computed")
 	assert.InDelta(t, 10.0, reapDue.Seconds(), 2)
+}
+
+func TestScheduler_AnInFlightServiceAsksToBeRevisited(t *testing.T) {
+	svc, _, kv := serviceTestRig(t)
+	_, err := svc.CreateService(context.Background(), &ecs.CreateServiceInput{
+		Cluster: aws.String("web"), ServiceName: aws.String("web"),
+		TaskDefinition: aws.String("app"), DesiredCount: aws.Int64(1),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	// The task is PENDING: it reaches RUNNING by reporting through the gateway,
+	// which is not a write this loop can watch, so the pass must come back.
+	due, err := svc.reconcileAllServices(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, reconcileInterval, due)
+
+	keys, err := keysWithPrefix(t.Context(), kv, TasksPrefix("web"))
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	var task TaskRecord
+	found, err := getJSON(t.Context(), kv, keys[0], &task)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, svc.recordTaskState(t.Context(), &bus.TaskState{
+		AccountID: testAccountID, ClusterName: "web", TaskID: task.TaskID, LastStatus: TaskStatusRunning,
+	}))
+
+	due, err = svc.reconcileAllServices(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, due, "a service at its desired count waits on a wake, not on a deadline")
+}
+
+func TestScheduler_AGatewayTaskStateReportWakesTheLeader(t *testing.T) {
+	sc, svc, kv := schedulerRig(t)
+	taskID := runOneTask(t, svc, kv)
+	require.NoError(t, sc.subscribeBus(t.Context()))
+	t.Cleanup(sc.unsubscribeBus)
+
+	// The agent reports through the gateway, so the record is written by whichever
+	// worker served the call — not by this node's scheduler.
+	_, err := svc.SubmitTaskStateChange(t.Context(), &ecs.SubmitTaskStateChangeInput{
+		Cluster: aws.String("web"), Task: aws.String(taskID), Status: aws.String(TaskStatusRunning),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.NoError(t, sc.nc.Flush())
+
+	assert.Eventually(t, func() bool { return woke(sc) }, 2*time.Second, 10*time.Millisecond,
+		"a task-state report over the gateway must reach the leader's reconcile")
 }

--- a/spinifex/handlers/ecs/revisit_test.go
+++ b/spinifex/handlers/ecs/revisit_test.go
@@ -1,0 +1,216 @@
+//test:in-package — the deadlines are unexported pass returns (reap, timerPass,
+//convergeIfDue) and the trigger is an unexported channel, so an external test
+//package can reach neither.
+
+package handlers_ecs
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/mulgadc/spinifex/spinifex/handlers/ecs/bus"
+	"github.com/mulgadc/spinifex/spinifex/reconciler"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// woke reports whether the scheduler asked for a service pass, and drains the
+// signal so a later check sees only what happened after this one.
+func woke(sc *Scheduler) bool {
+	select {
+	case <-sc.wake:
+		return true
+	default:
+		return false
+	}
+}
+
+func busMsg(t *testing.T, payload any) *nats.Msg {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return &nats.Msg{Data: data}
+}
+
+// schedulerRig wires a scheduler over the shared service rig, with one cluster,
+// one task definition and one registered instance.
+func schedulerRig(t *testing.T) (*Scheduler, *Service, jetstream.KeyValue) {
+	t.Helper()
+	svc, nc := newTestService(t)
+	_, err := svc.CreateCluster(context.Background(), &ecs.CreateClusterInput{ClusterName: aws.String("web")}, testAccountID)
+	require.NoError(t, err)
+	registerTaskDef(t, svc, "app", 128, 256)
+	registerInstance(t, svc, "web", "i-1", 4096, 8192)
+	kv, err := svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	return NewScheduler(nc, svc, "test-holder"), svc, kv
+}
+
+// runOneTask places a task and returns its ID, read back from the record rather
+// than sliced out of the ARN.
+func runOneTask(t *testing.T, svc *Service, kv jetstream.KeyValue) string {
+	t.Helper()
+	_, err := svc.RunTask(context.Background(), &ecs.RunTaskInput{
+		Cluster: aws.String("web"), TaskDefinition: aws.String("app"), Count: aws.Int64(1),
+	}, testAccountID)
+	require.NoError(t, err)
+	keys, err := keysWithPrefix(t.Context(), kv, TasksPrefix("web"))
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	var task TaskRecord
+	found, err := getJSON(t.Context(), kv, keys[0], &task)
+	require.NoError(t, err)
+	require.True(t, found)
+	return task.TaskID
+}
+
+func TestScheduler_ATaskStateTriggersAPassAndAHeartbeatDoesNot(t *testing.T) {
+	sc, svc, kv := schedulerRig(t)
+	taskID := runOneTask(t, svc, kv)
+
+	sc.onHeartbeat(busMsg(t, &bus.Heartbeat{
+		AccountID: testAccountID, ClusterName: "web", InstanceID: "i-1",
+	}))
+	assert.False(t, woke(sc), "a heartbeat says only that an instance is alive: the reaper reads it, the reconcile does not")
+
+	sc.onTaskState(busMsg(t, &bus.TaskState{
+		AccountID: testAccountID, ClusterName: "web", TaskID: taskID, LastStatus: TaskStatusRunning,
+	}))
+	assert.True(t, woke(sc), "a task changing state moves a service's running count, so it must wake the reconcile")
+}
+
+func TestScheduler_ABurstOfTaskStatesLeavesOneSignal(t *testing.T) {
+	sc, svc, kv := schedulerRig(t)
+	taskID := runOneTask(t, svc, kv)
+
+	for range 5 {
+		sc.onTaskState(busMsg(t, &bus.TaskState{
+			AccountID: testAccountID, ClusterName: "web", TaskID: taskID, LastStatus: TaskStatusRunning,
+		}))
+	}
+	assert.True(t, woke(sc))
+	assert.False(t, woke(sc), "the signal means 'something changed', so a burst must not queue five passes")
+}
+
+func TestScheduler_AnIdleServiceIsNotRewritten(t *testing.T) {
+	svc, _, kv := serviceTestRig(t)
+	_, err := svc.CreateService(context.Background(), &ecs.CreateServiceInput{
+		Cluster: aws.String("web"), ServiceName: aws.String("web"),
+		TaskDefinition: aws.String("app"), DesiredCount: aws.Int64(1),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	// The first pass is allowed to settle the record; every pass after it has
+	// nothing to say, and an unconditional write would churn KV forever.
+	require.NoError(t, svc.reconcileAllServices(t.Context()))
+	entry, err := kv.Get(t.Context(), ServiceKey("web", "web"))
+	require.NoError(t, err)
+	settled := entry.Revision()
+
+	for range 3 {
+		require.NoError(t, svc.reconcileAllServices(t.Context()))
+	}
+	entry, err = kv.Get(t.Context(), ServiceKey("web", "web"))
+	require.NoError(t, err)
+	assert.Equal(t, settled, entry.Revision(), "an idle service must not be rewritten by a pass that changed nothing")
+}
+
+func TestScheduler_TheReaperAsksForTheSoonestHeartbeatWindow(t *testing.T) {
+	sc, _, kv := schedulerRig(t)
+	now := time.Now().UTC()
+
+	var inst InstanceRecord
+	found, err := getJSON(t.Context(), kv, InstanceKey("web", "i-1"), &inst)
+	require.NoError(t, err)
+	require.True(t, found)
+	inst.LastSeen = now.Add(-30 * time.Second)
+	require.NoError(t, putJSON(t.Context(), kv, InstanceKey("web", "i-1"), &inst))
+
+	due, err := sc.reap(t.Context())
+	require.NoError(t, err)
+	assert.InDelta(t, (heartbeatTimeout - 30*time.Second).Seconds(), due.Seconds(), 2,
+		"a live instance falls due when its heartbeat window closes, not on the reaper's old interval")
+
+	// Past the window the reaper acts, and with nothing live left it asks for
+	// nothing: the resync is the only thing that need bring it back.
+	inst.LastSeen = now.Add(-2 * heartbeatTimeout)
+	require.NoError(t, putJSON(t.Context(), kv, InstanceKey("web", "i-1"), &inst))
+	due, err = sc.reap(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, due)
+
+	found, err = getJSON(t.Context(), kv, InstanceKey("web", "i-1"), &inst)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, InstanceStatusDraining, inst.Status, "an instance past its window is still reaped")
+}
+
+func TestScheduler_ConvergeIsDueAtItsIntervalAndNotBefore(t *testing.T) {
+	sc, _, _ := schedulerRig(t)
+
+	// Unstamped, so the first pass runs it and asks for the full interval.
+	due := sc.convergeIfDue(t.Context())
+	assert.Equal(t, convergeInterval, due)
+	first := sc.lastConverge
+	require.False(t, first.IsZero())
+
+	due = sc.convergeIfDue(t.Context())
+	assert.Positive(t, due)
+	assert.LessOrEqual(t, due, convergeInterval)
+	assert.Equal(t, first, sc.lastConverge, "a pass inside the interval must not re-assert the policy")
+
+	sc.lastConverge = time.Now().Add(-2 * convergeInterval)
+	due = sc.convergeIfDue(t.Context())
+	assert.Equal(t, convergeInterval, due)
+	assert.True(t, sc.lastConverge.After(first))
+}
+
+func TestScheduler_AFollowerAsksAgainAtTheLeaseRate(t *testing.T) {
+	sc, _, _ := schedulerRig(t)
+	require.False(t, sc.lease.Held())
+
+	// Leadership turns over without anything being written, so a follower has no
+	// signal to wait on and must keep asking.
+	due, err := sc.reconcileServicesPass(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, leaseRefresh, due)
+
+	due, err = sc.timerPass(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, leaseRefresh, due)
+}
+
+func TestScheduler_TheTimerPassReturnsTheSoonestOfItsJobs(t *testing.T) {
+	sc, _, kv := schedulerRig(t)
+	now := time.Now().UTC()
+
+	// A live instance due in 10s, and a stopped task due much later: the pass must
+	// come back for the sooner of the two.
+	var inst InstanceRecord
+	found, err := getJSON(t.Context(), kv, InstanceKey("web", "i-1"), &inst)
+	require.NoError(t, err)
+	require.True(t, found)
+	inst.LastSeen = now.Add(10*time.Second - heartbeatTimeout)
+	require.NoError(t, putJSON(t.Context(), kv, InstanceKey("web", "i-1"), &inst))
+
+	stopped := TaskRecord{
+		TaskID: "t-1", Cluster: "web", ARN: TaskARN(testRegion, testAccountID, "web", "t-1"),
+		LastStatus: TaskStatusStopped, DesiredStatus: TaskStatusStopped, StoppedAt: now,
+	}
+	require.NoError(t, putJSON(t.Context(), kv, TaskKey("web", "t-1"), &stopped))
+
+	reapDue, err := sc.reap(t.Context())
+	require.NoError(t, err)
+	sweepDue, err := sc.sweepStoppedTasks(t.Context())
+	require.NoError(t, err)
+	require.Positive(t, sweepDue)
+	assert.Equal(t, reapDue, reconciler.Earliest(reapDue, sweepDue),
+		"the pass returns the soonest deadline, not the last one computed")
+	assert.InDelta(t, 10.0, reapDue.Seconds(), 2)
+}

--- a/spinifex/handlers/ecs/scheduler.go
+++ b/spinifex/handlers/ecs/scheduler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/handlers/ecs/bus"
 	"github.com/mulgadc/spinifex/spinifex/kvlease"
+	"github.com/mulgadc/spinifex/spinifex/reconciler"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -23,11 +24,10 @@ const (
 	schedulerLeaderKey  = "scheduler"
 	leaseRefresh        = 20 * time.Second
 	reaperInterval      = 30 * time.Second
-	reconcileInterval   = 10 * time.Second
 	heartbeatTimeout    = 90 * time.Second
 	stoppedReasonReaped = "ContainerInstance disconnected"
 
-	// sweepInterval is how often the leader prunes stale STOPPED task records;
+	// sweepInterval is what a failed sweep retries at, having learnt no deadline;
 	// stoppedTaskRetention keeps a just-stopped task describable (DescribeTasks /
 	// UI exit reason) before it is dropped, matching AWS's ~1h STOPPED window.
 	sweepInterval        = 60 * time.Second
@@ -37,6 +37,10 @@ const (
 	// policy. The document changes only across releases, so this trades a slower
 	// pickup after an upgrade for a fleet-wide write every reconcile tick.
 	convergeInterval = 5 * time.Minute
+
+	// reconcileResync is the drift backstop for both scheduler loops, and the
+	// outer bound on every deadline they return.
+	reconcileResync = 5 * time.Minute
 )
 
 // Scheduler is the per-daemon ECS control loop. A single leader (elected via the
@@ -51,13 +55,29 @@ type Scheduler struct {
 	lease    *kvlease.Lease
 	leaseErr error
 
+	// wake carries a bus message that changed something the service reconcile
+	// reads. Fed by the task-state subscription and not by the heartbeat one:
+	// that separation is the whole reason this loop needs no KV watch.
+	wake chan struct{}
+
+	// passMu keeps the two loops from running a pass at the same time. They are
+	// separate schedules over the same records, and the four tickers they replace
+	// shared one goroutine, so the leader stays the single writer it was.
+	passMu sync.Mutex
+
+	// lastConverge stamps the instance-role converge, which rides the timer pass
+	// rather than a ticker. Guarded by passMu, like the pass that writes it.
+	lastConverge time.Time
+
 	mu   sync.Mutex
 	subs []*nats.Subscription
 }
 
 // NewScheduler constructs a Scheduler. holder identifies this daemon in the lease.
 func NewScheduler(nc *nats.Conn, svc *Service, holder string) *Scheduler {
-	sc := &Scheduler{nc: nc, svc: svc, holder: holder}
+	// One slot: it means "something the reconcile reads has changed", and a
+	// second arriving before the pass runs says nothing the first did not.
+	sc := &Scheduler{nc: nc, svc: svc, holder: holder, wake: make(chan struct{}, 1)}
 	sc.lease, sc.leaseErr = kvlease.New(kvlease.Config{
 		Name:   "ecs/scheduler",
 		Bucket: sc.leaderBucket,
@@ -90,49 +110,97 @@ func (sc *Scheduler) Run(ctx context.Context) {
 		slog.ErrorContext(ctx, "ECS scheduler: lease config invalid", "holder", sc.holder, "err", sc.leaseErr)
 		return
 	}
-	reaperTicker := time.NewTicker(reaperInterval)
-	reconcileTicker := time.NewTicker(reconcileInterval)
-	sweepTicker := time.NewTicker(sweepInterval)
-	convergeTicker := time.NewTicker(convergeInterval)
-	defer reaperTicker.Stop()
-	defer reconcileTicker.Stop()
-	defer sweepTicker.Stop()
-	defer convergeTicker.Stop()
-
 	leaseDone := make(chan struct{})
 	go func() {
 		defer close(leaseDone)
 		sc.lease.Run(ctx)
 	}()
-	for {
-		select {
-		case <-ctx.Done():
-			// The daemon waits on Run, so the lease delete must complete before
-			// it returns, otherwise the next leader waits out the full TTL.
-			<-leaseDone
-			return
-		case <-reaperTicker.C:
-			sc.runIfLeader("instance reap", func() error { return sc.reap(ctx) })
-		case <-reconcileTicker.C:
-			sc.runIfLeader("service reconcile", func() error { return sc.svc.reconcileAllServices(ctx) })
-		case <-sweepTicker.C:
-			sc.runIfLeader("stopped-task sweep", func() error { return sc.sweepStoppedTasks(ctx) })
-		case <-convergeTicker.C:
-			sc.runIfLeader("instance role converge", func() error { return sc.convergeInstanceRoles(ctx) })
-		}
-	}
+
+	// Two loops rather than four tickers, split by what wakes them. Services are
+	// woken by the bus and nothing else; the reaper, the sweep and the converge
+	// are woken by elapsed time and nothing else. Neither watches KV: the account
+	// bucket carries a heartbeat write per instance per interval, which no filter
+	// can exclude, so watching it would scale wake-ups with the fleet.
+	var loops sync.WaitGroup
+	loops.Add(2)
+	go func() {
+		defer loops.Done()
+		reconciler.Run(ctx, reconciler.Config{
+			Name:      "ecs/services",
+			Reconcile: sc.reconcileServicesPass,
+			Trigger:   sc.wake,
+			Resync:    reconcileResync,
+		})
+	}()
+	go func() {
+		defer loops.Done()
+		reconciler.Run(ctx, reconciler.Config{
+			Name:      "ecs/timers",
+			Reconcile: sc.timerPass,
+			Resync:    reconcileResync,
+		})
+	}()
+
+	<-ctx.Done()
+	loops.Wait()
+	// The daemon waits on Run, so the lease delete must complete before it
+	// returns, otherwise the next leader waits out the full TTL.
+	<-leaseDone
 }
 
-// runIfLeader runs one leader-only pass, logging a pass that could not complete.
-// A pass errors only when it could not observe the whole fleet, so this log is
-// the operator's signal that a tick was skipped rather than found nothing to do.
-func (sc *Scheduler) runIfLeader(pass string, run func() error) {
+// reconcileServicesPass converges every service, and says when to come back with
+// nothing having arrived. A service settles into a shape the bus then keeps it
+// in, so a leader with nothing in flight asks for no deadline at all.
+func (sc *Scheduler) reconcileServicesPass(ctx context.Context) (time.Duration, error) {
 	if !sc.lease.Held() {
-		return
+		// Leadership turns over without anything being published, so a follower
+		// has to keep asking. The pass itself is a lease check and nothing more.
+		return leaseRefresh, nil
 	}
-	if err := run(); err != nil {
-		slog.Error("ECS scheduler: pass failed", "pass", pass, "err", err)
+	sc.passMu.Lock()
+	defer sc.passMu.Unlock()
+	if err := sc.svc.reconcileAllServices(ctx); err != nil {
+		slog.Error("ECS scheduler: pass failed", "pass", "service reconcile", "err", err)
 	}
+	return 0, nil
+}
+
+// timerPass runs the three jobs that only elapsed time can trigger, and returns
+// the soonest of their deadlines. None of them is announced by a write, so
+// without this they would run on the resync alone.
+func (sc *Scheduler) timerPass(ctx context.Context) (time.Duration, error) {
+	if !sc.lease.Held() {
+		return leaseRefresh, nil
+	}
+	sc.passMu.Lock()
+	defer sc.passMu.Unlock()
+	reapDue, err := sc.reap(ctx)
+	if err != nil {
+		slog.Error("ECS scheduler: pass failed", "pass", "instance reap", "err", err)
+		reapDue = reaperInterval
+	}
+	sweepDue, err := sc.sweepStoppedTasks(ctx)
+	if err != nil {
+		slog.Error("ECS scheduler: pass failed", "pass", "stopped-task sweep", "err", err)
+		sweepDue = sweepInterval
+	}
+	convergeDue := sc.convergeIfDue(ctx)
+	return reconciler.Earliest(reconciler.Earliest(reapDue, sweepDue), convergeDue), nil
+}
+
+// convergeIfDue re-asserts the instance-role policy when its interval has
+// elapsed, and reports how long until it is due again. It rides this pass rather
+// than a ticker of its own because the document changes only across releases, so
+// the exact cadence does not matter.
+func (sc *Scheduler) convergeIfDue(ctx context.Context) time.Duration {
+	if remaining := time.Until(sc.lastConverge.Add(convergeInterval)); remaining > 0 {
+		return remaining
+	}
+	sc.lastConverge = time.Now()
+	if err := sc.convergeInstanceRoles(ctx); err != nil {
+		slog.Error("ECS scheduler: pass failed", "pass", "instance role converge", "err", err)
+	}
+	return convergeInterval
 }
 
 // onGained refuses the lease when this node cannot converge instance roles.
@@ -213,7 +281,22 @@ func (sc *Scheduler) onTaskState(msg *nats.Msg) {
 		slog.Error("ECS scheduler: record task-state failed", "task", m.TaskID, "err", err)
 		return
 	}
+	// A task changing state is what moves a service's running count, so this is
+	// the signal the reconcile was polling for. A heartbeat deliberately does not
+	// signal: it says only that an instance is alive, which the reaper reads on
+	// its own schedule.
+	sc.signal()
 	slog.Info("ECS scheduler: task state", "task", m.TaskID, "status", m.LastStatus)
+}
+
+// signal reports that the service reconcile has something to do, without
+// blocking: the channel's single slot already means "at least one change is
+// pending".
+func (sc *Scheduler) signal() {
+	select {
+	case sc.wake <- struct{}{}:
+	default:
+	}
 }
 
 // reap marks instances that have missed their heartbeat window DRAINING and stops
@@ -221,32 +304,39 @@ func (sc *Scheduler) onTaskState(msg *nats.Msg) {
 // error when the account enumeration could not be completed, so a pass that
 // could not see the whole fleet is reported rather than read as "nothing to
 // reap" — every unlisted account keeps its dead instances' capacity held.
-func (sc *Scheduler) reap(ctx context.Context) error {
+// The duration is when the soonest live instance's heartbeat window closes. An
+// agent falling silent writes nothing, so a deadline is the only thing that
+// brings the reaper back to notice it.
+func (sc *Scheduler) reap(ctx context.Context) (time.Duration, error) {
 	js, err := jetstream.New(sc.nc)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	buckets, err := accountBuckets(ctx, sc.nc)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	now := time.Now().UTC()
+	var next time.Duration
 	for _, bucket := range buckets {
 		kv, err := js.KeyValue(ctx, bucket.name)
 		if err != nil {
 			slog.Error("ECS scheduler: open bucket failed", "bucket", bucket.name, "err", err)
 			continue
 		}
-		sc.reapBucket(ctx, kv, bucket.accountID, now)
+		next = reconciler.Earliest(next, sc.reapBucket(ctx, kv, bucket.accountID, now))
 	}
-	return nil
+	return next, nil
 }
 
-func (sc *Scheduler) reapBucket(ctx context.Context, kv jetstream.KeyValue, accountID string, now time.Time) {
+// reapBucket reaps one account's disconnected instances and reports when the
+// soonest instance it left alone falls due.
+func (sc *Scheduler) reapBucket(ctx context.Context, kv jetstream.KeyValue, accountID string, now time.Time) time.Duration {
 	keys, err := keysWithPrefix(ctx, kv, "clusters/")
 	if err != nil {
-		return
+		return 0
 	}
+	var next time.Duration
 	for _, k := range keys {
 		if !strings.Contains(k, "/instances/") {
 			continue
@@ -256,7 +346,11 @@ func (sc *Scheduler) reapBucket(ctx context.Context, kv jetstream.KeyValue, acco
 		if err != nil || !found {
 			continue
 		}
-		if inst.Status != InstanceStatusActive || now.Sub(inst.LastSeen) < heartbeatTimeout {
+		if inst.Status != InstanceStatusActive {
+			continue
+		}
+		if now.Sub(inst.LastSeen) < heartbeatTimeout {
+			next = reconciler.Earliest(next, inst.LastSeen.Add(heartbeatTimeout).Sub(now))
 			continue
 		}
 		slog.Warn("ECS scheduler: reaping disconnected instance", "cluster", inst.Cluster, "instance", inst.InstanceID,
@@ -268,6 +362,7 @@ func (sc *Scheduler) reapBucket(ctx context.Context, kv jetstream.KeyValue, acco
 		}
 		sc.stopInstanceTasks(ctx, kv, accountID, inst.Cluster, inst.InstanceID)
 	}
+	return next
 }
 
 // stopInstanceTasks transitions a reaped instance's non-stopped tasks to STOPPED

--- a/spinifex/handlers/ecs/scheduler.go
+++ b/spinifex/handlers/ecs/scheduler.go
@@ -27,6 +27,10 @@ const (
 	heartbeatTimeout    = 90 * time.Second
 	stoppedReasonReaped = "ContainerInstance disconnected"
 
+	// reconcileInterval is how soon a service with something in flight is
+	// revisited. A settled service asks for nothing and is woken by the bus.
+	reconcileInterval = 10 * time.Second
+
 	// sweepInterval is what a failed sweep retries at, having learnt no deadline;
 	// stoppedTaskRetention keeps a just-stopped task describable (DescribeTasks /
 	// UI exit reason) before it is dropped, matching AWS's ~1h STOPPED window.
@@ -148,9 +152,9 @@ func (sc *Scheduler) Run(ctx context.Context) {
 	<-leaseDone
 }
 
-// reconcileServicesPass converges every service, and says when to come back with
-// nothing having arrived. A service settles into a shape the bus then keeps it
-// in, so a leader with nothing in flight asks for no deadline at all.
+// reconcileServicesPass converges every service and says when to come back. A
+// settled fleet asks for no deadline at all: what would change it is a task
+// state report, and that arrives as a wake.
 func (sc *Scheduler) reconcileServicesPass(ctx context.Context) (time.Duration, error) {
 	if !sc.lease.Held() {
 		// Leadership turns over without anything being published, so a follower
@@ -159,10 +163,12 @@ func (sc *Scheduler) reconcileServicesPass(ctx context.Context) (time.Duration, 
 	}
 	sc.passMu.Lock()
 	defer sc.passMu.Unlock()
-	if err := sc.svc.reconcileAllServices(ctx); err != nil {
+	revisit, err := sc.svc.reconcileAllServices(ctx)
+	if err != nil {
 		slog.Error("ECS scheduler: pass failed", "pass", "service reconcile", "err", err)
+		return reconcileInterval, nil
 	}
-	return 0, nil
+	return revisit, nil
 }
 
 // timerPass runs the three jobs that only elapsed time can trigger, and returns
@@ -231,11 +237,24 @@ func (sc *Scheduler) subscribeBus(_ context.Context) error {
 		_ = heartbeat.Unsubscribe()
 		return err
 	}
+	// The agent reports task state through the gateway, so the change lands on
+	// whichever worker served the call. This is how it reaches the leader.
+	wake, err := sc.nc.Subscribe("ecs.bus.*.*.service-reconcile", sc.onReconcileWake)
+	if err != nil {
+		_ = register.Unsubscribe()
+		_ = heartbeat.Unsubscribe()
+		_ = taskState.Unsubscribe()
+		return err
+	}
 	sc.mu.Lock()
-	sc.subs = []*nats.Subscription{register, heartbeat, taskState}
+	sc.subs = []*nats.Subscription{register, heartbeat, taskState, wake}
 	sc.mu.Unlock()
 	return nil
 }
+
+// onReconcileWake carries no payload and writes nothing: the change it announces
+// is already in KV by the time it is published.
+func (sc *Scheduler) onReconcileWake(*nats.Msg) { sc.signal() }
 
 func (sc *Scheduler) unsubscribeBus() {
 	sc.mu.Lock()

--- a/spinifex/handlers/ecs/service_test.go
+++ b/spinifex/handlers/ecs/service_test.go
@@ -469,7 +469,7 @@ func TestScheduler_LeadershipWiresBusSubscriptions(t *testing.T) {
 	require.Zero(t, sc.subCount(), "subscriptions must not exist before election")
 
 	require.True(t, sc.lease.TryAcquire(t.Context()))
-	assert.Equal(t, 3, sc.subCount(), "leader must own the register, heartbeat and task-state subscriptions")
+	assert.Equal(t, 4, sc.subCount(), "leader must own the register, heartbeat, task-state and reconcile-wake subscriptions")
 
 	sc.lease.Release(t.Context())
 	assert.Zero(t, sc.subCount(), "a released leader must drop its subscriptions")
@@ -486,7 +486,7 @@ func TestScheduler_LoserHoldsNoSubscriptions(t *testing.T) {
 	require.True(t, a.lease.TryAcquire(t.Context()))
 	require.False(t, b.lease.TryAcquire(t.Context()))
 	assert.Zero(t, b.subCount())
-	assert.Equal(t, 3, a.subCount())
+	assert.Equal(t, 4, a.subCount())
 }
 
 func TestScheduler_RunReleasesLeaseOnShutdown(t *testing.T) {

--- a/spinifex/handlers/ecs/services.go
+++ b/spinifex/handlers/ecs/services.go
@@ -403,20 +403,25 @@ func persistServiceIfChanged(ctx context.Context, kv jetstream.KeyValue, svc *Se
 	return putJSON(ctx, kv, ServiceKey(svc.Cluster, svc.Name), svc)
 }
 
-// reconcileAllServices is the scheduler-tick fan-out: every ACTIVE service in
-// every ECS account bucket is reconciled. Runs only on the scheduler leader.
-// Returns an error when the account enumeration could not be completed, so a
-// pass that could not see the whole fleet is reported rather than read as "no
-// services to reconcile" — every unlisted account stalls below its desired count.
-func (s *Service) reconcileAllServices(ctx context.Context) error {
+// reconcileAllServices reconciles every ACTIVE service in every ECS account
+// bucket. Runs only on the scheduler leader. Returns an error when the account
+// enumeration could not be completed, so a pass that could not see the whole
+// fleet is reported rather than read as "no services to reconcile" — every
+// unlisted account stalls below its desired count.
+//
+// The duration asks for a revisit while any service is still in flight. A task
+// takes time to reach RUNNING and reports through the gateway, so the pass that
+// launched it comes back on its own rather than trusting a wake to arrive.
+func (s *Service) reconcileAllServices(ctx context.Context) (time.Duration, error) {
 	js, err := s.js()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	buckets, err := accountBuckets(ctx, s.nc)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	var next time.Duration
 	for _, bucket := range buckets {
 		kv, err := js.KeyValue(ctx, bucket.name)
 		if err != nil {
@@ -432,9 +437,26 @@ func (s *Service) reconcileAllServices(ctx context.Context) error {
 			if err := s.reconcileService(ctx, kv, bucket.accountID, &recs[i]); err != nil {
 				slog.Error("ECS reconcile: service failed", "service", recs[i].Name, "err", err)
 			}
+			if !serviceSettled(&recs[i]) {
+				next = reconcileInterval
+			}
 		}
 	}
-	return nil
+	return next, nil
+}
+
+// serviceSettled reports whether a service is where it was asked to be, with no
+// task mid-flight and no rollout still advancing. An unsettled service is what a
+// revisit deadline is for: nothing it is waiting on is a KV write it can watch.
+func serviceSettled(svc *ServiceRecord) bool {
+	if svc.Status != ServiceStatusActive {
+		return true
+	}
+	if svc.PendingCount > 0 || svc.RunningCount != svc.DesiredCount {
+		return false
+	}
+	primary := svc.primaryDeployment()
+	return primary == nil || primary.RolloutState != RolloutStateInProgress
 }
 
 // launchDeploymentTasks places n tasks for a specific deployment via the standard

--- a/spinifex/handlers/ecs/services.go
+++ b/spinifex/handlers/ecs/services.go
@@ -1,7 +1,9 @@
 package handlers_ecs
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"strings"
@@ -335,6 +337,12 @@ func (s *Service) reconcileService(ctx context.Context, kv jetstream.KeyValue, a
 	if svc.Status != ServiceStatusActive {
 		return nil
 	}
+	// Snapshotted before the normalisers run, so a normalisation that does change
+	// something is still persisted.
+	before, err := json.Marshal(svc)
+	if err != nil {
+		return err
+	}
 	svc.normalizeDeploymentConfig()
 	svc.ensurePrimaryDeployment()
 
@@ -347,10 +355,10 @@ func (s *Service) reconcileService(ctx context.Context, kv jetstream.KeyValue, a
 	primary := svc.primaryDeployment()
 	if primary != nil {
 		// A failing deployment trips the breaker (and may roll back); persist and
-		// let the next tick roll the replacement in.
+		// let the next pass roll the replacement in.
 		if tripCircuitBreaker(svc, primary) {
 			svc.RunningCount, svc.PendingCount = running, pending
-			return putJSON(ctx, kv, ServiceKey(svc.Cluster, svc.Name), svc)
+			return persistServiceIfChanged(ctx, kv, svc, before)
 		}
 		desired := svc.DesiredCount
 		maxCount := desired * svc.MaximumPercent / 100
@@ -373,6 +381,25 @@ func (s *Service) reconcileService(ctx context.Context, kv jetstream.KeyValue, a
 	}
 
 	svc.RunningCount, svc.PendingCount = running, pending
+	return persistServiceIfChanged(ctx, kv, svc, before)
+}
+
+// persistServiceIfChanged writes a service record only when the pass actually
+// altered it. The reconcile runs on every trigger and every resync, so writing
+// unconditionally churns every record on each one, and would wake any loop
+// watching the bucket with a change it made itself.
+//
+// The comparison is over the marshalled form rather than a field list: what a
+// pass may touch is spread across the deployment and rollout bookkeeping, and a
+// hand-maintained list of those fields would rot.
+func persistServiceIfChanged(ctx context.Context, kv jetstream.KeyValue, svc *ServiceRecord, before []byte) error {
+	after, err := json.Marshal(svc)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(before, after) {
+		return nil
+	}
 	return putJSON(ctx, kv, ServiceKey(svc.Cluster, svc.Name), svc)
 }
 

--- a/spinifex/handlers/ecs/services_test.go
+++ b/spinifex/handlers/ecs/services_test.go
@@ -120,7 +120,7 @@ func TestService_Reconcile_ReplacesStoppedTask(t *testing.T) {
 	require.Len(t, live, 1) // STOPPED task drops out of the active set
 
 	// Reconcile launches a replacement back to desired=2.
-	require.NoError(t, svc.reconcileAllServices(t.Context()))
+	require.NoError(t, dropRevisit(svc.reconcileAllServices)(t.Context()))
 	live, err = svc.listServiceTasks(t.Context(), kv, "web", "web")
 	require.NoError(t, err)
 	assert.Len(t, live, 2)
@@ -172,7 +172,7 @@ func TestService_DeleteService_DrainsAndInactivates(t *testing.T) {
 	}, testAccountID)
 	require.NoError(t, err)
 	require.Len(t, desc.Services, 1)
-	require.NoError(t, svc.reconcileAllServices(t.Context()))
+	require.NoError(t, dropRevisit(svc.reconcileAllServices)(t.Context()))
 	live, _ = svc.listServiceTasks(t.Context(), kv, "web", "web")
 	assert.Empty(t, live)
 }

--- a/spinifex/handlers/ecs/tasks_gc.go
+++ b/spinifex/handlers/ecs/tasks_gc.go
@@ -6,51 +6,59 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/reconciler"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
 // sweepStoppedTasks prunes stale STOPPED task records across every ECS account
-// bucket. Leader-only (scheduler is the single KV writer); runs on the sweep
-// tick. Mirrors reap()'s bucket walk. Returns an error when the account
-// enumeration could not be completed, so a pass that saw only part of the fleet
-// is reported rather than passing for a clean sweep.
-func (sc *Scheduler) sweepStoppedTasks(ctx context.Context) error {
+// bucket. Leader-only (scheduler is the single KV writer). Mirrors reap()'s
+// bucket walk. Returns an error when the account enumeration could not be
+// completed, so a pass that saw only part of the fleet is reported rather than
+// passing for a clean sweep.
+//
+// The duration is when the soonest surviving record falls due. A record ageing
+// out writes nothing, so nothing else would bring the sweep back for it.
+func (sc *Scheduler) sweepStoppedTasks(ctx context.Context) (time.Duration, error) {
 	js, err := jetstream.New(sc.nc)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	buckets, err := accountBuckets(ctx, sc.nc)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	now := time.Now().UTC()
+	var next time.Duration
 	for _, bucket := range buckets {
 		kv, err := js.KeyValue(ctx, bucket.name)
 		if err != nil {
 			slog.Error("ECS sweep: open bucket failed", "bucket", bucket.name, "err", err)
 			continue
 		}
-		pruned, serr := sc.svc.sweepStoppedBucket(ctx, kv, now, stoppedTaskRetention)
+		pruned, due, serr := sc.svc.sweepStoppedBucket(ctx, kv, now, stoppedTaskRetention)
 		if serr != nil {
 			slog.Error("ECS sweep: bucket failed", "bucket", bucket.name, "err", serr)
 			continue
 		}
+		next = reconciler.Earliest(next, due)
 		if pruned > 0 {
 			slog.Info("ECS sweep: pruned stale STOPPED tasks", "bucket", bucket.name, "count", pruned)
 		}
 	}
-	return nil
+	return next, nil
 }
 
 // sweepStoppedBucket deletes task records that have been STOPPED longer than
 // retention. A task missing its StoppedAt timestamp is never pruned (defensive:
-// it would otherwise look infinitely old). Returns the number deleted.
-func (s *Service) sweepStoppedBucket(ctx context.Context, kv jetstream.KeyValue, now time.Time, retention time.Duration) (int, error) {
+// it would otherwise look infinitely old). Returns the number deleted and when
+// the soonest record it kept falls due.
+func (s *Service) sweepStoppedBucket(ctx context.Context, kv jetstream.KeyValue, now time.Time, retention time.Duration) (int, time.Duration, error) {
 	keys, err := keysWithPrefix(ctx, kv, "clusters/")
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	pruned := 0
+	var next time.Duration
 	for _, k := range keys {
 		if !strings.Contains(k, "/tasks/") {
 			continue
@@ -64,6 +72,7 @@ func (s *Service) sweepStoppedBucket(ctx context.Context, kv jetstream.KeyValue,
 			continue
 		}
 		if now.Sub(task.StoppedAt) <= retention {
+			next = reconciler.Earliest(next, task.StoppedAt.Add(retention).Sub(now))
 			continue
 		}
 		if derr := kv.Delete(ctx, k); derr != nil {
@@ -72,5 +81,5 @@ func (s *Service) sweepStoppedBucket(ctx context.Context, kv jetstream.KeyValue,
 		}
 		pruned++
 	}
-	return pruned, nil
+	return pruned, next, nil
 }

--- a/spinifex/handlers/ecs/tasks_gc_test.go
+++ b/spinifex/handlers/ecs/tasks_gc_test.go
@@ -25,9 +25,12 @@ func TestSweepStoppedBucket_PrunesOnlyStale(t *testing.T) {
 	put("running", TaskStatusRunning, time.Time{})           // not stopped -> keep
 	put("nostamp", TaskStatusStopped, time.Time{})           // STOPPED but no timestamp -> keep (defensive)
 
-	pruned, err := svc.sweepStoppedBucket(t.Context(), kv, now, time.Hour)
+	pruned, due, err := svc.sweepStoppedBucket(t.Context(), kv, now, time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, 1, pruned)
+	// "fresh" is the only survivor with a clock on it, so the sweep must come back
+	// when its retention expires, not on the resync.
+	assert.Equal(t, 55*time.Minute, due)
 
 	exists := func(id string) bool {
 		var rec TaskRecord


### PR DESCRIPTION
## The ECS scheduler ran four tickers, and the 10s one rewrote every service record on every pass

`Scheduler.Run` drove a `select` over four tickers: service reconcile 10s, heartbeat reaper 30s, stopped-task sweep 60s, instance-role converge 5m. 9.2 passes a minute whether or not anything had changed, and `reconcileService` ended in an unconditional `putJSON`, so an idle service was rewritten six times a minute forever — **measured at exactly 6.0 writes/min on env19**.

**The conversion that worked for RDS (#948) and EKS (#952) does not apply here.** That analysis is the part worth reviewing first.

### Why not a KV watch

Two properties of the ECS account bucket, either alone sufficient.

**It is written every 30s per container instance.** The agent re-registers on every heartbeat tick and that rewrites the whole instance record, because `LastSeen` is exactly what the reaper reads. `InstanceKey` is `clusters/<cluster>/instances/<id>`, and `/` is not the NATS subject separator, so that key is a single token: the filter can only be `">"` and heartbeats cannot be excluded from it. Measured on env19: **2.0 writes/min per instance, unchanged by this PR.**

| | passes per minute |
| --- | --- |
| four tickers | 9.2, independent of fleet size |
| a `">"` watch, from heartbeats alone | 2 × instances |

Break-even is about five container instances, and past that it degrades linearly while the tickers do not.

**And the pass writes to the bucket it would watch.** A watch would self-trigger on the service record the pass had just written — a feedback loop, not merely extra passes. EKS was safe from this only because `SetClusterHealthState` no-ops when unchanged.

### Where the wake comes from — and the correction in the second commit

The first commit triggered the reconcile from the scheduler's `ecs.bus.*.*.task-state.*` subscription. **That was wrong, and staging this on env19 is what surfaced it.** The agent moved onto the gateway (`docs/development/archive/feature/ecs-agent-gateway-control-plane.md`), and nothing publishes those subjects any more — the scheduler's three bus subscriptions are dead in production, so the trigger would never have fired on a live cluster and the reconcile would have run on the 5m resync alone.

What actually happens now is `agent → gateway → ecs.SubmitTaskStateChange → recordTaskState`, served by a `spinifex-workers` queue-group member that is rarely the leader. So the second commit publishes a payload-free wake on the cluster's `service-reconcile` subject from that path, and the leader subscribes to it. The wake crosses nodes because the event does.

**The pass also names its own deadline rather than trusting the wake to arrive**: a service with a task still in flight asks to be revisited at the old 10s cadence, and only a settled fleet — running == desired, nothing pending, no rollout advancing — asks for nothing. That is what makes the wake an optimisation rather than a correctness dependency.

### The service write becomes conditional

`reconcileService` marshals the record on entry and writes only if the pass changed it. The snapshot is taken *before* the normalisers run, so a normalisation that does change something is still persisted. Comparing the marshalled form rather than a field list is deliberate: what a pass may touch is spread across the deployment and rollout bookkeeping, and a hand-maintained list would rot.

### Reaper, sweep and converge: one deadline-driven pass

| Job | Deadline |
| --- | --- |
| reaper | earliest `LastSeen + heartbeatTimeout` across active instances |
| sweep | earliest `StoppedAt + stoppedTaskRetention` across stopped tasks |
| converge | `convergeInterval` since it last ran, stamped in the pass |

The pass returns the soonest of the three via `reconciler.Earliest`. A pass that failed falls back to the old interval rather than to nothing — a non-positive duration reads as "no deadline", the trap the RDS conversion hit.

### The two loops do not overlap

Four tickers on one `select` could never run two passes at once, and "the leader is the single KV writer" rested on that. Two loops can, so both passes hold a `passMu` for their duration. `runIfLeader` is gone: each pass does its own lease check, because a follower must also return a deadline to be asked again at.

---

## env19 verification

Three-node env19, one `t3.small` container instance running the `spinifex-ecs-node` AMI (built and imported for this: `ami-ebe212a4d59e2b560`), cluster `demo`, service `web` at desired 1 running a busybox sleeper. Baseline is `dev` `e9404f1d7`; branch is `74acc68e5`. Timestamps are read from the task and instance records, not from a poll loop, so the numbers do not depend on sampling rate.

### Replacement latency: the 5-second mode disappears

Stop the service's running task, measure from the STOPPED report (`stoppedAt`) to the replacement's `createdAt`.

| | n | mean | median | max |
| --- | --- | --- | --- | --- |
| `dev` `e9404f1d7` | 15 | 2.56s | 0.25s | **5.26s** |
| this branch | 8 | **0.31s** | 0.31s | **0.31s** |

The baseline is bimodal — every sample is either ~0.2s or ~5.2s, nothing between. That is not noise: the agent polls every 5s, so stops quantise onto a 5s grid, and a 10s reconcile tick therefore either catches a stop immediately or misses it by a whole 5s beat. Half the time a replacement waited out a tick it had no reason to wait for.

The branch has no second mode: **every one of the 8 samples was 0.30–0.31s**, which is the 250ms debounce plus the write. It is ~80ms *slower* than the baseline's lucky mode and 17× faster than its unlucky one.

### Idle write churn: the service record stops being rewritten

120s idle window, KV watch counting writes per key:

| key | `dev` `e9404f1d7` | this branch |
| --- | --- | --- |
| `clusters/demo/services/web` | 12 (6.0/min) | **0** |
| `clusters/demo/instances/i-…` | 4 (2.0/min) | 4 (2.0/min) |

The baseline's 12 writes are the 10s ticker's unconditional put, landing on the 10s grid to the millisecond. The instance row is the heartbeat, and it is deliberately unchanged — it is also the reason a KV watch was the wrong answer here.

### Reaper: lands on the timeout instead of after it

Stop the container instance's VM; measure from its last `LastSeen` to the DRAINING write.

| | sample 1 | sample 2 |
| --- | --- | --- |
| `dev` `e9404f1d7` | 90.34s | **103.2s** |
| this branch | 90.06s | 90.06s |

Two samples per build is not a distribution, but the baseline's second sample lands inside the predicted 90–120s window and the branch's two are 60ms off the 90s timeout, which is the shape the change predicts: a deadline rather than a 30s ticker.

### What is NOT verified

**That the wake crossed nodes in these samples.** `ecs.SubmitTaskStateChange` is queue-grouped across `spinifex-workers`, so the worker that served each report may or may not have been the leader — I did not pin them to different nodes. The latency numbers prove the wake reached the leader; they do not prove it had to travel to get there.

**The sweep's deadline.** `stoppedTaskRetention` is 1h, so nothing expired inside the test window. It rests on unit tests.

### State

env19 is left on this branch with cluster `demo`, service `web` running 1/1, the container instance ACTIVE, and the imported ECS-node AMI. Also still present from earlier work: the EKS node AMI, the RDS postgres AMI, two RDS test instances, and an `ecsInstanceRole` + instance profile created by hand (the bringup script in `scripts/` predates the IMDS credential switch and seeds keys the agent no longer reads — worth a follow-up).

---

Plan: `docs/development/josh/improvements/reconciler-ecs-deadlines.md`. Bead: `mulga-ap4rn`, under `mulga-bw2cw`. vpcd remains.
