### PR TITLE
refactor: wake the vpcd drift loop on intent changes, not a fixed 5-minute ticker

### DIFF
--- a/spinifex/network/reconcile/drift.go
+++ b/spinifex/network/reconcile/drift.go
@@ -6,17 +6,24 @@ import (
 	"log/slog"
 	"time"
 
+	handlers_ec2_eip "github.com/mulgadc/spinifex/spinifex/handlers/ec2/eip"
+	handlers_ec2_igw "github.com/mulgadc/spinifex/spinifex/handlers/ec2/igw"
+	handlers_ec2_natgw "github.com/mulgadc/spinifex/spinifex/handlers/ec2/natgw"
+	handlers_ec2_routetable "github.com/mulgadc/spinifex/spinifex/handlers/ec2/routetable"
+	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/otelsetup"
+	loop "github.com/mulgadc/spinifex/spinifex/reconciler"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
-// DriftInterval is the gap between drift passes. Var (not const) so
-// integration tests can shrink it.
+// DriftInterval is the resync backstop between drift passes when nothing
+// changes. Var (not const) so integration tests can shrink it.
 var DriftInterval = 5 * time.Minute
 
-// driftBackoffBase is the requeue gap after the first incomplete pass. Var so
-// tests can shrink it.
+// driftBackoffBase is the requeue gap after the first incomplete pass, and the
+// floor on how often a change may drive a pass. Var so tests can shrink it.
 var driftBackoffBase = 5 * time.Second
 
 // driftBackoffFactor grows the requeue gap per consecutive incomplete pass, up
@@ -25,14 +32,50 @@ var driftBackoffBase = 5 * time.Second
 // of a VPC having no external gateway.
 const driftBackoffFactor = 3
 
-// DriftLoop runs Reconcile every DriftInterval, gated on AcquireLeader so
-// only one vpcd scans at a time. An incomplete pass requeues on a short
-// backoff instead. Returns when ctx is cancelled.
+// intentBuckets names every KV bucket LoadIntentFromKV reads. A write to one of
+// them is an intent change and nothing else: none of their writers is periodic,
+// and a pass writes OVN rather than KV, so watching them cannot self-trigger.
+var intentBuckets = []string{
+	handlers_ec2_vpc.KVBucketVPCs,
+	handlers_ec2_vpc.KVBucketSubnets,
+	handlers_ec2_vpc.KVBucketSecurityGroups,
+	handlers_ec2_vpc.KVBucketENIs,
+	handlers_ec2_igw.KVBucketIGW,
+	handlers_ec2_eip.KVBucketEIPs,
+	handlers_ec2_routetable.KVBucketRouteTables,
+	handlers_ec2_natgw.KVBucketNatGateways,
+}
+
+// intentSource watches the intent buckets. Enumerated rather than fixed so a
+// bucket that does not exist yet is left alone: the EC2 handlers own these and
+// set their history depth, and an opening watch would create one at the wrong
+// depth. A bucket that appears later is picked up on the next resync.
+func intentSource(js jetstream.JetStream) loop.Source {
+	return loop.Dynamic(func(ctx context.Context) ([]*kvstore.Bucket, error) {
+		buckets := make([]*kvstore.Bucket, 0, len(intentBuckets))
+		for _, name := range intentBuckets {
+			kv, err := js.KeyValue(ctx, name)
+			if err != nil {
+				slog.DebugContext(ctx, "reconcile/drift: intent bucket not available, skipping",
+					"bucket", name, "err", err)
+				continue
+			}
+			// js is passed so a watcher whose stream was lost can reconnect;
+			// RecreateIfMissing stays false so that reconnect never creates.
+			buckets = append(buckets, kvstore.NewOpenBucket(js, kv, kvstore.Config{Name: name}))
+		}
+		return buckets, nil
+	}, ">")
+}
+
+// DriftLoop reconciles on every intent change and every DriftInterval, gated on
+// AcquireLeader so only one vpcd scans at a time. An incomplete pass asks to be
+// revisited on a short backoff instead. Returns when ctx is cancelled.
 //
 // startup is the outcome of the bootstrap ReconcileApplyOnly pass, or nil when
-// this node did not run one. Seeding from it matters because the gateway LRP's
-// first DORA happens in that pass: without the seed a resource that failed
-// before the loop started waits a full DriftInterval for its first retry.
+// this node did not run one. It seeds the first deadline rather than triggering
+// a pass: that bootstrap pass is the startup scan, and running a second one here
+// would duplicate it and pull a scan forward on every clean boot.
 func DriftLoop(ctx context.Context, rec Reconciler, nc *nats.Conn, localAZ, holder string, startup error) {
 	js, err := jetstream.New(nc)
 	if err != nil {
@@ -40,30 +83,51 @@ func DriftLoop(ctx context.Context, rec Reconciler, nc *nats.Conn, localAZ, hold
 		return
 	}
 
-	backoff := nextDriftBackoff(0, startup)
-	timer := time.NewTimer(driftWait(backoff))
-	defer timer.Stop()
+	loop.Run(ctx, loop.Config{
+		Name:      "vpcd/drift",
+		Sources:   []loop.Source{intentSource(js)},
+		Reconcile: driftPass(rec, nc, js, localAZ, holder, startup),
+		Resync:    DriftInterval,
+	})
+}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-			previous := backoff
-			backoff = nextDriftBackoff(backoff, runDriftCycle(ctx, rec, nc, js, localAZ, holder))
-			wait := driftWait(backoff)
-			if backoff != previous {
-				slog.Info("reconcile/drift: requeue interval changed", "wait_ms", otelsetup.Millis(wait))
-			}
-			timer.Reset(wait)
+// driftPass returns the reconcile pass, closing over the backoff ladder and the
+// last pass time. Run never calls it concurrently with itself, which is why
+// neither needs a lock.
+func driftPass(rec Reconciler, nc *nats.Conn, js jetstream.JetStream, localAZ, holder string, startup error) func(context.Context) (time.Duration, error) {
+	var backoff time.Duration
+	var lastPass time.Time
+	seeded := false
+
+	return func(ctx context.Context) (time.Duration, error) {
+		if !seeded {
+			seeded = true
+			backoff = nextDriftBackoff(0, startup)
+			return backoff, nil
 		}
+		// A change-driven pass is a repair check, not the apply path: the event
+		// subscriber has already applied the change, so coalescing a burst behind
+		// the floor the ladder starts at costs a scan nothing it would have
+		// found. Without it a launch storm scans continuously.
+		if wait := time.Until(lastPass.Add(driftBackoffBase)); wait > 0 {
+			return wait, nil
+		}
+		lastPass = time.Now()
+		previous := backoff
+		backoff = nextDriftBackoff(backoff, runDriftCycle(ctx, rec, nc, js, localAZ, holder))
+		if backoff != previous {
+			slog.Info("reconcile/drift: requeue interval changed", "backoff_ms", otelsetup.Millis(backoff))
+		}
+		// The outcome is logged by the cycle, and an unconverged pass is a change
+		// of schedule rather than a failure of the loop.
+		return backoff, nil
 	}
 }
 
 // nextDriftBackoff returns the requeue backoff after a pass: zero once a pass
 // converges, otherwise the previous backoff tripled from driftBackoffBase and
-// held at DriftInterval. Tracked separately from the wait it produces, so a
-// backoff sitting at the cap is not mistaken for a converged loop and reset.
+// held at DriftInterval. Zero means no deadline, leaving a converged loop to the
+// resync rather than asking for a revisit it does not need.
 func nextDriftBackoff(current time.Duration, err error) time.Duration {
 	if !errors.Is(err, ErrPassIncomplete) {
 		return 0
@@ -75,16 +139,7 @@ func nextDriftBackoff(current time.Duration, err error) time.Duration {
 	return min(next, DriftInterval)
 }
 
-// driftWait is the gap before the next pass for a backoff; no backoff means a
-// full DriftInterval.
-func driftWait(backoff time.Duration) time.Duration {
-	if backoff <= 0 {
-		return DriftInterval
-	}
-	return backoff
-}
-
-// runDriftCycle is one tick body, split out so tests can drive it directly.
+// runDriftCycle is one pass body, split out so tests can drive it directly.
 // Returns the reconcile outcome so the caller can size the next wait; a cycle
 // this node did not win the election for returns nil.
 func runDriftCycle(ctx context.Context, rec Reconciler, nc *nats.Conn, js jetstream.JetStream, localAZ, holder string) error {

--- a/spinifex/network/reconcile/drift.go
+++ b/spinifex/network/reconcile/drift.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -55,10 +56,17 @@ func intentSource(js jetstream.JetStream) loop.Source {
 		buckets := make([]*kvstore.Bucket, 0, len(intentBuckets))
 		for _, name := range intentBuckets {
 			kv, err := js.KeyValue(ctx, name)
-			if err != nil {
-				slog.DebugContext(ctx, "reconcile/drift: intent bucket not available, skipping",
-					"bucket", name, "err", err)
+			switch {
+			case errors.Is(err, jetstream.ErrBucketNotFound):
+				// Nothing of this kind has ever been created here.
+				slog.DebugContext(ctx, "reconcile/drift: intent bucket absent, not watched",
+					"bucket", name)
 				continue
+			case err != nil:
+				// Reported rather than skipped: a blip is not evidence the bucket
+				// went away, and a partial list would have the caller tear down
+				// the watchers it left out.
+				return nil, fmt.Errorf("resolve intent bucket %s: %w", name, err)
 			}
 			// js is passed so a watcher whose stream was lost can reconnect;
 			// RecreateIfMissing stays false so that reconnect never creates.

--- a/spinifex/network/reconcile/drift.go
+++ b/spinifex/network/reconcile/drift.go
@@ -120,9 +120,11 @@ func driftPass(rec Reconciler, nc *nats.Conn, js jetstream.JetStream, localAZ, h
 		if wait := time.Until(lastPass.Add(driftBackoffBase)); wait > 0 {
 			return wait, nil
 		}
-		lastPass = time.Now()
 		previous := backoff
 		backoff = nextDriftBackoff(backoff, runDriftCycle(ctx, rec, nc, js, localAZ, holder))
+		// Stamped after the scan, not before: the floor is a gap between passes,
+		// and a pass slower than the floor would otherwise leave none at all.
+		lastPass = time.Now()
 		if backoff != previous {
 			slog.Info("reconcile/drift: requeue interval changed", "backoff_ms", otelsetup.Millis(backoff))
 		}

--- a/spinifex/network/reconcile/drift_test.go
+++ b/spinifex/network/reconcile/drift_test.go
@@ -1,6 +1,6 @@
 //test:in-package — the backoff ladder is unexported state (driftBackoffBase,
-//nextDriftBackoff, driftWait) and the tests drive runDriftCycle directly to
-//pin what DriftLoop does with its return value.
+//nextDriftBackoff) and the tests drive runDriftCycle directly to pin what
+//DriftLoop does with its return value.
 
 package reconcile
 
@@ -200,33 +200,30 @@ func TestRunDriftCycle_SkipsWhenNotElected(t *testing.T) {
 	}
 }
 
-// The ladder itself, as pure functions: exact gaps are asserted here because the
-// loop tests above run on compressed timings and can only prove ordering.
+// The ladder itself, as a pure function: exact gaps are asserted here because
+// the loop tests above run on compressed timings and can only prove ordering.
+// Zero is the converged value and means no deadline, which leaves the next pass
+// to the resync the loop configures at DriftInterval.
 func TestDrift_IncompletePassBacksOffThenResets(t *testing.T) {
 	incomplete := incompleteErr()
 	outcomes := []error{incomplete, incomplete, incomplete, incomplete, incomplete, incomplete, nil}
 
 	var backoff time.Duration
-	var waits []time.Duration
+	var got []time.Duration
 	for _, outcome := range outcomes {
 		backoff = nextDriftBackoff(backoff, outcome)
-		waits = append(waits, driftWait(backoff))
+		got = append(got, backoff)
 	}
 
 	want := []time.Duration{
 		5 * time.Second, 15 * time.Second, 45 * time.Second,
 		135 * time.Second, DriftInterval, DriftInterval, // capped, then held
-		DriftInterval, // converged: back to the routine interval
+		0, // converged: no deadline, the resync takes over
 	}
 	for i := range want {
-		if waits[i] != want[i] {
-			t.Fatalf("wait after pass %d = %v, want %v (full sequence %v)", i+1, waits[i], want[i], waits)
+		if got[i] != want[i] {
+			t.Fatalf("backoff after pass %d = %v, want %v (full sequence %v)", i+1, got[i], want[i], got)
 		}
-	}
-	// The cap and the reset produce the same wait, so pin the state behind it:
-	// a converged pass must clear the backoff, not sit at the cap.
-	if backoff != 0 {
-		t.Errorf("backoff after a converged pass = %v, want 0", backoff)
 	}
 }
 
@@ -246,9 +243,6 @@ func TestDrift_NonIncompleteOutcomesKeepDriftInterval(t *testing.T) {
 			// Start from a backoff already in force, so a reset is observable.
 			if got := nextDriftBackoff(45*time.Second, tt.err); got != 0 {
 				t.Errorf("nextDriftBackoff(45s, %v) = %v, want 0", tt.err, got)
-			}
-			if got := driftWait(0); got != DriftInterval {
-				t.Errorf("driftWait(0) = %v, want %v", got, DriftInterval)
 			}
 		})
 	}

--- a/spinifex/network/reconcile/drift_watch_test.go
+++ b/spinifex/network/reconcile/drift_watch_test.go
@@ -1,0 +1,213 @@
+//test:in-package — intentSource, intentBuckets and driftBackoffBase are
+//unexported, and the point of these tests is what the loop watches rather than
+//what it does once woken.
+
+package reconcile
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	handlers_ec2_igw "github.com/mulgadc/spinifex/spinifex/handlers/ec2/igw"
+	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// createIntentBucket makes one intent bucket the way its owning handler would,
+// so a test can write to it and have the source find it.
+func createIntentBucket(t *testing.T, js jetstream.JetStream, name string) jetstream.KeyValue {
+	t.Helper()
+	kv, err := kvutil.GetOrCreateBucket(t.Context(), js, name, 1)
+	if err != nil {
+		t.Fatalf("create bucket %s: %v", name, err)
+	}
+	return kv
+}
+
+// bucketNames is what intentSource resolved this cycle.
+func bucketNames(t *testing.T, js jetstream.JetStream) []string {
+	t.Helper()
+	buckets, err := intentSource(js).Buckets(t.Context())
+	if err != nil {
+		t.Fatalf("enumerate intent buckets: %v", err)
+	}
+	names := make([]string, 0, len(buckets))
+	for _, b := range buckets {
+		names = append(names, b.Name())
+	}
+	return names
+}
+
+// streamExists reports whether the KV bucket's backing stream is present, which
+// is how a test tells "watched" from "created by being watched".
+func streamExists(t *testing.T, js jetstream.JetStream, name string) bool {
+	t.Helper()
+	_, err := js.Stream(t.Context(), "KV_"+name)
+	return err == nil
+}
+
+// The whole point of the conversion: a write to an intent bucket must reach the
+// loop long before DriftInterval, because that write is the repair signal a
+// dropped vpc.* event would otherwise leave for the next scan.
+func TestDriftLoop_IntentWriteWakesAPass(t *testing.T) {
+	_, nc, js := testutil.StartTestJetStream(t)
+	kv := createIntentBucket(t, js, handlers_ec2_vpc.KVBucketVPCs)
+	// The interval is long so a pass can only have come from the watch, and the
+	// floor is short so the write is not merely deferred behind it.
+	shrinkDriftTiming(t, time.Minute, time.Millisecond)
+
+	rec := &stubReconciler{outcomes: []error{nil}}
+	startDriftLoop(t, rec, nc, nil)
+
+	// After the startup seed the loop is armed at DriftInterval alone, so the
+	// watch has to be what brings the pass forward.
+	time.Sleep(200 * time.Millisecond)
+	if got := rec.callCount(); got != 0 {
+		t.Fatalf("reconcile ran %d times before any write, want 0", got)
+	}
+
+	if _, err := kv.Put(t.Context(), "vpc-watch-1", []byte(`{"VpcId":"vpc-watch-1"}`)); err != nil {
+		t.Fatalf("write intent: %v", err)
+	}
+	if got := waitForCalls(t, rec, 1, 5*time.Second); got < 1 {
+		t.Fatal("an intent write did not wake a pass within 5s, so the loop is " +
+			"still waiting out DriftInterval rather than watching the bucket")
+	}
+}
+
+// A burst is one pass, not one per key: the debounce coalesces it and the floor
+// keeps a launch storm from turning a five-minute OVN scan into a running one.
+func TestDriftLoop_BurstOfWritesIsOnePass(t *testing.T) {
+	_, nc, js := testutil.StartTestJetStream(t)
+	kv := createIntentBucket(t, js, handlers_ec2_vpc.KVBucketENIs)
+	shrinkDriftTiming(t, time.Minute, 2*time.Second)
+
+	rec := &stubReconciler{outcomes: []error{nil}}
+	startDriftLoop(t, rec, nc, nil)
+
+	for i := range 20 {
+		if _, err := kv.Put(t.Context(), "eni-burst-"+strconv.Itoa(i), []byte(`{}`)); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	if got := waitForCalls(t, rec, 1, 5*time.Second); got < 1 {
+		t.Fatal("a burst of intent writes never woke a pass")
+	}
+	// Well inside the 2s floor, so a second pass here could only come from the
+	// loop tracking writes rather than coalescing them.
+	time.Sleep(500 * time.Millisecond)
+	if got := rec.callCount(); got != 1 {
+		t.Errorf("reconcile ran %d times for one burst of 20 writes, want 1", got)
+	}
+}
+
+// Watching must not create. These buckets belong to the EC2 handlers, which set
+// their history depth; a bucket vpcd created first would fix the wrong depth in
+// place, and the handler's own get-or-create would then return it rather than
+// correct it.
+func TestIntentSource_DoesNotCreateMissingBuckets(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+
+	if got := bucketNames(t, js); len(got) != 0 {
+		t.Fatalf("intentSource resolved %v against an empty JetStream, want none", got)
+	}
+	for _, name := range intentBuckets {
+		if streamExists(t, js, name) {
+			t.Errorf("bucket %s exists after enumeration, want it left absent", name)
+		}
+	}
+}
+
+// A cluster that has never had an IGW has no IGW bucket, so the source has to
+// pick one up when it appears rather than only at startup. That is why it is a
+// Dynamic source: JetStream has no bucket-created event, so discovery rides the
+// resync.
+func TestIntentSource_PicksUpABucketThatAppearsLater(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	createIntentBucket(t, js, handlers_ec2_vpc.KVBucketVPCs)
+
+	if got := bucketNames(t, js); len(got) != 1 || got[0] != handlers_ec2_vpc.KVBucketVPCs {
+		t.Fatalf("intentSource resolved %v, want just %s", got, handlers_ec2_vpc.KVBucketVPCs)
+	}
+
+	createIntentBucket(t, js, handlers_ec2_igw.KVBucketIGW)
+	got := bucketNames(t, js)
+	if len(got) != 2 {
+		t.Fatalf("intentSource resolved %v after a second bucket appeared, want both", got)
+	}
+}
+
+// bucketConstants is every handler KV bucket constant referenced by a file.
+func bucketConstants(t *testing.T, path string) map[string]struct{} {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := map[string]struct{}{}
+	for _, m := range regexp.MustCompile(`handlers_ec2_\w+\.KVBucket\w+`).FindAllString(string(src), -1) {
+		out[m] = struct{}{}
+	}
+	return out
+}
+
+// Every bucket LoadIntentFromKV reads must be watched, or a change to it waits
+// out the resync while every other kind of change is repaired in seconds. The
+// two lists are compared at the source rather than by name, so a load added to
+// intent.go and not to intentBuckets fails here instead of going quiet.
+func TestIntentSource_CoversEveryBucketTheIntentLoadReads(t *testing.T) {
+	read := bucketConstants(t, "intent.go")
+	if len(read) == 0 {
+		t.Fatal("no bucket constants found in intent.go — the scan is not matching what it should")
+	}
+	watched := bucketConstants(t, "drift.go")
+	for name := range read {
+		if _, ok := watched[name]; !ok {
+			t.Errorf("%s is read by LoadIntentFromKV but absent from intentBuckets, "+
+				"so a change to it is only repaired on the resync", name)
+		}
+	}
+}
+
+// The floor is what stops a busy cluster scanning continuously, so it is pinned
+// on the pass rather than inferred from the loop's timing.
+func TestDriftPass_FloorsTheChangeDrivenRate(t *testing.T) {
+	_, nc, js := testutil.StartTestJetStream(t)
+	shrinkDriftTiming(t, time.Minute, time.Hour)
+
+	rec := &stubReconciler{outcomes: []error{nil}}
+	pass := driftPass(rec, nc, js, "us-east-1a", "node-1", nil)
+
+	// The seed pass does no work: the bootstrap ReconcileApplyOnly was the
+	// startup scan and this one must not repeat it.
+	if revisit, err := pass(t.Context()); err != nil || revisit != 0 {
+		t.Fatalf("seed pass = (%v, %v), want (0, nil) for a converged startup", revisit, err)
+	}
+	if got := rec.callCount(); got != 0 {
+		t.Fatalf("seed pass ran reconcile %d times, want 0", got)
+	}
+
+	if _, err := pass(t.Context()); err != nil {
+		t.Fatalf("first real pass: %v", err)
+	}
+	if got := rec.callCount(); got != 1 {
+		t.Fatalf("reconcile ran %d times, want 1", got)
+	}
+
+	revisit, err := pass(t.Context())
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if got := rec.callCount(); got != 1 {
+		t.Errorf("reconcile ran %d times inside the floor, want it deferred to 1", got)
+	}
+	if revisit <= 0 || revisit > driftBackoffBase {
+		t.Errorf("deferred pass asked to be revisited in %v, want a positive wait "+
+			"no longer than the floor (%v)", revisit, driftBackoffBase)
+	}
+}

--- a/spinifex/network/reconcile/drift_watch_test.go
+++ b/spinifex/network/reconcile/drift_watch_test.go
@@ -43,6 +43,28 @@ func bucketNames(t *testing.T, js jetstream.JetStream) []string {
 	return names
 }
 
+// waitForWatch writes probe keys until one of them wakes a pass, and returns the
+// call count once it has. Watchers attach asynchronously and are UpdatesOnly, so
+// a single write racing startup is lost for good; retrying is what makes a test
+// that needs a live watcher deterministic rather than dependent on how fast the
+// machine got there.
+func waitForWatch(t *testing.T, rec *stubReconciler, kv jetstream.KeyValue, prefix string) int {
+	t.Helper()
+	before := rec.callCount()
+	deadline := time.Now().Add(10 * time.Second)
+	for i := 0; time.Now().Before(deadline); i++ {
+		if _, err := kv.Put(t.Context(), prefix+strconv.Itoa(i), []byte(`{}`)); err != nil {
+			t.Fatalf("probe write %d: %v", i, err)
+		}
+		if got := waitForCalls(t, rec, before+1, 250*time.Millisecond); got > before {
+			return got
+		}
+	}
+	t.Fatal("no intent write woke a pass within 10s, so the loop is still waiting " +
+		"out DriftInterval rather than watching the bucket")
+	return 0
+}
+
 // streamExists reports whether the KV bucket's backing stream is present, which
 // is how a test tells "watched" from "created by being watched".
 func streamExists(t *testing.T, js jetstream.JetStream, name string) bool {
@@ -71,13 +93,8 @@ func TestDriftLoop_IntentWriteWakesAPass(t *testing.T) {
 		t.Fatalf("reconcile ran %d times before any write, want 0", got)
 	}
 
-	if _, err := kv.Put(t.Context(), "vpc-watch-1", []byte(`{"VpcId":"vpc-watch-1"}`)); err != nil {
-		t.Fatalf("write intent: %v", err)
-	}
-	if got := waitForCalls(t, rec, 1, 5*time.Second); got < 1 {
-		t.Fatal("an intent write did not wake a pass within 5s, so the loop is " +
-			"still waiting out DriftInterval rather than watching the bucket")
-	}
+	// Well inside DriftInterval, so the pass can only have come from the write.
+	waitForWatch(t, rec, kv, "vpc-watch-")
 }
 
 // A burst is one pass, not one per key: the debounce coalesces it and the floor
@@ -90,18 +107,22 @@ func TestDriftLoop_BurstOfWritesIsOnePass(t *testing.T) {
 	rec := &stubReconciler{outcomes: []error{nil}}
 	startDriftLoop(t, rec, nc, nil)
 
+	// The burst has to land on a watcher that is already attached, or the writes
+	// it is meant to coalesce are simply never seen.
+	base := waitForWatch(t, rec, kv, "eni-probe-")
+
 	for i := range 20 {
 		if _, err := kv.Put(t.Context(), "eni-burst-"+strconv.Itoa(i), []byte(`{}`)); err != nil {
 			t.Fatalf("write %d: %v", i, err)
 		}
 	}
-	if got := waitForCalls(t, rec, 1, 5*time.Second); got < 1 {
+	if got := waitForCalls(t, rec, base+1, 10*time.Second); got < base+1 {
 		t.Fatal("a burst of intent writes never woke a pass")
 	}
-	// Well inside the 2s floor, so a second pass here could only come from the
+	// The burst is long spent, so a further pass here could only come from the
 	// loop tracking writes rather than coalescing them.
 	time.Sleep(500 * time.Millisecond)
-	if got := rec.callCount(); got != 1 {
+	if got := rec.callCount() - base; got != 1 {
 		t.Errorf("reconcile ran %d times for one burst of 20 writes, want 1", got)
 	}
 }


### PR DESCRIPTION
## `DriftLoop` is the only thing that reconciles OVN against KV intent, and it ran on a fixed 5-minute timer

The fast path for a VPC change is the event subscriber: `vpc.create-port`, `vpc.create-sg`, `vpc.add-nat` and the rest are applied to OVN as they arrive. `DriftLoop` is the repair path for what that misses — a dropped event, a vpcd restart mid-apply, an apply that failed and logged. That repair waited on the next 300s tick of whichever of the three nodes ticked next — measured on env19 below at a median of 34s and a mean of 71s, with a worst case of 173s.

**So this is a repair-path win, not a general latency win.** Worth saying first, because "event-driven vpcd" reads as though VPC operations get faster, and they do not. It is the same finding the DNS pilot landed on and it is stated the same way.

This is the last loop named in the Approach on `mulga-bw2cw`. RDS #948, EKS #952, ECS #956 preceded it.

### Why a watch is safe here, where it was not for ECS

ECS deliberately did **not** get a KV watch: its account bucket takes a heartbeat write per container instance per 30s and the instance key is a single NATS subject token, so no filter could exclude them and wake-ups would have scaled with the fleet. Neither problem exists here, and I checked both rather than assuming.

**No periodic writer.** Every writer of the eight intent buckets is an EC2 API handler — `handlers/ec2/{vpc,igw,eip,natgw,routetable}` plus `handlers/ec2/vpc/security_group.go`. No heartbeat, no lease renewal, no status refresh. A write to one of them *is* an intent change.

**No self-trigger.** The reconcile path writes OVN, never KV: the only mutations under `network/reconcile/` are `ovn.UpdateDHCPOptionsOptions` and `ovn.UpdatePortGroupMemberships`. A pass cannot wake itself, which is the feedback loop a watch over a bucket the pass writes would create.

### The floor is the one thing this adds rather than removes

A vpcd pass loads intent from eight buckets and scans the OVN NB DB. `reconciler`'s debounce is bounded by `maxDebounce` at 2s, so a continuously-written bucket — ENIs under a launch storm — produces a pass every 250ms to 2s. Against one pass per 300s that is up to a 1200x increase in full-scan rate on whichever node holds the lock.

The floor is `driftBackoffBase`, the same 5s the ladder already uses for its fastest retry, so the loop has one stated maximum rate rather than two. A pass deferred by the floor returns the remaining time as its deadline, which is always sooner than any live backoff, so nothing pending is dropped. Repair latency becomes the debounce plus at most the floor, instead of the tens of seconds measured below.

### Watching must not create

`reconciler.Fixed` takes a `*kvstore.Bucket`, and `Bucket.KV` is get-or-create on first use. Watching a bucket that does not exist yet would have vpcd create it at vpcd's history depth, not the owning handler's — `KVBucketENIs` is created by `handlers/ec2/vpc` with history 10, and a vpcd-created one would default to 1, which the handler's later get-or-create would then return rather than correct.

So the source enumerates with `js.KeyValue` and skips what is absent, wrapping each live handle in `kvstore.NewOpenBucket(js, kv, …)`. Passing `js` lets a watcher whose stream was lost reconnect; leaving `RecreateIfMissing` false means that reconnect can never create. A bucket that appears later is picked up on the next resync, which is the `Dynamic` contract. This also matches `LoadIntentFromKV`'s own tolerance — it already treats a missing bucket as empty.

### The startup pass is the bootstrap pass, not a second one

`reconciler.Run` always runs a pass at startup, and vpcd has already run one by then: the leader-gated `ReconcileApplyOnly` in `launchService`, whose outcome arrives as `startup`. A second immediate pass would be the "additional serial retrofit pass" ADR-0006 S9 exists to forbid, and would break the existing guarantee that a clean boot does not pull a scan forward.

So the loop's first pass does no work and returns the seed deadline instead:

| `startup` | Deadline | Effect |
| --- | --- | --- |
| converged | 0 — none | next pass at the resync, a full `DriftInterval`. Unchanged |
| incomplete | `driftBackoffBase` | first pass at 5s. Unchanged |

`driftWait` is gone with it: "no backoff means a full `DriftInterval`" is now `Resync: DriftInterval`, and returning `DriftInterval` as a deadline *as well* would arm the revisit timer alongside the resync ticker and run two passes for one due date.

`vpcd/vpcd.go` is untouched — the exported signature does not change.

### Tests

Everything that pinned the old behaviour stays green unmodified, which is the point: `TestDriftLoop_ConvergedStartupWaitsFullInterval`, `TestDriftLoop_SeedsBackoffFromStartupOutcome`, `TestDriftLoop_IncompletePassRequeuesFast`, `TestDriftLoop_ConvergedPassReturnsToDriftInterval`, both `TestRunDriftCycle_*`, and the ADR-0006 invariants `TestL1_ReconcilerConverges`, `TestL2_DriftIntervalBounded`, `TestS9_SingleReconcilerNoRetrofitPasses`. The two ladder tests changed only where they asserted through the deleted `driftWait`.

New, in `drift_watch_test.go`, and each one checked for vacuity by breaking the thing it covers:

| Test | Fails as | With |
| --- | --- | --- |
| `IntentWriteWakesAPass` | `Sources: nil` | "an intent write did not wake a pass within 5s" |
| `BurstOfWritesIsOnePass` | `Sources: nil` | "a burst of intent writes never woke a pass" |
| `FloorsTheChangeDrivenRate` | floor disabled | "reconcile ran 2 times inside the floor, want it deferred to 1" |

Plus `DoesNotCreateMissingBuckets`, `PicksUpABucketThatAppearsLater`, and `CoversEveryBucketTheIntentLoadReads` — the last compares the bucket constants referenced by `intent.go` against those in `drift.go` at the source, so a load added to one and not the other fails here rather than going quiet on resync-only repair.

`make preflight` passes.

### env19 verification, on a cleaned cluster

Three-node env19, emptied first — no instances, no ENIs, no volumes, one default security group — because the first attempt was measuring something else entirely (see below). Baseline is `dev` `d02863792`; branch is `192543979`. An intent write is `ec2 create-security-group`. Both timestamps are server-side and from the same journals: `subscribers: created security group` to the `kvlease: elected` line every pass emits before it scans. That avoids the ~1.65s the `aws` CLI itself takes, which is larger than the entire branch measurement.

| | n | min | median | max | mean |
| --- | --- | --- | --- | --- | --- |
| baseline `d02863792` | 9 | 25.35s | 77.92s | 137.91s | 75.28s |
| this branch | 12 | **0.24s** | **0.24s** | **0.24s** | **0.24s** |

**Every branch sample is 0.24s to two decimal places** — the 250ms debounce, and nothing else. There is no spread to report because there is no spread: the pass fires before `create-security-group` has even returned to the caller. Pass duration on the clean cluster is 0.22-0.30s, median 0.27s.

**The baseline is not the uniform 0-300s I assumed when writing the plan.** Each node runs its own 300s timer at its own phase offset and they never collide on an idle cluster, so a change is repaired by whichever of the three ticks next. Per-node cadence measured 309.4s, 309.5s, 309.4s — the interval plus the pass.

Median 77.9s to 0.24s is a 325x reduction on the repair path.

**Idle cost is unchanged.** Over a 770s window on the same clean cluster with no intent writes at all, the three nodes ran 3, 3 and 2 passes — 2.6 per node, exactly the 300s resync — and logged zero `not leader, skipping reconcile`. So the watch adds no idle work and does not make the three nodes contend; it only removes the wait when something actually changes.

### What the first attempt measured, and why the cluster had to be emptied

Worth recording, because the first numbers looked like the change had failed.

env19 still held leftovers from the ECS and RDS work: three instances, two of them stopped. A stopped instance keeps its ENI and its auto-assigned public IP, so `reconcile/apply` kept trying to bring up a guest port SB binding for a VM with no tap — five retries at 5s, then `guest port datapath did not converge`. Pass duration was bimodal: **20 passes at 0.31-0.37s and 12 at 45.6s.**

With a 300s ticker that stall is paid rarely. Woken on every intent change, the loop hits it often, and because `reconciler.Run` serialises passes, every subsequent write queues behind a 45s scan. Measured repair latency came out at 22-28s medians — a number about the stall, not about this change.

That is filed as `mulga-xm0y3` and is not caused by this PR, but it is a real interaction worth stating: **on a cluster where a reconcile pass stalls, waking more often multiplies the exposure.** The 5s floor does not help, because it is shorter than the stall.

### Three fixes found after the first push

All are follow-up commits on this branch rather than the original design:

- **A per-bucket resolve failure was a skip**, which drops the bucket from the enumerated set and has the reconciler tear its watcher down until the next resync. Only a genuine `ErrBucketNotFound` is a skip now; anything else fails the enumeration, which is what tells the caller to keep the watchers it already has.
- **The floor was stamped before the scan rather than after**, so a pass slower than the floor left no gap behind it at all. On this env, with 45s passes against a 5s floor, that is the difference between a floor and no floor.
- **Two of the new tests raced watcher startup** and failed in CI while passing locally. Watchers attach asynchronously and are `UpdatesOnly`, so a write that beats the attach is lost for good rather than replayed. Both now probe until a write demonstrably wakes a pass, then make the assertion. Verified 5x under CPU contention on two cores.

---

Plan: `docs/development/improvements/reconciler-vpcd-drift-watch.md`. Bead: `mulga-54iac`, under `mulga-bw2cw`.
