### PR TITLE
feat: retry a transient reconcile failure before the resync, not after it

### DIFF
--- a/spinifex/reconciler/failure_test.go
+++ b/spinifex/reconciler/failure_test.go
@@ -1,0 +1,127 @@
+//test:in-package — pass and keyPass are the decision under test, and driving
+//them through Run would turn a pure classification into a timing test against
+//DefaultErrorRetry.
+
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+)
+
+// A terminal failure repeats identically however often it is retried, so asking
+// to be revisited early only produces the same error sooner. The resync stays as
+// the backstop, which is why the deadline is left alone rather than suppressed.
+func TestPass_ATerminalFailureAsksForNoEarlyRetry(t *testing.T) {
+	cfg := Config{
+		Name: "terminal",
+		Reconcile: func(context.Context) (time.Duration, error) {
+			return 0, errors.New(awserrors.ErrorInvalidParameterValue)
+		},
+	}
+
+	assert.Zero(t, pass(t.Context(), cfg, "test"),
+		"a 400 will be a 400 next time; retrying early only logs the same failure sooner")
+}
+
+// The case the deadline exists for: a fault that clears on its own should not
+// leave the world unconverged until the resync, which is five minutes by default.
+func TestPass_ATransientFailureIsRetriedBeforeTheResync(t *testing.T) {
+	cfg := Config{
+		Name: "transient",
+		Reconcile: func(context.Context) (time.Duration, error) {
+			return 0, errors.New(awserrors.ErrorServiceUnavailable)
+		},
+	}
+
+	assert.Equal(t, DefaultErrorRetry, pass(t.Context(), cfg, "test"))
+}
+
+// An error carrying no AWS code at all is the common case — a wrapped NATS or
+// S3 failure — and IsTerminal calls it transient by design, so it is retried
+// rather than silently abandoned.
+func TestPass_AnUnclassifiableFailureIsTreatedAsTransient(t *testing.T) {
+	cfg := Config{
+		Name: "unclassified",
+		Reconcile: func(context.Context) (time.Duration, error) {
+			return 0, errors.New("read zone: connection reset")
+		},
+	}
+
+	assert.Equal(t, DefaultErrorRetry, pass(t.Context(), cfg, "test"))
+}
+
+// A pass partway through a transition names its own deadline, and that deadline
+// is the reason the loop revisits at all. The error retry may bring a revisit
+// forward but must never push one back.
+func TestPass_ACalleesSoonerDeadlineSurvivesATransientFailure(t *testing.T) {
+	cfg := Config{
+		Name: "sooner",
+		Reconcile: func(context.Context) (time.Duration, error) {
+			return 2 * time.Second, errors.New(awserrors.ErrorServiceUnavailable)
+		},
+	}
+
+	assert.Equal(t, 2*time.Second, pass(t.Context(), cfg, "test"),
+		"the callee asked for 2s; the error retry must not defer it to DefaultErrorRetry")
+}
+
+// A callee asking for later than the error retry gets the retry instead, which
+// is the same direction: sooner wins.
+func TestPass_ACalleesLaterDeadlineYieldsToTheErrorRetry(t *testing.T) {
+	cfg := Config{
+		Name: "later",
+		Reconcile: func(context.Context) (time.Duration, error) {
+			return time.Hour, errors.New(awserrors.ErrorServiceUnavailable)
+		},
+	}
+
+	assert.Equal(t, DefaultErrorRetry, pass(t.Context(), cfg, "test"))
+}
+
+// The per-key path carries the same classification. A key is otherwise covered
+// only by the whole-set resync, so a transient key failure is the case with the
+// most to gain from an early revisit.
+func TestKeyPass_ClassifiesTheSameWayAsAWholeSetPass(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{name: "terminal", err: errors.New(awserrors.ErrorInvalidParameterValue), want: 0},
+		{name: "transient", err: errors.New(awserrors.ErrorServiceUnavailable), want: DefaultErrorRetry},
+		{name: "unclassifiable", err: errors.New("put key: no responders"), want: DefaultErrorRetry},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			cfg := Config{
+				Name: "keys",
+				ReconcileKey: func(_ context.Context, key string) (time.Duration, error) {
+					got = key
+					return 0, tt.err
+				},
+			}
+
+			assert.Equal(t, tt.want, keyPass(t.Context(), cfg, "i-abc"))
+			assert.Equal(t, "i-abc", got, "the key that failed has to reach the callee")
+		})
+	}
+}
+
+// A pass that succeeds keeps whatever deadline it named, so the error retry
+// cannot leak into the healthy path and make every loop revisit on a timer it
+// never asked for.
+func TestPass_ASuccessfulPassKeepsItsOwnDeadline(t *testing.T) {
+	cfg := Config{
+		Name:      "ok",
+		Reconcile: func(context.Context) (time.Duration, error) { return 90 * time.Second, nil },
+	}
+
+	assert.Equal(t, 90*time.Second, pass(t.Context(), cfg, "test"))
+}

--- a/spinifex/reconciler/reconciler.go
+++ b/spinifex/reconciler/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/otelsetup"
 	"github.com/nats-io/nats.go/jetstream"
@@ -40,6 +41,10 @@ const (
 	// be established, so a bucket that is briefly unreachable is retried
 	// without spinning.
 	retryWatch = 5 * time.Second
+	// DefaultErrorRetry is how soon a pass that failed transiently asks to be
+	// revisited. Waiting out the resync leaves the world unconverged for minutes
+	// over a fault that usually clears in seconds.
+	DefaultErrorRetry = 15 * time.Second
 )
 
 // Source names the buckets to watch and the keys within them that matter.
@@ -332,6 +337,23 @@ func settle(ctx context.Context, changes <-chan struct{}, debounce time.Duration
 	}
 }
 
+// failed reports a reconcile failure and returns the deadline it should be
+// retried on. A terminal error will fail identically however often it is
+// repeated, so it is reported as needing intervention and asks for nothing
+// sooner than the resync; anything else is retried promptly.
+//
+// A deadline the callee asked for survives when it is sooner: a pass partway
+// through a transition still gets revisited on its own schedule.
+func failed(ctx context.Context, loop, what string, err error, revisit time.Duration, attrs ...any) time.Duration {
+	attrs = append([]any{"loop", loop}, append(attrs, "err", err)...)
+	if awserrors.IsTerminal(err) {
+		slog.ErrorContext(ctx, what+" failed and will not succeed unchanged", attrs...)
+		return revisit
+	}
+	slog.WarnContext(ctx, what+" failed, retrying", attrs...)
+	return Earliest(revisit, DefaultErrorRetry)
+}
+
 // pass runs one reconcile, logging rather than returning a failure: the loop
 // outlives any single pass, and the next resync retries. A failed pass keeps
 // its deadline, so a caller partway through a transition still gets revisited
@@ -340,9 +362,8 @@ func pass(ctx context.Context, cfg Config, trigger string) time.Duration {
 	start := time.Now()
 	revisit, err := cfg.Reconcile(ctx)
 	if err != nil {
-		slog.WarnContext(ctx, "reconcile pass failed, retrying next cycle",
-			"loop", cfg.Name, "trigger", trigger, "duration_ms", otelsetup.Millis(time.Since(start)), "err", err)
-		return revisit
+		return failed(ctx, cfg.Name, "reconcile pass", err, revisit,
+			"trigger", trigger, "duration_ms", otelsetup.Millis(time.Since(start)))
 	}
 	slog.DebugContext(ctx, "reconcile pass complete",
 		"loop", cfg.Name, "trigger", trigger, "duration_ms", otelsetup.Millis(time.Since(start)),
@@ -350,16 +371,15 @@ func pass(ctx context.Context, cfg Config, trigger string) time.Duration {
 	return revisit
 }
 
-// keyPass runs one per-key reconcile. Its failure is logged rather than
-// retried here: the resync re-reconciles the whole set, so a key that failed is
-// covered by the same backstop as a key the queue never saw.
+// keyPass runs one per-key reconcile. The resync re-reconciles the whole set, so
+// a key that failed is covered by the same backstop as a key the queue never
+// saw; the deadline a transient failure asks for only brings that forward.
 func keyPass(ctx context.Context, cfg Config, key string) time.Duration {
 	start := time.Now()
 	revisit, err := cfg.ReconcileKey(ctx, key)
 	if err != nil {
-		slog.WarnContext(ctx, "reconcile key failed, retrying on the next resync",
-			"loop", cfg.Name, "key", key, "duration_ms", otelsetup.Millis(time.Since(start)), "err", err)
-		return revisit
+		return failed(ctx, cfg.Name, "reconcile key", err, revisit,
+			"key", key, "duration_ms", otelsetup.Millis(time.Since(start)))
 	}
 	slog.DebugContext(ctx, "reconcile key complete",
 		"loop", cfg.Name, "key", key, "duration_ms", otelsetup.Millis(time.Since(start)),


### PR DESCRIPTION
## `awserrors.IsTerminal` had no caller, and the loop it was written for needed one

#923 added `IsTerminal` with this doc comment:

> It is the predicate a reconcile loop needs to choose between requeueing work and dropping it.

Nothing has called it since. `grep` for it across the tree returns its own tests and an unrelated `recordIsTerminal` in `handlers/quota`. Meanwhile `reconciler.pass` and `reconciler.keyPass` — the loop that comment names — treat every failure identically:

```go
revisit, err := cfg.Reconcile(ctx)
if err != nil {
	slog.WarnContext(ctx, "reconcile pass failed, retrying next cycle", ...)
	return revisit
}
```

`revisit` from a failed callee is essentially always zero, `clampRevisit(0, resync)` is zero, and zero means no deadline. So the next attempt is the resync.

**A transient failure waits out the full resync.** Five minutes by default. Nothing about a NATS blip warrants five minutes of staleness, and the loop already has the mechanism to ask for sooner — it was throwing it away.

**A terminal failure is announced as recoverable.** "retrying next cycle" is false for a 400 or a 501: the identical call fails identically, every cycle, forever, at WARN. That is the one distinction an operator reading these logs actually needs.

## What this does

Both paths go through one `failed()` helper that classifies with `IsTerminal`:

| | log | deadline |
| --- | --- | --- |
| terminal | ERROR, "will not succeed unchanged" | unchanged — the resync remains the backstop |
| anything else | WARN, "retrying" | `Earliest(callee's own, DefaultErrorRetry)` |

`DefaultErrorRetry` is 15s, a package constant rather than a `Config` field. No caller has asked to tune it, and adding the knob before anyone needs one is what the master plan records Phase 2 getting wrong.

Two properties make the direction safe. `Earliest` means a callee that named its own sooner deadline keeps it — a pass partway through a transition is not deferred to the error retry. And `clampRevisit` already caps every request at the resync, so **a loop can only become more eager than it is today, never slower.**

## What this is not

The master plan (`declarative-control-plane.md:436`) motivates this work as:

> its absence is already felt: 286 sites hand-roll the transient/terminal distinction with `errors.Is`

That figure does not survive an audit, and this PR deliberately does not act on it. Non-test `errors.Is` calls number 727, but the distribution is:

| sentinel | count | a retry decision? |
| --- | --- | --- |
| `jetstream.ErrKeyNotFound` | 177 | no — "does this key exist" |
| `jetstream.ErrNoKeysFound` | 94 | no |
| `jetstream.ErrKeyExists` | 49 | no — create-if-absent |
| `nats.ErrNoResponders` | 33 | **yes** |
| `jetstream.ErrKeyRevisionMismatch` | 25 | no — CAS lost |
| `jetstream.ErrBucketNotFound` | 23 | no |

Roughly 380 of the 727 are JetStream key-existence sentinels driving business logic. `IsTerminal` classifies via `ResolveErrorCode`, which fails on every one of them, so converting those sites would answer "transient" to questions that were never about retrying. The actual hand-rolled classifiers number **nine**, and the three genuinely duplicated ones (`isNATSTransient` in `handlers/iam` and `gateway`, `natsTransient` in `handlers/eks`) answer a different question — "is this a NATS-unavailable condition I should surface as 503" — so folding them into `IsTerminal` would conflate two predicates. Filed as a follow-up rather than done here.

## Risk

I first wrote this section claiming the change alters retry timing for **all eight** reconcile loops, and warning of an error storm. Auditing what each loop actually hands back to `pass` shows that is wrong, in the alarming direction:

| loop | returns to `pass` on failure | reaches the new code? |
| --- | --- | --- |
| `quota` (awsgw, whole-set) | `0, err` | **yes** — only when `quotaCfg.Enabled` |
| `quota` (awsgw, per-key) | `0, err` | **yes** — same gate |
| `eks/<cluster>` | `r.interval, err` (non-sentinel) | **yes** |
| `vpcd/drift` | `backoff, nil` always | no |
| `rds` | `revisit, nil` — *"already logged, so it is not returned again"* | no |
| `ecs/services` | `reconcileInterval, nil` | no |
| `ecs/timers` | `Earliest(...), nil` | no |
| `dns` | `0, nil` always | no |

Five of seven loops log their own failures and return nil, so the reconciler's error contract is inert for them. Real blast radius is **quota and EKS**, and quota is off by default. That is also the answer to why `IsTerminal` had no caller: the callees weren't propagating errors for anything to classify.

One interaction worth naming. EKS's `reconcilePass` deliberately returns `r.interval` (30s), commented *"Retried at the old cadence rather than left to the resync"*. `Earliest(30s, 15s)` makes that 15s — so this halves a cadence its author chose explicitly. Still inside the "only sooner, never later" guarantee, but it is an override rather than a gap being filled.

## Live (env19, 3 nodes)

Deployed `e5c8edccc` to casuarina/bottlebrush/ironbark. All three active on the branch build.

**No regression, demonstrated.** An EKS cluster went `CREATING` → `ACTIVE` end to end, `eks/verify969` electing on ironbark and running to convergence. Zero `reconcile pass failed` / `will not succeed unchanged` lines on any node across the window.

**The failure path was not exercised live.** It only runs when a callee returns an error, and per the table the only loop on a default env19 that can is EKS. Inducing one meant briefly stopping NATS on ironbark, which was blocked as a disruptive action on a live node and not worked around. So both behavioural claims — the WARN/ERROR split and the 15s cadence — rest on the unit tests below. Live evidence covers absence of regression only.

## Tests

Seven cases in `reconciler/failure_test.go`, in-package because `pass`/`keyPass` are the decision under test and driving them through `Run` would turn a pure classification into a timing test against a 15s constant.

| test | pins |
| --- | --- |
| `ATerminalFailureAsksForNoEarlyRetry` | a 400 gets no early revisit |
| `ATransientFailureIsRetriedBeforeTheResync` | a 503 gets `DefaultErrorRetry` |
| `AnUnclassifiableFailureIsTreatedAsTransient` | a wrapped error with no AWS code is retried, not abandoned |
| `ACalleesSoonerDeadlineSurvivesATransientFailure` | 2s beats the error retry |
| `ACalleesLaterDeadlineYieldsToTheErrorRetry` | 1h does not |
| `KeyPass_ClassifiesTheSameWayAsAWholeSetPass` | all three cases on the per-key path, plus the key reaching the callee |
| `ASuccessfulPassKeepsItsOwnDeadline` | the error retry cannot leak into the healthy path |

Both checked by breaking the code:

- inverting `IsTerminal` → `!IsTerminal` fails 5 tests plus all 3 `keyPass` subtests;
- replacing `Earliest(revisit, DefaultErrorRetry)` with a bare `DefaultErrorRetry` fails exactly `ACalleesSoonerDeadlineSurvivesATransientFailure` and nothing else.

`make preflight` passes.

---

Plan: `docs/development/improvements/awserrors-terminal-adoption.md`. Bead: `mulga-1qgld`.
