### PR TITLE
feat: add the e2e guest disk-performance gate

### DIFF
--- a/.github/scripts/suite-sets.sh
+++ b/.github/scripts/suite-sets.sh
@@ -57,6 +57,10 @@ e2e_suite_timeout() {
     # rds serialises its DB VMs behind a 4 GiB semaphore, so its wall clock is
     # set by how long it waits for the budget, not by how long a test runs.
     rds) echo "50m" ;;
+    # diskperf runs two 16 GiB fio profiles per repetition, each on a volume it
+    # creates first. One pass is ~20 minutes on the bare-metal cell and a
+    # baseline capture at SPINIFEX_DISKPERF_REPS=3 is three times that.
+    diskperf) echo "180m" ;;
     *) echo "30m" ;;
   esac
 }

--- a/.github/workflows/e2e-baremetal.yml
+++ b/.github/workflows/e2e-baremetal.yml
@@ -14,6 +14,21 @@ on:
         required: false
         type: string
         default: ""
+      suites:
+        description: "Space-separated e2e suites to run on the node. Default is the correctness set; a performance caller names its own so its numbers come off an otherwise idle cell"
+        required: false
+        type: string
+        default: "single cert lb"
+      suite-env:
+        description: "Extra environment for the suite invocation, e.g. SPINIFEX_DISKPERF_REPS=3"
+        required: false
+        type: string
+        default: ""
+      cell:
+        description: "Nightly cell number this run reports as. Names the artifact bundle and the ES dimension, so two callers of this workflow stay distinguishable in the sink"
+        required: false
+        type: string
+        default: "20"
 
 permissions:
   contents: read
@@ -30,13 +45,14 @@ jobs:
   e2e_baremetal:
     name: Bare-Metal Single-Node E2E
     runs-on: [ self-hosted, ci-baremetal ]
-    timeout-minutes: 120
+    timeout-minutes: 240
     concurrency:
       group: e2e-baremetal-cluster
       cancel-in-progress: false
     env:
       BM_ISO_CACHE: /var/cache/spinifex-iso-builder
-      ARTIFACT_DIR: /tmp/spinifex-e2e-nightly-cell-20-${{ github.run_id }}
+      BM_CELL: ${{ inputs.cell || '20' }}
+      ARTIFACT_DIR: /tmp/spinifex-e2e-nightly-cell-${{ inputs.cell || '20' }}-${{ github.run_id }}
       # Caller-supplied (workflow_call input); empty for a manual
       # workflow_dispatch run, which bm-bootstrap.sh treats as "no attrs".
       SPINIFEX_OTEL_ATTRS: ${{ inputs.otel-attrs }}
@@ -126,9 +142,23 @@ jobs:
           BM_EPDU_ENV: ${{ runner.temp }}/epdu.env
           BM_UBUNTU_IMAGE: ${{ env.BM_ISO_CACHE }}/ubuntu-26.04-cloudimg-amd64.img
           SPX_EXTERNAL_POOL: ${{ env.SPINIFEX_CI_POOL }}
+          BM_SUITES: ${{ inputs.suites || 'single cert lb' }}
+          BM_SUITE_ENV: ${{ inputs.suite-env }}
         run: |
           mkdir -p "${ARTIFACT_DIR}"
           set -o pipefail
+          # Per-suite budgets are declared once in suite-sets.sh. The script
+          # applies one timeout to every suite in the list, so the widest wins.
+          . "${GITHUB_WORKSPACE}/.github/scripts/suite-sets.sh"
+          BM_TEST_TIMEOUT=""
+          for suite in ${BM_SUITES}; do
+            tmo="$(e2e_suite_timeout "${suite}")"
+            if [ -z "${BM_TEST_TIMEOUT}" ] || [ "${tmo%m}" -gt "${BM_TEST_TIMEOUT%m}" ]; then
+              BM_TEST_TIMEOUT="${tmo}"
+            fi
+          done
+          export BM_TEST_TIMEOUT
+          echo "suites=${BM_SUITES} test-timeout=${BM_TEST_TIMEOUT}"
           sudo -E mulga/scripts/baremetal/run-baremetal-e2e.sh \
             --vmlinuz   "${BM_ISO_CACHE}/vmlinuz" \
             --initrd    "${BM_ISO_CACHE}/initrd.img" \
@@ -151,7 +181,7 @@ jobs:
         uses: ./.github/actions/junit-to-es
         with:
           junit-glob: ${{ env.ARTIFACT_DIR }}/junit-*.xml
-          cell: "20"
+          cell: ${{ env.BM_CELL }}
 
       - name: Analyze e2e failures
         if: always()
@@ -159,12 +189,12 @@ jobs:
         with:
           junit-glob: ${{ env.ARTIFACT_DIR }}/junit-*.xml
           log-dir: ${{ env.ARTIFACT_DIR }}
-          title: "E2E failure analysis (cell 20)"
+          title: "E2E failure analysis (cell ${{ env.BM_CELL }})"
 
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: e2e-artifacts-cell-20-${{ github.run_id }}
+          name: e2e-artifacts-cell-${{ env.BM_CELL }}-${{ github.run_id }}
           path: ${{ env.ARTIFACT_DIR }}
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/e2e-baremetal.yml
+++ b/.github/workflows/e2e-baremetal.yml
@@ -109,6 +109,10 @@ jobs:
           ssh-keygen -y -f "${RUNNER_TEMP}/bm-ci" > "${RUNNER_TEMP}/bm-ci.pub"
 
       - name: Build Artifacts
+        env:
+          # The node runs pre-built binaries, so a suite absent here cannot be
+          # selected later. Same list as the run step for that reason.
+          BM_SUITES: ${{ inputs.suites || 'single cert lb' }}
         run: |
           mulga/scripts/baremetal/bm-build-artifacts.sh \
             "$GITHUB_WORKSPACE" \

--- a/.github/workflows/e2e-baremetal.yml
+++ b/.github/workflows/e2e-baremetal.yml
@@ -1,7 +1,26 @@
 name: E2E Bare-Metal
 
 on:
+  # Mirrors the suite selection of workflow_call so a baseline capture can be
+  # driven by hand. A dispatch run sees only the inputs declared here, so
+  # omitting these would silently fall back to the correctness set.
   workflow_dispatch:
+    inputs:
+      suites:
+        description: "Space-separated e2e suites to run on the node. Default is the correctness set; a performance run names its own so its numbers come off an otherwise idle cell"
+        required: false
+        type: string
+        default: "single cert lb"
+      suite-env:
+        description: "Extra environment for the suite invocation, e.g. SPINIFEX_DISKPERF_REPS=3"
+        required: false
+        type: string
+        default: ""
+      cell:
+        description: "Nightly cell number this run reports as. Names the artifact bundle and the ES dimension, so two callers of this workflow stay distinguishable in the sink"
+        required: false
+        type: string
+        default: "20"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       cells:
-        description: "Comma-separated cell numbers to run, no spaces (blank = all). 1-3, 8-10, 17-19 tofu permutation matrix, 20 baremetal, 21-22 ISO, 23 predastore throughput, 24 predastore fault injection, 25-27 service suites (eks, ecs, rds)"
+        description: "Comma-separated cell numbers to run, no spaces (blank = all). 1-3, 8-10, 17-19 tofu permutation matrix, 20 baremetal, 21-22 ISO, 23 predastore throughput, 24 predastore fault injection, 25-27 service suites (eks, ecs, rds), 28 guest disk performance"
         required: false
 
 permissions:
@@ -627,6 +627,34 @@ jobs:
       # above, matrix.cell) for free — cell-20 needs its own attrs string.
       # There's no matrix leg here, just the one fixed baremetal cell.
       otel-attrs: ci.run_id=${{ github.run_id }},ci.workflow=${{ github.workflow }},ci.cell=20,ci.matrix=baremetal/pxe/real-hw
+    secrets: inherit
+
+  # The guest disk-performance gate. Same bare-metal node as cell 20 and
+  # therefore queued behind it by the shared concurrency group, which is the
+  # point: perf numbers off a cell still running other suites are noise, and
+  # the availability assertions measure host responsiveness under a single
+  # tenant's load, which a co-tenant correctness suite would confound.
+  #
+  # It reimages the cluster first, like every other caller of that workflow, so
+  # it is a fresh node rather than whatever cell-20 left behind.
+  diskperf:
+    name: cell-28 (baremetal/diskperf)
+    needs: baremetal
+    if: >-
+      always() && (
+        github.event_name == 'schedule' ||
+        inputs.cells == '' ||
+        contains(format(',{0},', inputs.cells), ',28,')
+      )
+    permissions:
+      contents: read
+      statuses: write
+    uses: ./.github/workflows/e2e-baremetal.yml
+    with:
+      ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref_name }}
+      cell: "28"
+      suites: diskperf
+      otel-attrs: ci.run_id=${{ github.run_id }},ci.workflow=${{ github.workflow }},ci.cell=28,ci.matrix=baremetal/pxe/diskperf
     secrets: inherit
 
   # ISO cells. Unlike 1-19 these need no tofu: the harnesses run QEMU directly

--- a/Makefile
+++ b/Makefile
@@ -163,9 +163,13 @@ test-build-scripts:
 # E2E harness unit tests. Build-tagged `e2e` so they're skipped by the
 # default `go test ./spinifex/...`. Runs with mocked AWS clients — no
 # infrastructure required, safe to run in CI without a cluster.
+#
+# diskperf/ is here for the same reason: its baseline comparison and probe
+# accounting decide whether the disk-performance gate passes, and that
+# arithmetic has to be covered off-cluster or the gate is trusted untested.
 test-harness:
 	@echo -e "\n....Running e2e harness unit tests...."
-	$(_Q)LOG_IGNORE=1 go test -tags=e2e -timeout 60s ./tests/e2e/harness/... $(_RACEQ)
+	$(_Q)LOG_IGNORE=1 go test -tags=e2e -timeout 60s ./tests/e2e/harness/... ./tests/e2e/diskperf/... $(_RACEQ)
 
 # In-process integration tier: the real gateway router against embedded NATS
 # JetStream, with only the daemon-side NATS subjects stubbed.

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -18,9 +18,9 @@ SUITE_TAG   ?= $(notdir $(patsubst %/...,%,$(firstword $(PKG))))
 # BIN_DIR/<suite>.test so CI can ship binaries (not source + go toolchain) to
 # the remote VM.
 BIN_DIR      ?= $(CURDIR)/_bin
-SUITES_BUILD ?= cert lb eks ecs single iam ecr bedrock gpu natuplink multinode storagegrowth partialblock rds quota
+SUITES_BUILD ?= cert lb eks ecs single iam ecr bedrock gpu natuplink multinode storagegrowth partialblock rds quota diskperf
 
-.PHONY: e2e e2e-quota e2e-cert e2e-lb e2e-eks e2e-ecs e2e-single e2e-iam e2e-ecr e2e-bedrock e2e-multinode e2e-bm e2e-reboot e2e-tofu e2e-gpu e2e-natuplink e2e-storagegrowth e2e-partialblock e2e-rds e2e-all clean e2e-build
+.PHONY: e2e e2e-quota e2e-cert e2e-lb e2e-eks e2e-ecs e2e-single e2e-iam e2e-ecr e2e-bedrock e2e-multinode e2e-bm e2e-reboot e2e-tofu e2e-gpu e2e-natuplink e2e-storagegrowth e2e-partialblock e2e-diskperf e2e-rds e2e-all clean e2e-build
 
 RUN_FLAG = $(if $(RUN),-run '$(RUN)',)
 
@@ -57,9 +57,12 @@ e2e-gpu:        ; $(MAKE) e2e PKG=./gpu/...
 e2e-natuplink:  ; $(MAKE) e2e PKG=./natuplink/...
 e2e-storagegrowth: ; $(MAKE) e2e PKG=./storagegrowth/...
 e2e-partialblock:  ; $(MAKE) e2e PKG=./partialblock/...
-# The only suite with its own budget: one instance's `available` wait is 23
-# minutes, so a single wedged create eats most of a 30m package timeout before
-# the tests still running get to report.
+# Two 16 GiB fio profiles per repetition, each on a freshly created volume, so
+# a pass is ~20 minutes on the bare-metal cell. CI resolves the same budget
+# from e2e_suite_timeout in .github/scripts/suite-sets.sh.
+e2e-diskperf:      ; $(MAKE) e2e PKG=./diskperf/... TIMEOUT=180m
+# One instance's `available` wait is 23 minutes, so a single wedged create eats
+# most of a 30m package timeout before the tests still running get to report.
 e2e-rds:        ; $(MAKE) e2e PKG=./rds/... TIMEOUT=45m
 e2e-quota:      ; $(MAKE) e2e PKG=./quota/...
 e2e-all:        ; $(MAKE) e2e

--- a/tests/e2e/diskperf/availability.go
+++ b/tests/e2e/diskperf/availability.go
@@ -1,0 +1,206 @@
+//go:build e2e
+
+package diskperf
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+)
+
+// Availability bounds. These are ceilings on a responsiveness probe, not
+// latency targets: a healthy probe answers in milliseconds and a starved one
+// never answers at all, so the exact value between those two matters little and
+// the bound is set to leave the healthy case orders of magnitude of headroom.
+const (
+	// guestProbeBound covers a fresh SSH handshake plus a stat, which costs a
+	// few hundred milliseconds on an idle guest.
+	guestProbeBound = 15 * time.Second
+	// hostProbeBound covers a TCP connect and an SSH banner read on the host,
+	// which is sub-millisecond on the local network.
+	hostProbeBound = 5 * time.Second
+
+	// probeInterval is the gap between successive probes. Frequent enough to
+	// catch a stall that resolves inside a minute, sparse enough that the
+	// probes themselves are not part of the workload.
+	probeInterval = 5 * time.Second
+)
+
+// probe is one repeated responsiveness check running alongside a workload.
+type probe struct {
+	// Name identifies the probe in failure output.
+	Name string
+	// Bound is the ceiling a single attempt must answer within.
+	Bound time.Duration
+	// Attempt performs one check. It must return promptly on failure rather
+	// than block, since exceeding Bound is itself the signal.
+	Attempt func() error
+}
+
+// probeReport is what one probe observed across a workload.
+type probeReport struct {
+	Name     string
+	Samples  int
+	Failures int
+	Max      time.Duration
+	// FirstFailure is the earliest breach, kept because the first one carries
+	// the cause and later ones are usually consequences of it.
+	FirstFailure error
+	// FirstFailureAt is measured from the start of the watch.
+	FirstFailureAt time.Duration
+}
+
+// ok reports whether every sample answered inside the bound.
+func (r probeReport) ok() bool { return r.Failures == 0 && r.Samples > 0 }
+
+// summary renders the report for test output.
+func (r probeReport) summary() string {
+	return fmt.Sprintf("%s: %d samples, %d over bound, max %s", r.Name, r.Samples, r.Failures, r.Max.Round(time.Millisecond))
+}
+
+// probeRecords renders the reports for the result artifact. FirstFailure is an
+// error and does not marshal, so it is flattened to its message.
+func probeRecords(reports []probeReport) []map[string]any {
+	out := make([]map[string]any, 0, len(reports))
+	for _, r := range reports {
+		rec := map[string]any{
+			"name":       r.Name,
+			"samples":    r.Samples,
+			"over_bound": r.Failures,
+			"max_ms":     r.Max.Milliseconds(),
+		}
+		if r.FirstFailure != nil {
+			rec["first_failure"] = r.FirstFailure.Error()
+			rec["first_failure_at_s"] = int(r.FirstFailureAt.Seconds())
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// watch runs every probe on its own goroutine until stop is closed, and
+// returns what each observed. Probes run concurrently with each other and with
+// the workload; each holds its own connection, so one blocking does not
+// serialise the rest.
+func watch(probes []probe, stop <-chan struct{}) []probeReport {
+	reports := make([]probeReport, len(probes))
+	var wg sync.WaitGroup
+	origin := time.Now()
+
+	for i, p := range probes {
+		wg.Add(1)
+		go func(i int, p probe) {
+			defer wg.Done()
+			rep := probeReport{Name: p.Name}
+			for {
+				select {
+				case <-stop:
+					reports[i] = rep
+					return
+				default:
+				}
+
+				started := time.Now()
+				err := p.Attempt()
+				elapsed := time.Since(started)
+				rep.Samples++
+				if elapsed > rep.Max {
+					rep.Max = elapsed
+				}
+				if err != nil || elapsed > p.Bound {
+					rep.Failures++
+					if rep.FirstFailure == nil {
+						rep.FirstFailure = failureCause(err, elapsed, p.Bound)
+						rep.FirstFailureAt = started.Sub(origin)
+					}
+				}
+
+				select {
+				case <-stop:
+					reports[i] = rep
+					return
+				case <-time.After(probeInterval):
+				}
+			}
+		}(i, p)
+	}
+	wg.Wait()
+	return reports
+}
+
+// failureCause distinguishes a probe that answered too late from one that did
+// not answer at all. The two have different causes and the message has to say
+// which was seen.
+func failureCause(err error, elapsed, bound time.Duration) error {
+	if err != nil {
+		return fmt.Errorf("failed after %s: %w", elapsed.Round(time.Millisecond), err)
+	}
+	return fmt.Errorf("answered in %s, over the %s bound", elapsed.Round(time.Millisecond), bound)
+}
+
+// guestProbe checks that the guest still services ordinary I/O on its root
+// volume while the workload runs on a different volume. Reading the root
+// deliberately targets a volume the job never touches, so a breach is evidence
+// that one volume's workload degrades another rather than merely that the job
+// is slow.
+//
+// The command is a directory read and a stat of the root filesystem: the
+// original symptom was `ls` and tab-completion freezing outright, not a
+// measurable slowdown.
+func guestProbe(tgt harness.SSHTarget) probe {
+	return probe{
+		Name:  "guest responsiveness (root volume)",
+		Bound: guestProbeBound,
+		Attempt: func() error {
+			out, err := harness.GuestExecTimeout(tgt, "stat -f / >/dev/null && ls -1 /usr/bin >/dev/null", guestProbeBound)
+			if err != nil {
+				return fmt.Errorf("%w\n%s", err, out)
+			}
+			return nil
+		},
+	}
+}
+
+// hostProbe checks that the host's own sshd still accepts a connection and
+// speaks first. The original blocker escaped the guest and made SSH to the host
+// fail, so this is the assertion that the blast radius stays inside the tenant.
+//
+// A banner read rather than a full authentication: it needs no credential, and
+// receiving the banner already proves the kernel completed a handshake and
+// scheduled sshd, which is exactly what a starved host cannot do.
+func hostProbe(addr string) probe {
+	return probe{
+		Name:  "host sshd (" + addr + ")",
+		Bound: hostProbeBound,
+		Attempt: func() error {
+			return readSSHBanner(addr, hostProbeBound)
+		},
+	}
+}
+
+// readSSHBanner dials addr and reads the SSH identification string the server
+// sends on connect.
+func readSSHBanner(addr string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return fmt.Errorf("set deadline: %w", err)
+	}
+	buf := make([]byte, 64)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return fmt.Errorf("read banner: %w", err)
+	}
+	if n < 4 || string(buf[:4]) != "SSH-" {
+		return errors.New("peer sent no SSH identification string")
+	}
+	return nil
+}

--- a/tests/e2e/diskperf/availability_test.go
+++ b/tests/e2e/diskperf/availability_test.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+package diskperf
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// oneShot builds a probe that closes stop after its first attempt, so watch
+// returns after exactly one sample without waiting out probeInterval.
+func oneShot(name string, attempt func() error, stop chan struct{}) probe {
+	var once sync.Once
+	return probe{
+		Name:  name,
+		Bound: time.Second,
+		Attempt: func() error {
+			defer once.Do(func() { close(stop) })
+			return attempt()
+		},
+	}
+}
+
+func TestWatchRecordsAHealthySample(t *testing.T) {
+	stop := make(chan struct{})
+	reports := watch([]probe{oneShot("healthy", func() error { return nil }, stop)}, stop)
+
+	if len(reports) != 1 {
+		t.Fatalf("watch returned %d reports, want 1", len(reports))
+	}
+	r := reports[0]
+	if !r.ok() {
+		t.Errorf("healthy probe not ok: %s (%v)", r.summary(), r.FirstFailure)
+	}
+	if r.Samples != 1 {
+		t.Errorf("samples = %d, want 1", r.Samples)
+	}
+}
+
+func TestWatchRecordsAFailedSample(t *testing.T) {
+	stop := make(chan struct{})
+	boom := errors.New("connection refused")
+	reports := watch([]probe{oneShot("broken", func() error { return boom }, stop)}, stop)
+
+	r := reports[0]
+	if r.ok() {
+		t.Fatalf("failing probe reported ok: %s", r.summary())
+	}
+	if r.Failures != 1 {
+		t.Errorf("failures = %d, want 1", r.Failures)
+	}
+	if !errors.Is(r.FirstFailure, boom) {
+		t.Errorf("first failure does not wrap the cause: %v", r.FirstFailure)
+	}
+}
+
+// A probe that answers, but too late, is a breach. Without this the gate would
+// pass on a host that took a minute to accept a connection, which is the
+// symptom it exists to catch.
+func TestWatchTreatsASlowAnswerAsABreach(t *testing.T) {
+	stop := make(chan struct{})
+	p := oneShot("slow", func() error {
+		time.Sleep(50 * time.Millisecond)
+		return nil
+	}, stop)
+	p.Bound = time.Millisecond
+
+	r := watch([]probe{p}, stop)[0]
+	if r.ok() {
+		t.Fatalf("slow probe reported ok: %s", r.summary())
+	}
+	if !strings.Contains(r.FirstFailure.Error(), "over the") {
+		t.Errorf("breach is not reported as a timing one: %v", r.FirstFailure)
+	}
+}
+
+// A probe with no samples is not a pass. The distinction matters because a
+// watch that never ran and one that ran cleanly otherwise look identical.
+func TestProbeReportWithNoSamplesIsNotOK(t *testing.T) {
+	if (probeReport{Name: "never ran"}).ok() {
+		t.Error("a report with zero samples reported ok")
+	}
+}
+
+func TestReadSSHBannerAcceptsAnSSHServer(t *testing.T) {
+	addr := serveOnce(t, func(c net.Conn) { _, _ = c.Write([]byte("SSH-2.0-OpenSSH_9.6\r\n")) })
+	if err := readSSHBanner(addr, time.Second); err != nil {
+		t.Errorf("readSSHBanner: %v", err)
+	}
+}
+
+// Something listening on 22 that is not sshd does not prove the host can still
+// schedule sshd, so the banner is checked rather than the connect alone.
+func TestReadSSHBannerRejectsANonSSHPeer(t *testing.T) {
+	addr := serveOnce(t, func(c net.Conn) { _, _ = c.Write([]byte("HTTP/1.1 400\r\n")) })
+	if err := readSSHBanner(addr, time.Second); err == nil {
+		t.Error("readSSHBanner accepted a peer that sent no SSH identification string")
+	}
+}
+
+// A connection that is accepted and then never spoken on is exactly what a
+// starved host looks like, and it must not read as healthy.
+func TestReadSSHBannerRejectsASilentPeer(t *testing.T) {
+	addr := serveOnce(t, func(net.Conn) { time.Sleep(time.Second) })
+	if err := readSSHBanner(addr, 100*time.Millisecond); err == nil {
+		t.Error("readSSHBanner accepted a peer that never sent a banner")
+	}
+}
+
+func TestReadSSHBannerRejectsAClosedPort(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	if err := readSSHBanner(addr, 200*time.Millisecond); err == nil {
+		t.Error("readSSHBanner accepted a closed port")
+	}
+}
+
+// serveOnce starts a listener that hands one connection to handle, and returns
+// its address. The listener is closed when the test ends.
+func serveOnce(t *testing.T, handle func(net.Conn)) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer conn.Close()
+		handle(conn)
+	}()
+	return ln.Addr().String()
+}

--- a/tests/e2e/diskperf/baseline.go
+++ b/tests/e2e/diskperf/baseline.go
@@ -1,0 +1,130 @@
+//go:build e2e
+
+package diskperf
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// Regression bands. Wide enough to survive bare-metal jitter, tight enough to
+// catch the 2x that matters.
+const (
+	failFraction = 0.25
+	warnFraction = 0.10
+)
+
+// baselineJSON is embedded rather than read from disk: the suite is
+// cross-compiled into a .test binary and shipped to the node without its
+// source, so a path-relative read would find nothing there.
+//
+//go:embed baseline.json
+var baselineJSON []byte
+
+// Baseline is the committed reference the throughput and latency assertions
+// compare against. It changes only by deliberate PR with a written
+// justification -- a baseline that updates itself is not a gate.
+type Baseline struct {
+	Version int `json:"version"`
+	// Origin records the hardware and build the numbers were taken on. A
+	// figure with no stated origin cannot be judged for whether it still
+	// applies to the cell running the gate.
+	Origin string                 `json:"origin"`
+	Jobs   map[string]BaselineJob `json:"jobs"`
+}
+
+// BaselineJob holds the reference metrics for one job. A zero field means "not
+// measured": it records and warns rather than failing, so the gate can land and
+// run before hardware numbers exist.
+type BaselineJob struct {
+	ReadIOPS    float64 `json:"read_iops"`
+	WriteIOPS   float64 `json:"write_iops"`
+	ReadP999Ms  float64 `json:"read_p99_9_ms"`
+	WriteP999Ms float64 `json:"write_p99_9_ms"`
+}
+
+func loadBaseline() (Baseline, error) {
+	var b Baseline
+	if err := json.Unmarshal(baselineJSON, &b); err != nil {
+		return Baseline{}, fmt.Errorf("parsing embedded baseline.json: %w", err)
+	}
+	return b, nil
+}
+
+// verdict is the outcome of comparing one metric against its reference.
+type verdict int
+
+const (
+	verdictUnmeasured verdict = iota
+	verdictOK
+	verdictWarn
+	verdictFail
+)
+
+// metric is one measured value and its reference.
+type metric struct {
+	Name string
+	Got  float64
+	Want float64
+	// HigherIsBetter distinguishes throughput from latency, which regress in
+	// opposite directions.
+	HigherIsBetter bool
+}
+
+// regression returns the fractional move in the bad direction, negative when
+// the measurement improved on the reference.
+func (m metric) regression() float64 {
+	if m.Want == 0 {
+		return 0
+	}
+	delta := (m.Want - m.Got) / m.Want
+	if !m.HigherIsBetter {
+		delta = -delta
+	}
+	return delta
+}
+
+// judge classifies the metric against the bands. An unmeasured reference or a
+// measurement fio did not produce is reported as such rather than compared,
+// since comparing against zero manufactures either a pass or a failure from no
+// evidence.
+func (m metric) judge() (verdict, string) {
+	if m.Want == 0 {
+		return verdictUnmeasured, fmt.Sprintf("%s: %.1f (no committed baseline — recorded, not gated)", m.Name, m.Got)
+	}
+	if m.Got == 0 || math.IsNaN(m.Got) {
+		return verdictUnmeasured, fmt.Sprintf("%s: not reported by fio (baseline %.1f)", m.Name, m.Want)
+	}
+	r := m.regression()
+	msg := fmt.Sprintf("%s: %.1f vs baseline %.1f (%+.1f%%)", m.Name, m.Got, m.Want, -r*100)
+	switch {
+	case r > failFraction:
+		return verdictFail, msg
+	case r > warnFraction:
+		return verdictWarn, msg
+	default:
+		return verdictOK, msg
+	}
+}
+
+// metricsFor pairs a job's measured aggregate with its reference. Read metrics
+// are omitted for a write-only job: fio reports zeros for the idle stream, and
+// a zero read IOPS is not a regression there.
+func metricsFor(job jobSpec, agg fioJob, base BaselineJob) []metric {
+	var ms []metric
+	if agg.Write.IOBytes > 0 {
+		ms = append(ms,
+			metric{Name: "write_iops", Got: agg.Write.IOPS, Want: base.WriteIOPS, HigherIsBetter: true},
+			metric{Name: "write_p99_9_ms", Got: agg.Write.p999Ms(), Want: base.WriteP999Ms},
+		)
+	}
+	if agg.Read.IOBytes > 0 {
+		ms = append(ms,
+			metric{Name: "read_iops", Got: agg.Read.IOPS, Want: base.ReadIOPS, HigherIsBetter: true},
+			metric{Name: "read_p99_9_ms", Got: agg.Read.p999Ms(), Want: base.ReadP999Ms},
+		)
+	}
+	return ms
+}

--- a/tests/e2e/diskperf/baseline.json
+++ b/tests/e2e/diskperf/baseline.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "origin": "unmeasured — no committed numbers yet. Every job below is zeroed, so the throughput and latency assertions record and warn rather than gate. Capture on the bare-metal cell with SPINIFEX_DISKPERF_REPS=3, take the median the suite prints, and replace this string with the host, the spinifex/viperblock/predastore versions and the date the numbers were taken on.",
+  "jobs": {
+    "randwrite-4k": {
+      "read_iops": 0,
+      "write_iops": 0,
+      "read_p99_9_ms": 0,
+      "write_p99_9_ms": 0
+    },
+    "randrw-70-30-4k": {
+      "read_iops": 0,
+      "write_iops": 0,
+      "read_p99_9_ms": 0,
+      "write_p99_9_ms": 0
+    }
+  }
+}

--- a/tests/e2e/diskperf/baseline.json
+++ b/tests/e2e/diskperf/baseline.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
-  "origin": "unmeasured — no committed numbers yet. Every job below is zeroed, so the throughput and latency assertions record and warn rather than gate. Capture on the bare-metal cell with SPINIFEX_DISKPERF_REPS=3, take the median the suite prints, and replace this string with the host, the spinifex/viperblock/predastore versions and the date the numbers were taken on.",
+  "origin": "bm-node1 (bare-metal cell 28, Debian 13, QEMU 10.0.11), spinifex v1.18.0-143-g0ec25417, viperblock v1.18.0-9-gab74c30, predastore v1.18.0-48-g62cbc5a, captured 2026-09-03 as the median of 3 repetitions. randwrite-4k has no read stream, so its read figures stay zero and remain ungated.",
   "jobs": {
     "randwrite-4k": {
       "read_iops": 0,
-      "write_iops": 0,
+      "write_iops": 42651.5,
       "read_p99_9_ms": 0,
-      "write_p99_9_ms": 0
+      "write_p99_9_ms": 801.1
     },
     "randrw-70-30-4k": {
-      "read_iops": 0,
-      "write_iops": 0,
-      "read_p99_9_ms": 0,
-      "write_p99_9_ms": 0
+      "read_iops": 59131.5,
+      "write_iops": 25391.9,
+      "read_p99_9_ms": 7.6,
+      "write_p99_9_ms": 7.7
     }
   }
 }

--- a/tests/e2e/diskperf/baseline_test.go
+++ b/tests/e2e/diskperf/baseline_test.go
@@ -1,0 +1,108 @@
+//go:build e2e
+
+package diskperf
+
+import (
+	"strings"
+	"testing"
+)
+
+// The embedded baseline is the gate's reference. A job renamed without its
+// baseline key would silently drop to "no committed baseline" and stop gating,
+// which is the failure mode this suite exists to prevent elsewhere.
+func TestBaselineCoversEveryGateJob(t *testing.T) {
+	base, err := loadBaseline()
+	if err != nil {
+		t.Fatalf("loadBaseline: %v", err)
+	}
+	for _, j := range gateJobs {
+		if _, ok := base.Jobs[j.Name]; !ok {
+			t.Errorf("baseline.json has no entry for job %q", j.Name)
+		}
+	}
+	for name := range base.Jobs {
+		if !slicesContainsJob(gateJobs, name) {
+			t.Errorf("baseline.json carries %q, which no gate job produces", name)
+		}
+	}
+	if strings.TrimSpace(base.Origin) == "" {
+		t.Error("baseline.json has no origin — a reference figure with no stated provenance cannot be judged for whether it still applies")
+	}
+}
+
+func slicesContainsJob(jobs []jobSpec, name string) bool {
+	for _, j := range jobs {
+		if j.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMetricJudgeBands(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		m    metric
+		want verdict
+	}{
+		{"throughput on baseline", metric{Name: "write_iops", Got: 1000, Want: 1000, HigherIsBetter: true}, verdictOK},
+		{"throughput improved", metric{Name: "write_iops", Got: 2000, Want: 1000, HigherIsBetter: true}, verdictOK},
+		{"throughput down 5%", metric{Name: "write_iops", Got: 950, Want: 1000, HigherIsBetter: true}, verdictOK},
+		{"throughput down 15%", metric{Name: "write_iops", Got: 850, Want: 1000, HigherIsBetter: true}, verdictWarn},
+		{"throughput halved", metric{Name: "write_iops", Got: 500, Want: 1000, HigherIsBetter: true}, verdictFail},
+
+		{"latency on baseline", metric{Name: "write_p99_9_ms", Got: 100, Want: 100}, verdictOK},
+		{"latency improved", metric{Name: "write_p99_9_ms", Got: 50, Want: 100}, verdictOK},
+		{"latency up 15%", metric{Name: "write_p99_9_ms", Got: 115, Want: 100}, verdictWarn},
+		{"latency doubled", metric{Name: "write_p99_9_ms", Got: 200, Want: 100}, verdictFail},
+
+		{"no committed baseline", metric{Name: "write_iops", Got: 900, Want: 0, HigherIsBetter: true}, verdictUnmeasured},
+		{"fio reported nothing", metric{Name: "write_iops", Got: 0, Want: 1000, HigherIsBetter: true}, verdictUnmeasured},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, msg := tc.m.judge()
+			if got != tc.want {
+				t.Errorf("judge() = %v, want %v (%s)", got, tc.want, msg)
+			}
+		})
+	}
+}
+
+// The band edges are the contract, so they are pinned rather than left to the
+// nearest test case either side of them.
+func TestMetricJudgeBandEdges(t *testing.T) {
+	exactWarn := metric{Name: "write_iops", Got: 900, Want: 1000, HigherIsBetter: true}
+	if v, msg := exactWarn.judge(); v != verdictOK {
+		t.Errorf("exactly %.0f%% regression = %v, want OK (the band is exclusive): %s", warnFraction*100, v, msg)
+	}
+	exactFail := metric{Name: "write_iops", Got: 750, Want: 1000, HigherIsBetter: true}
+	if v, msg := exactFail.judge(); v != verdictWarn {
+		t.Errorf("exactly %.0f%% regression = %v, want warn (the band is exclusive): %s", failFraction*100, v, msg)
+	}
+}
+
+// A write-only job reports zeros for the idle read stream. Comparing those
+// against a read baseline would report a total regression on every run.
+func TestMetricsForSkipsIdleStreams(t *testing.T) {
+	base := BaselineJob{ReadIOPS: 5000, WriteIOPS: 9000, ReadP999Ms: 100, WriteP999Ms: 90}
+	writeOnly := fioJob{Name: "randwrite-4k"}
+	writeOnly.Write.IOBytes = 1 << 30
+	writeOnly.Write.IOPS = 9000
+
+	ms := metricsFor(jobSpec{Name: "randwrite-4k"}, writeOnly, base)
+	for _, m := range ms {
+		if strings.HasPrefix(m.Name, "read_") {
+			t.Errorf("write-only job produced read metric %q", m.Name)
+		}
+	}
+	if len(ms) != 2 {
+		t.Errorf("write-only job produced %d metrics, want 2", len(ms))
+	}
+
+	mixed := writeOnly
+	mixed.Read.IOBytes = 1 << 30
+	mixed.Read.IOPS = 5000
+	if got := len(metricsFor(jobSpec{Name: "randrw-70-30-4k"}, mixed, base)); got != 4 {
+		t.Errorf("mixed job produced %d metrics, want 4", got)
+	}
+}

--- a/tests/e2e/diskperf/diskperf_test.go
+++ b/tests/e2e/diskperf/diskperf_test.go
@@ -1,0 +1,332 @@
+//go:build e2e
+
+package diskperf
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+)
+
+const (
+	// diskperfDevice is the guest-visible attach point requested for the volume
+	// under test.
+	diskperfDevice = "/dev/sdp"
+
+	// volumeHeadroomGiB pads the volume past the working set so fio's last job
+	// is not writing into the final block of the device.
+	volumeHeadroomGiB = 4
+
+	// volumeReadyTimeout bounds the wait for a hotplugged volume to reach the
+	// guest kernel.
+	volumeReadyTimeout = 90 * time.Second
+)
+
+// TestGuestDiskPerformance is the gate. It drives each pinned fio profile
+// against its own freshly created raw volume and asserts two separable classes
+// of property: that the guest and the host stayed responsive throughout, hard
+// pass/fail; and that throughput and latency have not regressed past the band,
+// against a committed baseline.
+//
+// The two are kept apart deliberately. The availability class is what would
+// have caught the original blocker, and it would have caught it on the first
+// run, because its thresholds are absolute rather than relative to a number
+// somebody measured on a good day. Folding them together would let a run that
+// left the host unreachable pass on the strength of a respectable IOPS figure.
+func TestGuestDiskPerformance(t *testing.T) {
+	fix := requireDiskPerfFixture(t)
+	harness.Phase(t, "Guest Disk Performance")
+
+	base, err := loadBaseline()
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	reps := envInt(t, "SPINIFEX_DISKPERF_REPS", 1)
+
+	instanceID, tgt := ensureDiskPerfInstance(t, fix)
+	az := harness.DiscoverDefaultAZ(t, fix.Harness)
+	harness.Detail(t, "instance", instanceID, "az", az, "reps", reps, "baseline_origin", base.Origin)
+
+	if err := installFio(tgt); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	hostAddr := hostSSHAddr(fix.Env)
+	if err := readSSHBanner(hostAddr, hostProbeBound); err != nil {
+		// Establish the probe works before the workload starts. Skipping the
+		// host assertion loudly is honest; asserting on a channel that was
+		// already broken would report the harness as a storage regression.
+		t.Errorf("host sshd probe is unusable before any load (%s): %v — the host-responsiveness assertion cannot run", hostAddr, err)
+		hostAddr = ""
+	}
+
+	for _, job := range gateJobs {
+		t.Run(job.Name, func(t *testing.T) {
+			runJob(t, fix, job, base.Jobs[job.Name], instanceID, tgt, az, hostAddr, reps)
+		})
+	}
+}
+
+// runJob executes one profile reps times, each against a volume created for
+// that repetition. The fresh volume is the reset: the extent index grows
+// monotonically, so a reused volume makes each repetition scan a larger index
+// than the last and drifts the gate's own numbers upward over time.
+func runJob(t *testing.T, fix *Fixture, job jobSpec, base BaselineJob, instanceID string, tgt harness.SSHTarget, az, hostAddr string, reps int) {
+	t.Helper()
+	sizeGiB := int64(job.workingSetGiB() + volumeHeadroomGiB)
+
+	var results []runResult
+	var probes []probeReport
+	for rep := 1; rep <= reps; rep++ {
+		harness.Step(t, "rep %d/%d: %d jobs x %d GiB %s %s at qd%d on a fresh %d GiB volume",
+			rep, reps, job.NumJobs, job.SizeGiB, job.BlockSize, job.RW, job.IODepth, sizeGiB)
+
+		volID := createVolume(t, fix, az, sizeGiB)
+		before := harness.GuestDiskSet(t, tgt)
+		harness.AttachVolumeWait(t, fix.AWS, volID, instanceID, diskperfDevice)
+		dev := harness.WaitForNewGuestDisk(t, tgt, before, volumeReadyTimeout)
+
+		res, reports := driveWithProbes(t, job, tgt, dev, hostAddr)
+		harness.DetachVolumeWait(t, fix.AWS, volID)
+
+		assertAvailability(t, job, reports)
+		results = append(results, res)
+		probes = append(probes, reports...)
+	}
+
+	report := aggregate(t, job, base, results, probes)
+	harness.DumpFile(t, resultsDir(t, fix), job.Name+"-result.json", report)
+}
+
+// resultsDir is the run's top-level artifact directory rather than the
+// per-test one. The per-test directory deletes itself when the test passes,
+// which is right for failure diagnostics and wrong for these: a passing run is
+// exactly the run whose numbers a baseline capture needs to read.
+func resultsDir(t *testing.T, fix *Fixture) string {
+	t.Helper()
+	dir := fix.Env.ArtifactDir
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("results dir %s: %v", dir, err)
+	}
+	return dir
+}
+
+// driveWithProbes runs the job while the responsiveness probes watch. The
+// probes only bracket the availability job: they cost a connection every few
+// seconds, which is negligible against the workload but is still load, and it
+// has no place in a run whose numbers feed a baseline.
+func driveWithProbes(t *testing.T, job jobSpec, tgt harness.SSHTarget, dev, hostAddr string) (runResult, []probeReport) {
+	t.Helper()
+	if !job.Availability {
+		res, err := runFio(tgt, job, dev)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		return res, nil
+	}
+
+	probes := []probe{guestProbe(tgt)}
+	if hostAddr != "" {
+		probes = append(probes, hostProbe(hostAddr))
+	}
+
+	stop := make(chan struct{})
+	done := make(chan []probeReport, 1)
+	go func() { done <- watch(probes, stop) }()
+
+	res, err := runFio(tgt, job, dev)
+	close(stop)
+	reports := <-done
+
+	if err != nil {
+		// A job that did not finish inside its budget is the stall itself, so
+		// what the probes saw while it ran is the diagnosis and has to be
+		// printed alongside the failure rather than dropped with the run.
+		for _, r := range reports {
+			t.Logf("  %s", r.summary())
+			if r.FirstFailure != nil {
+				t.Logf("    first breach at +%s: %v", r.FirstFailureAt.Round(time.Second), r.FirstFailure)
+			}
+		}
+		t.Fatalf("%v", err)
+	}
+	return res, reports
+}
+
+// assertAvailability turns the probe reports into hard pass/fail. Zero
+// tolerance: one breach means the guest or the host stopped answering while a
+// single tenant ran an ordinary workload.
+func assertAvailability(t *testing.T, job jobSpec, reports []probeReport) {
+	t.Helper()
+	if !job.Availability {
+		return
+	}
+	if len(reports) == 0 {
+		t.Fatal("availability job ran with no probes — nothing was asserted")
+	}
+	for _, r := range reports {
+		harness.Detail(t, "probe", r.Name, "samples", r.Samples, "over_bound", r.Failures, "max_ms", r.Max.Milliseconds())
+		if r.Samples == 0 {
+			t.Errorf("%s: no samples taken — the probe never ran, so it proved nothing", r.Name)
+			continue
+		}
+		if r.ok() {
+			continue
+		}
+		t.Errorf("%s: %d of %d samples breached the bound, first at +%s: %v",
+			r.Name, r.Failures, r.Samples, r.FirstFailureAt.Round(time.Second), r.FirstFailure)
+	}
+}
+
+// aggregate compares the run against the baseline and returns the recorded
+// result for the artifact bundle. Every metric is printed whatever its verdict,
+// so a passing run still leaves the numbers behind for the next baseline
+// capture to be judged against.
+func aggregate(t *testing.T, job jobSpec, base BaselineJob, results []runResult, probes []probeReport) []byte {
+	t.Helper()
+	if len(results) == 0 {
+		t.Fatalf("job %q produced no results", job.Name)
+	}
+
+	agg := medianAggregate(results)
+	recorded := map[string]any{
+		"job":          job.Name,
+		"reps":         len(results),
+		"fio_version":  results[0].Report.Version,
+		"read_iops":    agg.Read.IOPS,
+		"write_iops":   agg.Write.IOPS,
+		"read_p99_9":   agg.Read.p999Ms(),
+		"write_p99_9":  agg.Write.p999Ms(),
+		"read_max_ms":  agg.Read.maxMs(),
+		"write_max_ms": agg.Write.maxMs(),
+		// The availability evidence belongs in the same record as the numbers.
+		// A throughput figure taken from a run that left the host unreachable
+		// is not a throughput figure worth keeping.
+		"probes": probeRecords(probes),
+	}
+
+	for _, m := range metricsFor(job, agg, base) {
+		v, msg := m.judge()
+		switch v {
+		case verdictFail:
+			t.Errorf("REGRESSION %s", msg)
+		case verdictWarn:
+			t.Logf("  warn: %s", msg)
+		default:
+			t.Logf("  %s", msg)
+		}
+	}
+
+	blob, err := json.MarshalIndent(recorded, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding result: %v", err)
+	}
+	return blob
+}
+
+// medianAggregate reduces the repetitions to one aggregate by taking the median
+// of each metric independently. Per-metric rather than picking a single
+// representative run: the median run by IOPS is not necessarily the median run
+// by tail latency, and the tail is the number this gate cares most about.
+func medianAggregate(results []runResult) fioJob {
+	pick := func(f func(fioJob) float64) float64 {
+		xs := make([]float64, 0, len(results))
+		for _, r := range results {
+			xs = append(xs, f(r.Aggregate))
+		}
+		return median(xs)
+	}
+
+	var out fioJob
+	out.Name = results[0].Job
+	out.Read.IOPS = pick(func(j fioJob) float64 { return j.Read.IOPS })
+	out.Write.IOPS = pick(func(j fioJob) float64 { return j.Write.IOPS })
+	out.Read.Clat.Percentile = map[string]int64{p999Key: int64(pick(func(j fioJob) float64 { return float64(j.Read.Clat.Percentile[p999Key]) }))}
+	out.Write.Clat.Percentile = map[string]int64{p999Key: int64(pick(func(j fioJob) float64 { return float64(j.Write.Clat.Percentile[p999Key]) }))}
+	out.Read.Clat.Max = int64(pick(func(j fioJob) float64 { return float64(j.Read.Clat.Max) }))
+	out.Write.Clat.Max = int64(pick(func(j fioJob) float64 { return float64(j.Write.Clat.Max) }))
+
+	// Carry the byte counts so metricsFor can still tell which streams the job
+	// actually exercised.
+	for _, r := range results {
+		out.Read.IOBytes += r.Aggregate.Read.IOBytes
+		out.Write.IOBytes += r.Aggregate.Write.IOBytes
+	}
+	return out
+}
+
+// createVolume makes a volume for a single repetition and registers its
+// teardown. The harness Ensure* helper memoizes on (az, size) and would hand
+// back the same volume every time, which is the opposite of the reset this
+// needs.
+func createVolume(t *testing.T, fix *Fixture, az string, sizeGiB int64) string {
+	t.Helper()
+	// e2e:allow-create — a fresh volume per repetition is the reset this gate depends on.
+	out, err := fix.AWS.EC2.CreateVolume(&ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String(az),
+		Size:             aws.Int64(sizeGiB),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume(%d GiB in %s): %v", sizeGiB, az, err)
+	}
+	volID := aws.StringValue(out.VolumeId)
+	harness.RegisterVolumeTeardown(t, fix.AWS, volID)
+	harness.WaitForVolumeState(t, fix.AWS, volID, "available")
+	return volID
+}
+
+// ensureDiskPerfInstance launches (or returns the memoized) guest and waits for
+// SSH.
+func ensureDiskPerfInstance(t *testing.T, fix *Fixture) (instanceID string, tgt harness.SSHTarget) {
+	t.Helper()
+	instType, arch := harness.DiscoverNanoInstanceType(t, fix.Harness)
+	ami := harness.DiscoverUbuntuAMI(t, fix.Harness, arch)
+	keyName, keyPath := harness.EnsureKeyPair(t, fix.Harness, fix.ArtifactDir(t))
+	vpc := harness.EnsureDefaultVPC(t, fix.Harness)
+	harness.AuthorizeSSHIngress(t, fix.AWS, vpc.SGID)
+
+	instanceID = harness.EnsureInstance(t, fix.Harness, harness.InstanceSpec{
+		AMIID:        ami,
+		InstanceType: instType,
+		KeyName:      keyName,
+		SubnetID:     vpc.SubnetID,
+		SGID:         vpc.SGID,
+	})
+	inst := harness.WaitForInstanceState(t, fix.AWS, instanceID, "running")
+	host, port := harness.InstancePublicSSHHost(t, inst)
+
+	harness.Step(t, "waiting for guest SSH on %s:%d (instance_type=%s)", host, port, instType)
+	if !harness.TryGuestSSHReady(host, port, "ubuntu", keyPath, 5*time.Minute) {
+		t.Fatalf("guest %s SSH %s:%d not ready after 5m", instanceID, host, port)
+	}
+	return instanceID, harness.SSHTarget{User: "ubuntu", Host: host, Port: port, KeyPath: keyPath}
+}
+
+// hostSSHAddr is the address the host-responsiveness probe dials. WANHost is
+// the externally reachable node address, which is what an operator locked out
+// by the original defect would have been trying to reach.
+func hostSSHAddr(env *harness.Env) string {
+	return net.JoinHostPort(env.WANHost, "22")
+}
+
+// envInt reads a positive integer override, failing outright on a malformed
+// value rather than silently falling back to the default.
+func envInt(t *testing.T, key string, def int) int {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		t.Fatalf("%s=%q is not a positive integer", key, v)
+	}
+	return n
+}

--- a/tests/e2e/diskperf/fio.go
+++ b/tests/e2e/diskperf/fio.go
@@ -1,0 +1,239 @@
+//go:build e2e
+
+package diskperf
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+)
+
+// Guest-side exit codes, distinct from fio's own so an infra fault is never
+// reported as a performance result. The suite is only meaningful when the tool
+// under measurement actually ran.
+const (
+	exitAptUpdate  = 10
+	exitAptInstall = 11
+)
+
+// p999Key is fio's percentile map key for p99.9. fio emits percentiles as
+// fixed-format decimal strings, so this is a literal rather than a formatted
+// float.
+const p999Key = "99.900000"
+
+// jobSpec is one pinned fio profile. Every field is fixed in code rather than
+// read from the environment: a gate whose workload can drift is comparing
+// against a baseline that no longer describes it.
+type jobSpec struct {
+	// Name is both the fio job name and the baseline key, so renaming one
+	// without the other retires the baseline entry rather than silently
+	// comparing against the wrong workload.
+	Name string
+	// RW is an fio --rw value. MixRead applies to randrw only.
+	RW      string
+	MixRead int
+
+	BlockSize string
+	// SizeGiB is per job. NumJobs jobs each take their own SizeGiB slice of the
+	// device via offset_increment, so the working set is NumJobs*SizeGiB.
+	SizeGiB int
+	NumJobs int
+	IODepth int
+
+	// Budget bounds the guest-side invocation. Exceeding it is an availability
+	// failure, not a slow result: the workload did not complete.
+	Budget time.Duration
+
+	// Availability marks the job whose run the responsiveness probes bracket.
+	// Sustained random write is the pattern that produced the original stall.
+	Availability bool
+}
+
+// gateJobs is the pinned profile set. randwrite-4k is the job that took the
+// guest and the host down, at the 4x4 GiB shape the exit criterion names;
+// randrw-70-30-4k is the mixed workload the headline IOPS figure came from.
+var gateJobs = []jobSpec{
+	{
+		Name:         "randwrite-4k",
+		RW:           "randwrite",
+		BlockSize:    "4k",
+		SizeGiB:      4,
+		NumJobs:      4,
+		IODepth:      32,
+		Budget:       45 * time.Minute,
+		Availability: true,
+	},
+	{
+		Name:      "randrw-70-30-4k",
+		RW:        "randrw",
+		MixRead:   70,
+		BlockSize: "4k",
+		SizeGiB:   4,
+		NumJobs:   4,
+		IODepth:   32,
+		Budget:    45 * time.Minute,
+	},
+}
+
+// workingSetGiB is the span of the device the job touches, and so the minimum
+// volume size it needs.
+func (j jobSpec) workingSetGiB() int { return j.SizeGiB * j.NumJobs }
+
+// command renders the fio invocation. The target is a raw device with
+// direct=1, so the guest page cache and any filesystem are out of the path;
+// offset_increment gives each job a disjoint region rather than four jobs
+// overwriting the same one.
+func (j jobSpec) command(dev, outPath string) string {
+	args := []string{
+		"sudo fio",
+		"--name=" + j.Name,
+		"--filename=/dev/" + dev,
+		"--rw=" + j.RW,
+		"--bs=" + j.BlockSize,
+		fmt.Sprintf("--size=%dG", j.SizeGiB),
+		fmt.Sprintf("--offset_increment=%dG", j.SizeGiB),
+		fmt.Sprintf("--numjobs=%d", j.NumJobs),
+		fmt.Sprintf("--iodepth=%d", j.IODepth),
+		"--ioengine=libaio",
+		"--direct=1",
+		"--group_reporting",
+		"--output-format=json",
+		"--output=" + outPath,
+	}
+	if j.RW == "randrw" {
+		args = append(args, fmt.Sprintf("--rwmixread=%d", j.MixRead))
+	}
+	return strings.Join(args, " ")
+}
+
+// fioReport is the subset of fio's JSON output the gate reads.
+type fioReport struct {
+	Version string   `json:"fio version"`
+	Jobs    []fioJob `json:"jobs"`
+}
+
+type fioJob struct {
+	Name  string    `json:"jobname"`
+	Read  fioStream `json:"read"`
+	Write fioStream `json:"write"`
+}
+
+type fioStream struct {
+	IOBytes int64   `json:"io_bytes"`
+	BWBytes int64   `json:"bw_bytes"`
+	IOPS    float64 `json:"iops"`
+	Clat    fioClat `json:"clat_ns"`
+}
+
+type fioClat struct {
+	Max        int64            `json:"max"`
+	Mean       float64          `json:"mean"`
+	Percentile map[string]int64 `json:"percentile"`
+}
+
+// p999Ms returns the p99.9 completion latency in milliseconds, or 0 when fio
+// did not emit the percentile because the stream moved no I/O.
+func (s fioStream) p999Ms() float64 {
+	return float64(s.Clat.Percentile[p999Key]) / 1e6
+}
+
+// maxMs returns the worst completion latency in milliseconds.
+func (s fioStream) maxMs() float64 { return float64(s.Clat.Max) / 1e6 }
+
+// runResult is one execution of one job.
+type runResult struct {
+	Job    string
+	Report fioReport
+	// Aggregate is the group_reporting job entry. fio emits one per --name
+	// under group_reporting, so this is the whole run for that job.
+	Aggregate fioJob
+}
+
+// installFio makes fio available in the guest. Distinct exit codes keep an apt
+// failure -- a network or mirror fault, not a storage one -- out of the
+// performance verdict.
+func installFio(tgt harness.SSHTarget) error {
+	script := strings.Join([]string{
+		"set -e",
+		"if command -v fio >/dev/null 2>&1; then exit 0; fi",
+		fmt.Sprintf("sudo apt-get update -y || exit %d", exitAptUpdate),
+		fmt.Sprintf("sudo DEBIAN_FRONTEND=noninteractive apt-get install -y fio || exit %d", exitAptInstall),
+	}, "\n")
+	if out, err := harness.GuestExecTimeout(tgt, script, 10*time.Minute); err != nil {
+		return fmt.Errorf("installing fio in the guest failed — this is an infra fault, not a performance result: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// runFio drives one job to completion and returns its parsed report. The JSON
+// is written to a file in the guest and fetched by a second command: fio's
+// forced-exit path on a wedged job corrupts its own heap and produces no
+// output, so a run that exceeds its budget must still be distinguishable from
+// one that failed to parse.
+func runFio(tgt harness.SSHTarget, j jobSpec, dev string) (runResult, error) {
+	outPath := "/tmp/diskperf-" + j.Name + ".json"
+	if out, err := harness.GuestExec(tgt, "sudo rm -f "+outPath); err != nil {
+		return runResult{}, fmt.Errorf("clearing %s: %w\n%s", outPath, err, out)
+	}
+
+	if out, err := harness.GuestExecTimeout(tgt, j.command(dev, outPath), j.Budget); err != nil {
+		return runResult{}, fmt.Errorf("fio job %q did not complete within %s — the workload stalled: %w\n%s", j.Name, j.Budget, err, out)
+	}
+
+	raw, err := harness.GuestExec(tgt, "sudo cat "+outPath)
+	if err != nil {
+		return runResult{}, fmt.Errorf("reading %s: %w\n%s", outPath, err, raw)
+	}
+	return parseFio(j.Name, raw)
+}
+
+// parseFio extracts the named job's aggregate from fio's JSON. fio prefixes
+// its output with progress lines on some builds, so the object is located by
+// its opening brace rather than assumed to start at byte zero.
+func parseFio(name, raw string) (runResult, error) {
+	start := strings.Index(raw, "{")
+	if start < 0 {
+		return runResult{}, fmt.Errorf("fio produced no JSON object for %q:\n%s", name, raw)
+	}
+	var rep fioReport
+	if err := json.Unmarshal([]byte(raw[start:]), &rep); err != nil {
+		return runResult{}, fmt.Errorf("parsing fio JSON for %q: %w\n%s", name, err, raw)
+	}
+	for _, jb := range rep.Jobs {
+		if jb.Name != name {
+			continue
+		}
+		if jb.Read.IOBytes == 0 && jb.Write.IOBytes == 0 {
+			return runResult{}, fmt.Errorf("fio job %q moved no bytes — it ran but did nothing, so its numbers describe nothing", name)
+		}
+		return runResult{Job: name, Report: rep, Aggregate: jb}, nil
+	}
+	return runResult{}, fmt.Errorf("fio JSON has no job named %q (found %s)", name, strings.Join(jobNames(rep), ", "))
+}
+
+func jobNames(rep fioReport) []string {
+	names := make([]string, 0, len(rep.Jobs))
+	for _, j := range rep.Jobs {
+		names = append(names, j.Name)
+	}
+	return names
+}
+
+// median returns the middle value of xs, averaging the two central values for
+// an even count. xs is copied so the caller's ordering survives.
+func median(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	mid := len(s) / 2
+	if len(s)%2 == 1 {
+		return s[mid]
+	}
+	return (s[mid-1] + s[mid]) / 2
+}

--- a/tests/e2e/diskperf/fio_test.go
+++ b/tests/e2e/diskperf/fio_test.go
@@ -1,0 +1,134 @@
+//go:build e2e
+
+package diskperf
+
+import (
+	"strings"
+	"testing"
+)
+
+// sampleFio is a trimmed fio JSON document with the fields the gate reads.
+const sampleFio = `{
+  "fio version": "fio-3.36",
+  "jobs": [
+    {
+      "jobname": "randwrite-4k",
+      "read":  {"io_bytes": 0, "bw_bytes": 0, "iops": 0.0,
+                "clat_ns": {"max": 0, "mean": 0, "percentile": {}}},
+      "write": {"io_bytes": 17179869184, "bw_bytes": 38000000, "iops": 9280.5,
+                "clat_ns": {"max": 342000000, "mean": 3400000, "percentile": {"99.900000": 93000000}}}
+    }
+  ]
+}`
+
+func TestParseFioReadsNamedJob(t *testing.T) {
+	res, err := parseFio("randwrite-4k", sampleFio)
+	if err != nil {
+		t.Fatalf("parseFio: %v", err)
+	}
+	if got := res.Aggregate.Write.IOPS; got != 9280.5 {
+		t.Errorf("write IOPS = %v, want 9280.5", got)
+	}
+	if got := res.Aggregate.Write.p999Ms(); got != 93 {
+		t.Errorf("write p99.9 = %v ms, want 93", got)
+	}
+	if got := res.Aggregate.Write.maxMs(); got != 342 {
+		t.Errorf("write max = %v ms, want 342", got)
+	}
+	if res.Report.Version != "fio-3.36" {
+		t.Errorf("fio version = %q, want fio-3.36", res.Report.Version)
+	}
+}
+
+// fio prefixes its JSON with progress output on some builds, so the object is
+// located by its opening brace rather than assumed to start at byte zero.
+func TestParseFioSkipsLeadingNoise(t *testing.T) {
+	if _, err := parseFio("randwrite-4k", "Jobs: 4 (f=4)\n"+sampleFio); err != nil {
+		t.Fatalf("parseFio with leading noise: %v", err)
+	}
+}
+
+// A job that ran but moved nothing must not be reported as a result: its
+// numbers describe no workload, and comparing them against a baseline would
+// manufacture either a pass or a regression from no evidence.
+func TestParseFioRejectsEmptyJob(t *testing.T) {
+	empty := strings.ReplaceAll(sampleFio, `"io_bytes": 17179869184`, `"io_bytes": 0`)
+	empty = strings.ReplaceAll(empty, `"iops": 9280.5`, `"iops": 0`)
+	_, err := parseFio("randwrite-4k", empty)
+	if err == nil {
+		t.Fatal("parseFio accepted a job that moved no bytes")
+	}
+	if !strings.Contains(err.Error(), "moved no bytes") {
+		t.Errorf("error does not name the cause: %v", err)
+	}
+}
+
+func TestParseFioRejectsMissingJob(t *testing.T) {
+	if _, err := parseFio("randread-4k", sampleFio); err == nil {
+		t.Fatal("parseFio accepted output with no matching job name")
+	}
+}
+
+func TestParseFioRejectsNonJSON(t *testing.T) {
+	if _, err := parseFio("randwrite-4k", "fio: engine libaio not loadable"); err == nil {
+		t.Fatal("parseFio accepted output containing no JSON object")
+	}
+}
+
+func TestMedian(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []float64
+		want float64
+	}{
+		{"empty", nil, 0},
+		{"single", []float64{7}, 7},
+		{"odd is the middle value", []float64{9, 1, 5}, 5},
+		{"even averages the two central", []float64{1, 2, 3, 4}, 2.5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := median(tc.in); got != tc.want {
+				t.Errorf("median(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// median must not reorder its input: callers hold the per-repetition slices and
+// an in-place sort would silently reassociate metrics across repetitions.
+func TestMedianDoesNotMutateInput(t *testing.T) {
+	in := []float64{3, 1, 2}
+	median(in)
+	if in[0] != 3 || in[1] != 1 || in[2] != 2 {
+		t.Errorf("median reordered its input: %v", in)
+	}
+}
+
+// The device has to be large enough for every job's region, since
+// offset_increment gives each job a disjoint slice rather than sharing one.
+func TestJobCommandCoversTheWholeWorkingSet(t *testing.T) {
+	for _, j := range gateJobs {
+		cmd := j.command("vdc", "/tmp/out.json")
+		for _, want := range []string{"--direct=1", "--filename=/dev/vdc", "--offset_increment=", "--output-format=json"} {
+			if !strings.Contains(cmd, want) {
+				t.Errorf("job %q command is missing %q:\n%s", j.Name, want, cmd)
+			}
+		}
+		if j.workingSetGiB() != j.SizeGiB*j.NumJobs {
+			t.Errorf("job %q working set %d does not match %d jobs x %d GiB", j.Name, j.workingSetGiB(), j.NumJobs, j.SizeGiB)
+		}
+	}
+}
+
+// randrw needs a mix and the single-direction profiles must not carry one,
+// since fio ignores rwmixread outside randrw and its presence would suggest a
+// mix that is not being run.
+func TestJobCommandSetsMixOnlyForRandrw(t *testing.T) {
+	for _, j := range gateJobs {
+		cmd := j.command("vdc", "/tmp/out.json")
+		hasMix := strings.Contains(cmd, "--rwmixread=")
+		if want := j.RW == "randrw"; hasMix != want {
+			t.Errorf("job %q rw=%s: rwmixread present=%v, want %v", j.Name, j.RW, hasMix, want)
+		}
+	}
+}

--- a/tests/e2e/diskperf/main_test.go
+++ b/tests/e2e/diskperf/main_test.go
@@ -1,0 +1,176 @@
+//go:build e2e
+
+// Package diskperf is the guest disk-performance gate. It launches an
+// instance, attaches a dedicated blank data volume, drives a pinned fio
+// profile inside the guest, and asserts two separable classes of property.
+//
+// Availability assertions are hard pass/fail with zero tolerance: the fio job
+// completes inside its budget, a guest responsiveness probe on a second SSH
+// channel answers throughout, and the host's own sshd answers throughout. A
+// healthy system sits orders of magnitude away from these bounds and a broken
+// one sits orders of magnitude past them, so they do not flap. They are the
+// class that catches a volume workload taking its guest, its neighbours or its
+// host down, and they are meaningful on the very first run because they are
+// absolute rather than relative.
+//
+// Throughput and latency assertions are banded against a committed baseline:
+// fail above a 25% regression, warn above 10%. Wide enough to survive
+// bare-metal jitter, tight enough to catch a 2x. A baseline entry that is
+// absent records and warns instead of failing, so the gate can run before
+// hardware numbers exist rather than blocking on them.
+//
+// Three things about the workload are deliberate. The target is a raw
+// unformatted device rather than a file on the boot disk, because a filesystem
+// layers guest page cache, allocation and journal traffic over what is being
+// measured. Each job gets its own freshly created volume, because the extent
+// index grows monotonically and reusing a volume makes results order-dependent
+// and drifting upward over time -- a gate that slowly normalises the
+// regression it exists to catch. And the guest responsiveness probe reads the
+// root volume, not the volume under test, so a passing probe is evidence of
+// isolation between volumes rather than of the workload merely being slow.
+//
+// The suite is excluded from the default e2e run and selected only by its own
+// make target, like gpu/ and storagegrowth/. Nothing under tests/e2e/harness/
+// is modified by it: that path is an infra glob, and editing it forces the
+// full CI matrix on every change.
+package diskperf
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+)
+
+var (
+	pkgFixOnce    sync.Once
+	pkgFix        *Fixture
+	pkgFixErr     error
+	pkgSkipReason string
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if pkgFix != nil {
+		if pkgFix.Harness != nil {
+			// A leaked resource fails the run: the suite may have passed, but it
+			// left state on the node that the next run will trip over.
+			if err := pkgFix.Harness.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "e2e teardown: %v\n", err)
+				code = 1
+			}
+		}
+	}
+	os.Exit(code)
+}
+
+// Fixture carries per-process state shared across disk-performance tests.
+type Fixture struct {
+	Env     *harness.Env
+	AWS     *harness.AWSClient
+	Harness *harness.Fixture
+
+	// PoolMode reports external_mode="pool". Guest SSH is the only channel for
+	// driving fio and for the responsiveness probe, and a nat-mode env has no
+	// EIP and no inbound path, so the suite skips outright without it.
+	PoolMode bool
+}
+
+// ArtifactDir returns the artifact directory for the currently running test.
+// Derived per-call from the live t rather than memoized on the singleton, so
+// it does not freeze to whichever test happened to build the fixture.
+func (f *Fixture) ArtifactDir(t *testing.T) string {
+	t.Helper()
+	return harness.ArtifactDir(t, f.Env)
+}
+
+// requireDiskPerfFixture returns the package-scoped Fixture singleton, building
+// it on first call. Skips the calling test when SPINIFEX_E2E is unset, when the
+// mode is not "single", or when external_mode is not "pool".
+func requireDiskPerfFixture(t *testing.T) *Fixture {
+	t.Helper()
+	pkgFixOnce.Do(func() {
+		if os.Getenv("SPINIFEX_E2E") == "" {
+			return
+		}
+		env := harness.LoadEnv(t)
+		if env.Mode != harness.ModeSingle {
+			pkgSkipReason = "diskperf suite requires SPINIFEX_MODE=single"
+			return
+		}
+		// Guard against NewAWSClient calling t.Fatal, which exits via
+		// runtime.Goexit and corrupts the Once state for subsequent tests.
+		if os.Getenv("SPINIFEX_AWS_INSECURE") != "1" {
+			if _, err := harness.ResolveCACert(env); err != nil {
+				pkgSkipReason = "no Spinifex CA cert found: " + err.Error() +
+					" — provision a local node first (ansible-playbook ansible/playbooks/dev-reset.yml), " +
+					"or target a remote cluster with SPINIFEX_AWS_INSECURE=1 (skips CA verification; see harness/aws.go)"
+				return
+			}
+		}
+		awsCli := harness.NewAWSClient(t, env)
+
+		h, err := harness.NewProcessFixture(awsCli)
+		if err != nil {
+			pkgFixErr = err
+			return
+		}
+		harness.EnsureDefaultSGOpen(t, awsCli)
+		pkgFix = &Fixture{
+			Env:      env,
+			AWS:      awsCli,
+			Harness:  h,
+			PoolMode: detectPoolMode(env),
+		}
+	})
+	if pkgFixErr != nil {
+		t.Fatalf("diskperf fixture init: %v", pkgFixErr)
+	}
+	if pkgFix == nil {
+		if pkgSkipReason != "" {
+			t.Skip(pkgSkipReason)
+		}
+		t.Skip("SPINIFEX_E2E unset")
+	}
+	if !pkgFix.PoolMode {
+		t.Skip("diskperf suite requires external_mode=pool — a nat env has no EIP and cannot reach guest SSH, the only channel for driving fio")
+	}
+	return pkgFix
+}
+
+// detectPoolMode reads external_mode from spinifex.toml, defaulting to false.
+// Copied from single/'s helper rather than imported: tests/e2e/harness/** is
+// an infra glob this suite deliberately never touches.
+func detectPoolMode(env *harness.Env) bool {
+	cfg := os.ExpandEnv("$HOME/spinifex/config/spinifex.toml")
+	if env.ConfigDir != "" {
+		cfg = filepath.Join(env.ConfigDir, "spinifex.toml")
+	}
+	f, err := os.Open(cfg)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	inNetwork := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") {
+			inNetwork = line == "[network]"
+			continue
+		}
+		if !inNetwork || !strings.HasPrefix(line, "external_mode") {
+			continue
+		}
+		if _, rhs, ok := strings.Cut(line, "="); ok {
+			return strings.Trim(strings.TrimSpace(rhs), "\"'") == "pool"
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Nothing measures guest disk performance in CI. That is why a quadratic index scan shipped in viperblock `35dd9f2` and survived three subsequent fixes to adjacent code, and it is why the two availability clauses at the end of Stage 0 in `improvements/ebs-performance.md` have never been evaluated: a sustained random-write workload took the guest, and then the host, down, and nothing since has demonstrated that it no longer does.

The mechanism is fixed — the ordered extent index landed in viperblock and no viperblock symbol sits above 0.82% in the profile. What has not happened is a demonstration that the guest and the host stay responsive under sustained random writes. This is the suite that makes that demonstration.

Bead `mulga-7cag2`. Plan: `docs/development/improvements/ebs-performance.md` item 1, marked SHIP in WS-1 of the v1 cut list.

**Read the two "what this does not do" points at the bottom before approving.** They are deliberate, and one of them means half the gate is inert on merge.

## Changes

`tests/e2e/diskperf/`, built on the existing harness and following the `partialblock`/`storagegrowth` pattern. Nothing under `tests/e2e/harness/` is touched — that path is an infra glob and editing it forces the full CI matrix on every change.

**Two profiles.** `randwrite-4k` at 4 jobs × 4 GiB, the shape the exit criterion names and the one that took the host down, and `randrw-70-30-4k`, the mixed workload the headline 8,905 IOPS came from. The target is a raw device with `direct=1` rather than a file on the boot disk, per S1.0, so guest page cache, filesystem allocation and journal traffic are out of the path.

**Two classes of assertion, kept apart.** Folding them together would let a run that left the host unreachable pass on a respectable IOPS figure.

- **Availability — hard pass/fail, zero tolerance, absolute rather than relative, so it gates from the first run.** The fio job completes inside its budget; a guest responsiveness probe answers throughout on a *second* SSH channel; the host's own sshd answers throughout. Two details worth review: the guest probe reads the **root** volume while the workload runs on a different one, so a pass is evidence of isolation *between* volumes rather than of the job merely being slow; and the host probe is a TCP connect plus an SSH banner read, which needs no credential and still proves the kernel completed a handshake and scheduled sshd — which is exactly what the original ~85-cores-of-map-iteration host could not do.
- **Throughput and latency — banded.** Fail above 25% regression, warn above 10%, per-metric median across repetitions. Per-metric rather than picking one representative run, because the median run by IOPS is not the median run by tail latency, and the tail is what this gate cares most about.

**A fresh volume per repetition.** Extent count grows monotonically, so reusing a volume makes the gate order-dependent and drifts its own numbers upward over time — it would slowly normalise the regression it exists to catch. This is the one place the suite calls `CreateVolume` directly rather than through `Ensure*`, which memoizes on `(az, size)` and would hand back the same volume every time; annotated `e2e:allow-create`.

**Harness resilience without a timeout race.** fio's 300 s reaper is measured from when it decides a job is unresponsive, so no harness-level timeout reliably lands ahead of the double-free. Instead each job is its own guest invocation against its own volume, and fio's JSON is written to a file and fetched by a separate command — so a wedged job loses only itself and is reported as a budget breach rather than as a parse failure. That is what S1.6 actually wanted.

**CI wiring.** `make e2e-diskperf`, plus nightly cell 25. `e2e-baremetal.yml` gains `suites`, `test-timeout`, `suite-env` and `cell` inputs so one reusable workflow serves both the correctness cell and this one; cell 25 queues behind cell 20 on the shared concurrency group, which is what keeps the numbers off a contended cell. Defaults are unchanged, so cell 20 behaves exactly as before. The matching `BM_SUITES` / `BM_TEST_TIMEOUT` / `BM_SUITE_ENV` support in `run-baremetal-e2e.sh` is on mulga main (`9198c65c`) — **that has to be present on the runner for cell 25 to do anything**, and it already is.

Deliberately absent from `E2E_SUITES_SINGLE` and from `service-interfaces.yaml`, like `gpu/`: its assertions are not reachable on a shared virtualised cell, where perf numbers are noise.

## Testing

The gate's own arithmetic is unit-tested off-cluster and runs in `make preflight` via `test-harness` — a gate whose comparison logic is itself untested is the failure mode this plan is otherwise full of, and `TestBlockMapCoalesce_EntryCountIsExtentsNotBlocks` is the local precedent for getting that wrong.

- Baseline bands including both exclusive edges, and the two unmeasured cases (no committed reference; fio reported nothing) kept distinct from a pass.
- Per-stream metric selection: a write-only job must not be compared against a read baseline, which would otherwise report a total regression on every run.
- fio JSON parsing, including leading progress noise, a missing job name, and a job that ran but moved no bytes.
- Probe accounting, including a slow-but-*successful* answer counting as a breach, and a report with zero samples not counting as a pass.
- `readSSHBanner` against a real listener: valid banner, non-SSH peer, silent peer, closed port.

Green under `-race`. `golangci-lint` clean. `make preflight` passes except for `TestNewIMDS_BuildsProvider` and three `admin_remote_test.go` cases, which fail identically on stock `dev` on this box for want of `/tmp/predastore/server.pem` — unrelated to this change.

**The suite itself has not run against hardware.** It needs the bare-metal cell.

## What this does not do

Two gaps, both deliberate, both stated so they are not discovered later:

1. **The throughput band does not gate yet.** `baseline.json` is committed, embedded in the test binary and unit-tested against the job list, but every figure is zero, and a zero reference records-and-warns rather than fails. There are no measured numbers to put there, and a band nobody measured would be a fabricated gate. Capture on the bare-metal cell with `SPINIFEX_DISKPERF_REPS=3` and commit the medians in a follow-up. **Until then only the availability class actually gates** — which is the right way round, since that class is absolute and is the one that would have caught the original blocker on its first run.
2. **The extent-count ceiling, named as a fourth availability assertion, is not implemented.** It needs `viperblock.index.entries` from S1.5, which does not exist.

Also still open, and not attempted here: the `workflow_call` from viperblock's and predastore's own CI into this cell. Catching a regression at submodule-bump time is already late. The substrate is now in place — `e2e-baremetal.yml` is a reusable workflow taking a suite list — so what remains is the cross-repo dispatch and its token.

Consequently **Stage 0 stays unclearable**: its two availability clauses are unverified for want of a run now, rather than for want of a gate. Merging this does not close the blocker; running it green does.
