### PR TITLE
fix: follow continuation tokens when listing metadata documents

### DIFF
--- a/spinifex/ebsmetadata/store.go
+++ b/spinifex/ebsmetadata/store.go
@@ -129,6 +129,47 @@ const listFetchConcurrency = 16
 // read of a metadata document.
 var listFetchTimeout = 10 * time.Second
 
+// maxListPages bounds a single listing. It exists only to turn a server that
+// keeps claiming truncation into an error rather than a hang; at the default
+// page size it is ten million documents, far past any real prefix.
+const maxListPages = 10000
+
+// listKeys returns every key under prefix, following continuation tokens to
+// exhaustion. Reading only the first page returns a prefix of the truth with no
+// error, which for a strict caller is worse than a failure: absence from a
+// truncated listing is not absence.
+func listKeys(ctx context.Context, objects objectstore.ObjectStore, bucket, prefix string) ([]string, error) {
+	var keys []string
+	var token *string
+
+	for range maxListPages {
+		result, err := objects.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bucket),
+			Prefix:            aws.String(prefix),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, object := range result.Contents {
+			if object == nil || object.Key == nil {
+				continue
+			}
+			keys = append(keys, *object.Key)
+		}
+		if !aws.BoolValue(result.IsTruncated) {
+			return keys, nil
+		}
+		// Truncated with nothing to resume from. Returning what arrived is the
+		// silent short answer this whole loop exists to prevent.
+		if aws.StringValue(result.NextContinuationToken) == "" {
+			return nil, fmt.Errorf("listing %s reported truncation with no continuation token", prefix)
+		}
+		token = result.NextContinuationToken
+	}
+	return nil, fmt.Errorf("listing %s did not finish within %d pages", prefix, maxListPages)
+}
+
 // listDocuments reads and decodes every document under prefix.
 //
 // skipCorrupt tolerates a document that cannot be fetched as well as one that
@@ -145,9 +186,7 @@ func listDocuments[T any](
 	unmarshal func([]byte) (T, error),
 	skipCorrupt bool,
 ) ([]T, error) {
-	result, err := s.objects.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(s.bucket), Prefix: aws.String(prefix),
-	})
+	keys, err := listKeys(ctx, s.objects, s.bucket, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -160,18 +199,13 @@ func listDocuments[T any](
 		document  T
 		fetchErr  error
 		decodeErr error
-		empty     bool
 	}
 
-	results := make([]fetched, len(result.Contents))
+	results := make([]fetched, len(keys))
 	slots := make(chan struct{}, listFetchConcurrency)
 	var wg sync.WaitGroup
 
-	for i, object := range result.Contents {
-		if object.Key == nil {
-			results[i].empty = true
-			continue
-		}
+	for i, key := range keys {
 		wg.Add(1)
 		slots <- struct{}{}
 		go func(idx int, key string) {
@@ -187,15 +221,13 @@ func listDocuments[T any](
 				return
 			}
 			results[idx].document, results[idx].decodeErr = unmarshal(data)
-		}(i, *object.Key)
+		}(i, key)
 	}
 	wg.Wait()
 
 	documents := make([]T, 0, len(results))
 	for _, r := range results {
 		switch {
-		case r.empty:
-			continue
 		case r.fetchErr != nil:
 			if !skipCorrupt {
 				return nil, r.fetchErr

--- a/spinifex/ebsmetadata/store_test.go
+++ b/spinifex/ebsmetadata/store_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -445,4 +447,128 @@ func TestListVolumes_BoundsOneSlowDocument(t *testing.T) {
 
 	_, err = hanging.ListVolumesStrict(ctx)
 	require.Error(t, err, "the strict listing must still report the document it could not read")
+}
+
+// A listing that reads one page returns a prefix of the truth and no error.
+// For a strict caller that is worse than a failure, because its whole premise
+// is that a document it did not see is not evidence of absence.
+func TestListVolumesFollowsEveryPage(t *testing.T) {
+	objects := objectstore.NewMemoryObjectStore()
+	store := NewStore(objects, "control-plane")
+	ctx := context.Background()
+
+	const documents = 24
+	want := make([]string, 0, documents)
+	keys := make([]string, 0, documents)
+	for i := range documents {
+		id := fmt.Sprintf("vol-%02d", i)
+		require.NoError(t, store.PutVolume(ctx, Volume{VolumeID: id, TenantID: "acct-1", CapacityGiB: 1}))
+		key, err := VolumeKey(id)
+		require.NoError(t, err)
+		want = append(want, id)
+		keys = append(keys, key)
+	}
+
+	for _, strict := range []bool{false, true} {
+		t.Run(fmt.Sprintf("strict=%v", strict), func(t *testing.T) {
+			paging := &pagingStore{ObjectStore: objects, keys: keys, pageSize: 5}
+			paged := NewStore(paging, "control-plane")
+
+			list := paged.ListVolumes
+			if strict {
+				list = paged.ListVolumesStrict
+			}
+			volumes, err := list(ctx)
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(volumes))
+			for _, v := range volumes {
+				got = append(got, v.VolumeID)
+			}
+			assert.Equal(t, want, got, "every page's documents must reach the caller")
+			assert.Equal(t, 5, paging.requests(), "24 documents at 5 a page is 5 requests")
+		})
+	}
+}
+
+// A truncated page with no token cannot be followed. Returning what arrived
+// would be the silent short answer, so it has to be an error for both callers.
+func TestListVolumesRefusesTruncationItCannotFollow(t *testing.T) {
+	objects := objectstore.NewMemoryObjectStore()
+	store := NewStore(objects, "control-plane")
+	ctx := context.Background()
+
+	require.NoError(t, store.PutVolume(ctx, Volume{VolumeID: "vol-1", TenantID: "acct-1", CapacityGiB: 1}))
+	key, err := VolumeKey("vol-1")
+	require.NoError(t, err)
+
+	broken := NewStore(&truncatedNoTokenStore{ObjectStore: objects, keys: []string{key}}, "control-plane")
+
+	_, err = broken.ListVolumes(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "continuation token")
+
+	_, err = broken.ListVolumesStrict(ctx)
+	require.Error(t, err)
+}
+
+// pagingStore serves a prefix one page at a time the way a real S3 does, and
+// counts the requests so a test can tell a followed listing from a lucky one.
+type pagingStore struct {
+	objectstore.ObjectStore
+
+	keys     []string
+	pageSize int
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *pagingStore) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+
+	start := 0
+	if token := aws.StringValue(in.ContinuationToken); token != "" {
+		n, err := strconv.Atoi(token)
+		if err != nil {
+			return nil, fmt.Errorf("continuation token %q was not one this store issued", token)
+		}
+		start = n
+	}
+	end := min(start+s.pageSize, len(s.keys))
+
+	contents := make([]*s3.Object, 0, end-start)
+	for _, key := range s.keys[start:end] {
+		contents = append(contents, &s3.Object{Key: aws.String(key)})
+	}
+
+	out := &s3.ListObjectsV2Output{Contents: contents, IsTruncated: aws.Bool(end < len(s.keys))}
+	if end < len(s.keys) {
+		out.NextContinuationToken = aws.String(strconv.Itoa(end))
+	}
+	return out, nil
+}
+
+func (s *pagingStore) requests() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// truncatedNoTokenStore claims there is more to read and offers no way to read
+// it, which is the one truncation a client cannot honour.
+type truncatedNoTokenStore struct {
+	objectstore.ObjectStore
+
+	keys []string
+}
+
+func (s *truncatedNoTokenStore) ListObjectsV2(_ context.Context, _ *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	contents := make([]*s3.Object, 0, len(s.keys))
+	for _, key := range s.keys {
+		contents = append(contents, &s3.Object{Key: aws.String(key)})
+	}
+	return &s3.ListObjectsV2Output{Contents: contents, IsTruncated: aws.Bool(true)}, nil
 }


### PR DESCRIPTION
## Summary

`ebsmetadata/store.go` `listDocuments` issued one `ListObjectsV2` and iterated `result.Contents`. It never read `IsTruncated` or `NextContinuationToken`, so past the server's page limit the listing returned a prefix of the truth and reported success.

Every caller of `ListVolumes`, `ListVolumesStrict`, `ListAMIs` and `ListAMIsStrict` inherited it. The tolerant ones return a short answer. The strict ones are worse: their whole premise is that a document they did not see is not evidence of absence, and a truncated page hands them exactly that with nothing to notice. A name-uniqueness check that cannot see an AMI concludes the name is free.

Closes `mulga-1d8kt`.

## Changes

Key collection is now its own step that walks the prefix to exhaustion before any document is fetched, in `listKeys`. The concurrent fetch and the in-order assembly below it are untouched, so the ordering and tolerance guarantees the existing tests pin are unchanged — they now just run over every key rather than the first page's.

Two failure modes get an explicit answer rather than a quiet one:

- **Truncated with no token.** The one truncation a client cannot honour. Returning what arrived is the silent short answer the change exists to prevent, so it is an error for tolerant and strict callers alike.
- **A server that keeps claiming truncation.** Bounded by a page count, so a bad token loop fails instead of hanging a daemon that is holding a request open. At the default page size the bound is ten million documents.

Nil keys are dropped while collecting instead of being carried through the fetch as empty slots, which removes the `empty` flag from the result struct.

## Testing

`TestListVolumesFollowsEveryPage` serves 24 documents five to a page through a fake that honours continuation tokens, and asserts all 24 arrive in five requests, for both the tolerant and the strict list. `TestListVolumesRefusesTruncationItCannotFollow` covers the tokenless truncation.

Both are load-bearing. Against the unfixed `store.go`:

```
--- FAIL: TestListVolumesFollowsEveryPage/strict=false
    expected: [vol-00 ... vol-23]
    actual  : [vol-00 vol-01 vol-02 vol-03 vol-04]
    expected: 5   (requests)
    actual  : 1
--- FAIL: TestListVolumesRefusesTruncationItCannotFollow
    An error is expected but got nil.
```

Five of 24 volumes, one request, no error — the bug as reported. The existing ebsmetadata suite passes unchanged and `make preflight` is green.

## Sequencing

This lands independently of predastore #117, which teaches predastore to truncate in the first place. A client that follows tokens behaves identically against a server that never truncates: one page, `IsTruncated` false, stop. So the order is safe either way, and leaving the client unfixed after #117 merges would turn a latent bug into an active one.