### PR TITLE
fix: seven EC2 creates honour ClientToken instead of duplicating on a retry

### DIFF
--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -44,6 +44,9 @@ type EC2Handler func(string, map[string]string, *GatewayConfig, string, *http.Re
 type ec2Action struct {
 	parse    func(map[string]string) (any, error)
 	dispatch func(string, any, *GatewayConfig, string, *http.Request) ([]byte, error)
+	// idempotent records that this action honours ClientToken, so the set of
+	// actions that do is assertable rather than folklore.
+	idempotent bool
 }
 
 func (h ec2Action) withQueryPreprocessor(preprocess func(map[string]string)) ec2Action {
@@ -67,17 +70,21 @@ func requestContext(r *http.Request) context.Context {
 	return utils.WithIdempotencyKey(r.Context(), r.Header.Get(utils.SDKInvocationIDHeader))
 }
 
+// parseEC2Input parses query args into an action's input type. Shared by every
+// ec2Action constructor so they all consume the same parse.
+func parseEC2Input[In any](q map[string]string) (any, error) {
+	input := new(In)
+	if err := awsec2query.QueryParamsToStruct(q, input); err != nil {
+		return nil, err
+	}
+	return input, nil
+}
+
 // ec2Handler creates a type-safe EC2Handler. Parsing is separate from dispatch
 // so authorization and execution consume the exact same input.
 func ec2Handler[In any](handler func(ctx context.Context, input *In, gw *GatewayConfig, accountID string) (any, error)) ec2Action {
 	return ec2Action{
-		parse: func(q map[string]string) (any, error) {
-			input := new(In)
-			if err := awsec2query.QueryParamsToStruct(q, input); err != nil {
-				return nil, err
-			}
-			return input, nil
-		},
+		parse: parseEC2Input[In],
 		dispatch: func(action string, parsed any, gw *GatewayConfig, accountID string, r *http.Request) ([]byte, error) {
 			input, ok := parsed.(*In)
 			if !ok {
@@ -117,13 +124,7 @@ func marshalEC2Response(action string, output any) ([]byte, error) {
 // e.g. RunInstances which enforces iam:PassRole on the supplied instance profile ARN.
 func ec2HandlerWithReq[In any](handler func(ctx context.Context, input *In, gw *GatewayConfig, accountID string, r *http.Request) (any, error)) ec2Action {
 	return ec2Action{
-		parse: func(q map[string]string) (any, error) {
-			input := new(In)
-			if err := awsec2query.QueryParamsToStruct(q, input); err != nil {
-				return nil, err
-			}
-			return input, nil
-		},
+		parse: parseEC2Input[In],
 		dispatch: func(action string, parsed any, gw *GatewayConfig, accountID string, r *http.Request) ([]byte, error) {
 			input, ok := parsed.(*In)
 			if !ok {
@@ -276,7 +277,7 @@ var ec2Actions = map[string]ec2Action{
 	"RegisterImage": ec2Handler(func(ctx context.Context, input *ec2.RegisterImageInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_image.RegisterImage(ctx, input, gw.NATSConn, accountID)
 	}),
-	"CopyImage": ec2Handler(func(ctx context.Context, input *ec2.CopyImageInput, gw *GatewayConfig, accountID string) (any, error) {
+	"CopyImage": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CopyImageInput, gw *GatewayConfig, accountID string) (ec2.CopyImageOutput, error) {
 		return gateway_ec2_image.CopyImage(ctx, input, gw.NATSConn, gw.Region, accountID)
 	}),
 	"DescribeImageAttribute": ec2Handler(func(ctx context.Context, input *ec2.DescribeImageAttributeInput, gw *GatewayConfig, accountID string) (any, error) {
@@ -303,9 +304,9 @@ var ec2Actions = map[string]ec2Action{
 		}
 		return gateway_ec2_volume.ModifyVolume(ctx, input, gw.NATSConn, accountID)
 	}),
-	"CreateVolume": ec2Handler(func(ctx context.Context, input *ec2.CreateVolumeInput, gw *GatewayConfig, accountID string) (any, error) {
+	"CreateVolume": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CreateVolumeInput, gw *GatewayConfig, accountID string) (ec2.Volume, error) {
 		if err := gw.Quota.EnforceVolumeCreate(ctx, gw.NATSConn, accountID, int(aws.Int64Value(input.Size))); err != nil {
-			return nil, err
+			return ec2.Volume{}, err
 		}
 		return gateway_ec2_volume.CreateVolume(ctx, input, gw.NATSConn, accountID)
 	}),
@@ -381,7 +382,7 @@ var ec2Actions = map[string]ec2Action{
 	"DetachInternetGateway": ec2Handler(func(ctx context.Context, input *ec2.DetachInternetGatewayInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_igw.DetachInternetGateway(ctx, input, gw.NATSConn, accountID)
 	}),
-	"CreateEgressOnlyInternetGateway": ec2Handler(func(ctx context.Context, input *ec2.CreateEgressOnlyInternetGatewayInput, gw *GatewayConfig, accountID string) (any, error) {
+	"CreateEgressOnlyInternetGateway": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CreateEgressOnlyInternetGatewayInput, gw *GatewayConfig, accountID string) (ec2.CreateEgressOnlyInternetGatewayOutput, error) {
 		return gateway_ec2_eigw.CreateEgressOnlyInternetGateway(ctx, input, gw.NATSConn, accountID)
 	}),
 	"DeleteEgressOnlyInternetGateway": ec2Handler(func(ctx context.Context, input *ec2.DeleteEgressOnlyInternetGatewayInput, gw *GatewayConfig, accountID string) (any, error) {
@@ -399,7 +400,7 @@ var ec2Actions = map[string]ec2Action{
 	"DescribePlacementGroups": ec2Handler(func(ctx context.Context, input *ec2.DescribePlacementGroupsInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_placementgroup.DescribePlacementGroups(ctx, input, gw.NATSConn, accountID)
 	}),
-	"CreateCapacityReservation": ec2Handler(func(ctx context.Context, input *ec2.CreateCapacityReservationInput, gw *GatewayConfig, accountID string) (any, error) {
+	"CreateCapacityReservation": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CreateCapacityReservationInput, gw *GatewayConfig, accountID string) (ec2.CreateCapacityReservationOutput, error) {
 		return gateway_ec2_capacityreservation.CreateCapacityReservation(ctx, input, gw.NATSConn, gw.ExpectedNodes, accountID)
 	}),
 	"DescribeCapacityReservations": ec2Handler(func(ctx context.Context, input *ec2.DescribeCapacityReservationsInput, gw *GatewayConfig, accountID string) (any, error) {
@@ -474,7 +475,7 @@ var ec2Actions = map[string]ec2Action{
 	"ModifySubnetAttribute": ec2Handler(func(ctx context.Context, input *ec2.ModifySubnetAttributeInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_vpc.ModifySubnetAttribute(ctx, input, gw.NATSConn, accountID)
 	}),
-	"CreateRouteTable": ec2Handler(func(ctx context.Context, input *ec2.CreateRouteTableInput, gw *GatewayConfig, accountID string) (any, error) {
+	"CreateRouteTable": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CreateRouteTableInput, gw *GatewayConfig, accountID string) (ec2.CreateRouteTableOutput, error) {
 		return gateway_ec2_routetable.CreateRouteTable(ctx, input, gw.NATSConn, accountID)
 	}),
 	"DeleteRouteTable": ec2Handler(func(ctx context.Context, input *ec2.DeleteRouteTableInput, gw *GatewayConfig, accountID string) (any, error) {
@@ -501,7 +502,7 @@ var ec2Actions = map[string]ec2Action{
 	"ReplaceRouteTableAssociation": ec2Handler(func(ctx context.Context, input *ec2.ReplaceRouteTableAssociationInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_routetable.ReplaceRouteTableAssociation(ctx, input, gw.NATSConn, accountID)
 	}),
-	"CreateNetworkInterface": ec2Handler(func(ctx context.Context, input *ec2.CreateNetworkInterfaceInput, gw *GatewayConfig, accountID string) (any, error) {
+	"CreateNetworkInterface": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CreateNetworkInterfaceInput, gw *GatewayConfig, accountID string) (ec2.CreateNetworkInterfaceOutput, error) {
 		return gateway_ec2_vpc.CreateNetworkInterface(ctx, input, gw.NATSConn, accountID)
 	}),
 	"DeleteNetworkInterface": ec2Handler(func(ctx context.Context, input *ec2.DeleteNetworkInterfaceInput, gw *GatewayConfig, accountID string) (any, error) {
@@ -564,7 +565,7 @@ var ec2Actions = map[string]ec2Action{
 	"DescribeAddressesAttribute": ec2Handler(func(ctx context.Context, input *ec2.DescribeAddressesAttributeInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_eip.DescribeAddressesAttribute(ctx, input, gw.NATSConn, accountID)
 	}),
-	"CreateNatGateway": ec2Handler(func(ctx context.Context, input *ec2.CreateNatGatewayInput, gw *GatewayConfig, accountID string) (any, error) {
+	"CreateNatGateway": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CreateNatGatewayInput, gw *GatewayConfig, accountID string) (ec2.CreateNatGatewayOutput, error) {
 		return gateway_ec2_natgw.CreateNatGateway(ctx, input, gw.NATSConn, accountID)
 	}),
 	"DeleteNatGateway": ec2Handler(func(ctx context.Context, input *ec2.DeleteNatGatewayInput, gw *GatewayConfig, accountID string) (any, error) {

--- a/spinifex/gateway/ec2/idem/idem.go
+++ b/spinifex/gateway/ec2/idem/idem.go
@@ -1,0 +1,56 @@
+// Package gateway_ec2_idem holds the client-token plumbing shared by the EC2
+// gateway: the KV bucket every EC2 action's token records live in, and the
+// extraction of a token and parameter hash from an SDK input struct.
+package gateway_ec2_idem
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/idempotency"
+)
+
+const (
+	// KVBucket is the JetStream KV bucket for EC2 ClientToken records. One
+	// bucket for the whole EC2 surface; per-action stores namespace their keys.
+	KVBucket = "spinifex-ec2-clienttokens"
+
+	// TTL must outlast SDK retry windows; short enough that a crashed in-flight
+	// record ages out and frees the token for a fresh attempt.
+	TTL = 15 * time.Minute
+
+	// tokenField is the ClientToken field on every EC2 input struct that
+	// supports idempotency.
+	tokenField = "ClientToken"
+)
+
+// TokenAndParams reads the ClientToken off an SDK input struct and hashes the
+// request with the token cleared, so identical requests always hash alike. It
+// reports false when the input carries no usable token, which means the caller
+// asked for no idempotency and the request runs unwrapped.
+func TokenAndParams(input any) (token, paramHash string, ok bool) {
+	v := reflect.ValueOf(input)
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return "", "", false
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return "", "", false
+	}
+	field := v.FieldByName(tokenField)
+	if !field.IsValid() || field.Kind() != reflect.Pointer || field.Type().Elem().Kind() != reflect.String {
+		return "", "", false
+	}
+	if field.IsNil() || field.Elem().String() == "" {
+		return "", "", false
+	}
+
+	// Hash a copy with the token cleared rather than the original: the caller's
+	// input is dispatched afterwards and must reach the handler intact.
+	clone := reflect.New(v.Type()).Elem()
+	clone.Set(v)
+	clone.FieldByName(tokenField).Set(reflect.Zero(field.Type()))
+	return field.Elem().String(), idempotency.ParamHash(clone.Addr().Interface()), true
+}

--- a/spinifex/gateway/ec2/idem/idem_test.go
+++ b/spinifex/gateway/ec2/idem/idem_test.go
@@ -1,0 +1,81 @@
+package gateway_ec2_idem_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	gateway_ec2_idem "github.com/mulgadc/spinifex/spinifex/gateway/ec2/idem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every converted action's input type has to yield its token, since the
+// decorator reads the field reflectively rather than per action.
+func TestTokenAndParams_ReadsEveryConvertedInput(t *testing.T) {
+	t.Parallel()
+	inputs := map[string]any{
+		"CreateVolume":                    &ec2.CreateVolumeInput{ClientToken: aws.String("tok")},
+		"CreateNetworkInterface":          &ec2.CreateNetworkInterfaceInput{ClientToken: aws.String("tok")},
+		"CreateNatGateway":                &ec2.CreateNatGatewayInput{ClientToken: aws.String("tok")},
+		"CreateRouteTable":                &ec2.CreateRouteTableInput{ClientToken: aws.String("tok")},
+		"CreateEgressOnlyInternetGateway": &ec2.CreateEgressOnlyInternetGatewayInput{ClientToken: aws.String("tok")},
+		"CopyImage":                       &ec2.CopyImageInput{ClientToken: aws.String("tok")},
+		"CreateCapacityReservation":       &ec2.CreateCapacityReservationInput{ClientToken: aws.String("tok")},
+	}
+	for action, input := range inputs {
+		token, hash, ok := gateway_ec2_idem.TokenAndParams(input)
+		require.True(t, ok, "%s must expose its ClientToken", action)
+		assert.Equal(t, "tok", token, action)
+		assert.NotEmpty(t, hash, action)
+	}
+}
+
+// No token means the client did not ask for idempotency, so the request runs
+// unwrapped rather than being rejected.
+func TestTokenAndParams_NoTokenOptsOut(t *testing.T) {
+	t.Parallel()
+	cases := map[string]any{
+		"nil field":     &ec2.CreateVolumeInput{},
+		"empty string":  &ec2.CreateVolumeInput{ClientToken: aws.String("")},
+		"nil pointer":   (*ec2.CreateVolumeInput)(nil),
+		"no such field": &ec2.DescribeVolumesInput{},
+		"not a struct":  aws.String("tok"),
+	}
+	for name, input := range cases {
+		_, _, ok := gateway_ec2_idem.TokenAndParams(input)
+		assert.False(t, ok, name)
+	}
+}
+
+// The hash must ignore the token itself: a retry carries the same token and the
+// same params, and a different token with the same params is different work.
+func TestTokenAndParams_HashIgnoresTheToken(t *testing.T) {
+	t.Parallel()
+	first := &ec2.CreateVolumeInput{Size: aws.Int64(8), ClientToken: aws.String("a")}
+	sameParams := &ec2.CreateVolumeInput{Size: aws.Int64(8), ClientToken: aws.String("b")}
+	changed := &ec2.CreateVolumeInput{Size: aws.Int64(16), ClientToken: aws.String("a")}
+
+	_, firstHash, ok := gateway_ec2_idem.TokenAndParams(first)
+	require.True(t, ok)
+	_, sameHash, ok := gateway_ec2_idem.TokenAndParams(sameParams)
+	require.True(t, ok)
+	_, changedHash, ok := gateway_ec2_idem.TokenAndParams(changed)
+	require.True(t, ok)
+
+	assert.Equal(t, firstHash, sameHash, "the token must not feed the hash")
+	assert.NotEqual(t, firstHash, changedHash, "changed params must change the hash")
+}
+
+// The input is dispatched to the handler after hashing, so clearing the token
+// for the hash must not clear it on the caller's struct.
+func TestTokenAndParams_LeavesTheInputIntact(t *testing.T) {
+	t.Parallel()
+	input := &ec2.CreateVolumeInput{Size: aws.Int64(8), ClientToken: aws.String("tok")}
+
+	_, _, ok := gateway_ec2_idem.TokenAndParams(input)
+	require.True(t, ok)
+
+	require.NotNil(t, input.ClientToken)
+	assert.Equal(t, "tok", *input.ClientToken)
+}

--- a/spinifex/gateway/ec2/image/CopyImage.go
+++ b/spinifex/gateway/ec2/image/CopyImage.go
@@ -13,7 +13,7 @@ import (
 
 // ValidateCopyImageInput validates the input parameters for CopyImage.
 // Copy is single-region and metadata-only; cross-region, encryption, and
-// Outposts are rejected here. ClientToken is accepted but not honoured.
+// Outposts are rejected here.
 func ValidateCopyImageInput(input *ec2.CopyImageInput, gwRegion string) error {
 	if input == nil {
 		return errors.New(awserrors.ErrorMissingParameter)

--- a/spinifex/gateway/ec2/instance/clienttoken.go
+++ b/spinifex/gateway/ec2/instance/clienttoken.go
@@ -6,22 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_ec2_idem "github.com/mulgadc/spinifex/spinifex/gateway/ec2/idem"
 	"github.com/mulgadc/spinifex/spinifex/idempotency"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-)
-
-const (
-	// kvBucketClientTokens is the JetStream KV bucket for ClientToken records.
-	kvBucketClientTokens = "spinifex-ec2-clienttokens" //nolint:gosec // G101 false positive: KV bucket name, not a credential
-
-	// clientTokenTTL must outlast SDK retry windows; short enough that a crashed
-	// in-flight record ages out and frees the token for a fresh launch.
-	clientTokenTTL = 15 * time.Minute
 )
 
 // ClientTokenStore is the RunInstances idempotency store: the first caller owns
@@ -53,8 +44,11 @@ func getClientTokenStore(ctx context.Context, nc *nats.Conn) (*ClientTokenStore,
 	return ctStore, errCTStoreInit
 }
 
+// newClientTokenStore takes the bucket unnamespaced. Every other EC2 action
+// namespaces its keys by action, but RunInstances predates that: re-keying live
+// records would make a retry re-launch instead of replay.
 func newClientTokenStore(ctx context.Context, js jetstream.JetStream) (*ClientTokenStore, error) {
-	return idempotency.OpenStore[ec2.Reservation](ctx, js, kvBucketClientTokens, clientTokenTTL)
+	return idempotency.OpenStore[ec2.Reservation](ctx, js, gateway_ec2_idem.KVBucket, gateway_ec2_idem.TTL)
 }
 
 // clientTokenParamHash hashes the request excluding ClientToken, so the same
@@ -65,44 +59,22 @@ func clientTokenParamHash(input *ec2.RunInstancesInput) string {
 	return idempotency.ParamHash(&clone)
 }
 
-// runInstancesWithClientToken wraps a launch in ClientToken idempotency:
-// claims the token, replays a completed reservation, or (as owner) launches,
-// finalizes, and aborts on failure. Extracted for unit-testability.
+// runInstancesWithClientToken wraps a launch in ClientToken idempotency and maps
+// the token errors onto the AWS ones RunInstances returns. Extracted for
+// unit-testability.
 func runInstancesWithClientToken(
 	ctx context.Context,
 	store *ClientTokenStore,
 	accountID, token, paramHash string,
 	launch func() (ec2.Reservation, error),
 ) (ec2.Reservation, error) {
-	var zero ec2.Reservation
-	replay, owned, cerr := store.Claim(ctx, accountID, token, paramHash)
-	if cerr != nil {
-		if errors.Is(cerr, idempotency.ErrParamMismatch) {
-			return zero, errors.New(awserrors.ErrorIdempotentParameterMismatch)
-		}
-		slog.Error("RunInstances: client-token claim failed", "token", token, "err", cerr)
-		return zero, errors.New(awserrors.ErrorServerInternal)
+	res, err := idempotency.Do(ctx, store, accountID, token, paramHash, launch)
+	switch {
+	case errors.Is(err, idempotency.ErrParamMismatch):
+		return ec2.Reservation{}, errors.New(awserrors.ErrorIdempotentParameterMismatch)
+	case errors.Is(err, idempotency.ErrUnavailable):
+		slog.ErrorContext(ctx, "RunInstances: client-token claim failed", "token", token, "err", err)
+		return ec2.Reservation{}, errors.New(awserrors.ErrorServerInternal)
 	}
-	if replay != nil {
-		return *replay, nil
-	}
-	if !owned {
-		return zero, errors.New(awserrors.ErrorServerInternal)
-	}
-
-	res, rerr := launch()
-
-	// Recording the launch outcome outlives ctx: a caller that went away mid-launch
-	// is exactly when the record must be settled, and leaving it in-flight parks
-	// every retry of that token behind the poll deadline until the record ages out.
-	outcomeCtx := context.WithoutCancel(ctx)
-	if rerr != nil {
-		store.Abort(outcomeCtx, accountID, token)
-		return zero, rerr
-	}
-	if ferr := store.Finalize(outcomeCtx, accountID, token, paramHash, res); ferr != nil {
-		// Launch succeeded; finalize failure only weakens future dedup — don't fail.
-		slog.Warn("RunInstances: failed to finalize client-token record", "token", token, "err", ferr)
-	}
-	return res, nil
+	return res, err
 }

--- a/spinifex/gateway/ec2_idempotency.go
+++ b/spinifex/gateway/ec2_idempotency.go
@@ -1,0 +1,97 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_ec2_idem "github.com/mulgadc/spinifex/spinifex/gateway/ec2/idem"
+	"github.com/mulgadc/spinifex/spinifex/idempotency"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ec2ClientTokenBucket lazily binds the EC2 token bucket, once per gateway
+// rather than once per request.
+func (gw *GatewayConfig) ec2ClientTokenBucket(ctx context.Context) (jetstream.KeyValue, error) {
+	gw.ec2TokenOnce.Do(func() {
+		js, err := jetstream.New(gw.NATSConn)
+		if err != nil {
+			gw.ec2TokenErr = fmt.Errorf("clienttoken jetstream: %w", err)
+			return
+		}
+		// The bind happens once, so it must not inherit the first caller's
+		// cancellation: a client that disconnects mid-open would poison the
+		// bucket for every later request. Deadline-free, so the open falls back
+		// to the JetStream API's own timeout.
+		gw.ec2TokenKV, gw.ec2TokenErr = idempotency.OpenBucket(
+			context.WithoutCancel(ctx), js, gateway_ec2_idem.KVBucket, gateway_ec2_idem.TTL)
+	})
+	return gw.ec2TokenKV, gw.ec2TokenErr
+}
+
+// ec2IdempotentHandler is ec2Handler for creates that honour ClientToken: a
+// repeat of the same token returns the first call's result instead of creating
+// a second resource. Out is pinned so the result can be stored and replayed.
+func ec2IdempotentHandler[In, Out any](handler func(ctx context.Context, input *In, gw *GatewayConfig, accountID string) (Out, error)) ec2Action {
+	return ec2Action{
+		idempotent: true,
+		parse:      parseEC2Input[In],
+		dispatch: func(action string, parsed any, gw *GatewayConfig, accountID string, r *http.Request) ([]byte, error) {
+			input, ok := parsed.(*In)
+			if !ok {
+				return nil, errors.New(awserrors.ErrorInternalError)
+			}
+			ctx := requestContext(r)
+			output, err := runEC2Idempotent(ctx, action, gw, accountID, input, func() (Out, error) {
+				return handler(ctx, input, gw, accountID)
+			})
+			if err != nil {
+				return nil, err
+			}
+			return marshalEC2Response(action, output)
+		},
+	}
+}
+
+// runEC2Idempotent runs work under the input's ClientToken. Requests without one
+// run unwrapped, which is what AWS does: the token is how a client opts in.
+func runEC2Idempotent[In, Out any](
+	ctx context.Context,
+	action string,
+	gw *GatewayConfig,
+	accountID string,
+	input *In,
+	work func() (Out, error),
+) (Out, error) {
+	var zero Out
+	// Hashed before the handler runs, so a handler that mutates its input cannot
+	// change what a retry of the same token hashes to.
+	token, paramHash, ok := gateway_ec2_idem.TokenAndParams(input)
+	if !ok {
+		return work()
+	}
+
+	kv, kerr := gw.ec2ClientTokenBucket(ctx)
+	if kerr != nil {
+		// Running anyway would create the duplicate the token was sent to
+		// prevent, so this fails rather than degrading to no idempotency.
+		slog.ErrorContext(ctx, "client-token store unavailable", "action", action, "err", kerr)
+		return zero, errors.New(awserrors.ErrorServerInternal)
+	}
+
+	// Namespaced by action: one bucket holds every EC2 action's records, and
+	// without the prefix one action's payload could be decoded as another's Out.
+	store := idempotency.NewStore[Out](kv, action)
+	output, err := idempotency.Do(ctx, store, accountID, token, paramHash, work)
+	switch {
+	case errors.Is(err, idempotency.ErrParamMismatch):
+		return zero, errors.New(awserrors.ErrorIdempotentParameterMismatch)
+	case errors.Is(err, idempotency.ErrUnavailable):
+		slog.ErrorContext(ctx, "client-token replay unavailable", "action", action, "token", token, "err", err)
+		return zero, errors.New(awserrors.ErrorServerInternal)
+	}
+	return output, err
+}

--- a/spinifex/gateway/ec2_idempotency_test.go
+++ b/spinifex/gateway/ec2_idempotency_test.go
@@ -1,0 +1,301 @@
+//test:in-package — the decorator, the action table and the gateway's token
+//bucket field are all unexported, and the point of these tests is that the
+//table's entries are wired to the decorator.
+
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/idempotency"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const idemTestAccount = "111122223333"
+
+// responseFields returns an EC2 response's leaf path=value pairs, sorted. The
+// XML builder emits elements in map order, so two renderings of one value
+// differ in element order but not in content; the request id is dropped because
+// it is freshly minted per response.
+func responseFields(t *testing.T, doc []byte) []string {
+	t.Helper()
+	var fields []string
+	var path []string
+	decoder := xml.NewDecoder(bytes.NewReader(doc))
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		switch tok := token.(type) {
+		case xml.StartElement:
+			path = append(path, tok.Name.Local)
+			fields = append(fields, strings.Join(path, "/"))
+		case xml.EndElement:
+			path = path[:len(path)-1]
+		case xml.CharData:
+			if text := strings.TrimSpace(string(tok)); text != "" {
+				fields = append(fields, strings.Join(path, "/")+"="+text)
+			}
+		}
+	}
+	fields = slices.DeleteFunc(fields, func(f string) bool {
+		return strings.Contains(f, "requestId")
+	})
+	slices.Sort(fields)
+	return fields
+}
+
+// newTokenGateway returns a gateway whose client-token bucket is already bound
+// to a test JetStream, so dispatch never reaches a real NATS connection.
+func newTokenGateway(t *testing.T) *GatewayConfig {
+	t.Helper()
+	_, nc, _ := testutil.StartTestJetStream(t)
+	kv, err := idempotency.OpenBucket(t.Context(), testutil.NewJetStream(t, nc), "gw-ec2-tokens", time.Minute)
+	require.NoError(t, err)
+
+	gw := &GatewayConfig{}
+	// Burns the Once as it binds, so ec2ClientTokenBucket returns this bucket
+	// rather than dialing.
+	gw.ec2TokenOnce.Do(func() { gw.ec2TokenKV = kv })
+	return gw
+}
+
+// dispatchTwice runs one action twice through the decorator with the same input
+// and reports how many times the create actually ran.
+func dispatchTwice[In, Out any](t *testing.T, gw *GatewayConfig, action string, input *In, result Out) (calls int, first, second []byte) {
+	t.Helper()
+	handler := ec2IdempotentHandler(func(ctx context.Context, in *In, gw *GatewayConfig, accountID string) (Out, error) {
+		calls++
+		return result, nil
+	})
+	first, err := handler.dispatch(action, input, gw, idemTestAccount, nil)
+	require.NoError(t, err)
+	second, err = handler.dispatch(action, input, gw, idemTestAccount, nil)
+	require.NoError(t, err)
+	return calls, first, second
+}
+
+// The bead's acceptance criterion, per converted action: the same token twice
+// creates one resource and the duplicate gets the first call's response.
+func TestIdempotentHandler_SameTokenCreatesOneResource(t *testing.T) {
+	t.Parallel()
+	tok := aws.String("tok-1")
+
+	t.Run("CreateVolume", func(t *testing.T) {
+		t.Parallel()
+		gw := newTokenGateway(t)
+		calls, first, second := dispatchTwice(t, gw, "CreateVolume",
+			&ec2.CreateVolumeInput{Size: aws.Int64(8), ClientToken: tok},
+			ec2.Volume{VolumeId: aws.String("vol-1")})
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, responseFields(t, first), responseFields(t, second))
+		assert.Contains(t, string(second), "vol-1")
+	})
+
+	t.Run("CreateNetworkInterface", func(t *testing.T) {
+		t.Parallel()
+		gw := newTokenGateway(t)
+		calls, first, second := dispatchTwice(t, gw, "CreateNetworkInterface",
+			&ec2.CreateNetworkInterfaceInput{ClientToken: tok},
+			ec2.CreateNetworkInterfaceOutput{
+				NetworkInterface: &ec2.NetworkInterface{NetworkInterfaceId: aws.String("eni-1")},
+			})
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, responseFields(t, first), responseFields(t, second))
+		assert.Contains(t, string(second), "eni-1")
+	})
+
+	// Both IDs have to survive the replay: re-creating either one leaks it.
+	t.Run("CreateNatGateway", func(t *testing.T) {
+		t.Parallel()
+		gw := newTokenGateway(t)
+		calls, first, second := dispatchTwice(t, gw, "CreateNatGateway",
+			&ec2.CreateNatGatewayInput{ClientToken: tok},
+			ec2.CreateNatGatewayOutput{
+				NatGateway: &ec2.NatGateway{
+					NatGatewayId: aws.String("nat-1"),
+					NatGatewayAddresses: []*ec2.NatGatewayAddress{
+						{AssociationId: aws.String("eipassoc-1")},
+					},
+				},
+			})
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, responseFields(t, first), responseFields(t, second))
+		assert.Contains(t, string(second), "nat-1")
+		assert.Contains(t, string(second), "eipassoc-1")
+	})
+
+	t.Run("CreateRouteTable", func(t *testing.T) {
+		t.Parallel()
+		gw := newTokenGateway(t)
+		calls, first, second := dispatchTwice(t, gw, "CreateRouteTable",
+			&ec2.CreateRouteTableInput{ClientToken: tok},
+			ec2.CreateRouteTableOutput{
+				RouteTable: &ec2.RouteTable{
+					RouteTableId: aws.String("rtb-1"),
+					Associations: []*ec2.RouteTableAssociation{
+						{RouteTableAssociationId: aws.String("rtbassoc-1")},
+					},
+				},
+			})
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, responseFields(t, first), responseFields(t, second))
+		assert.Contains(t, string(second), "rtb-1")
+		assert.Contains(t, string(second), "rtbassoc-1")
+	})
+
+	t.Run("CreateEgressOnlyInternetGateway", func(t *testing.T) {
+		t.Parallel()
+		gw := newTokenGateway(t)
+		calls, first, second := dispatchTwice(t, gw, "CreateEgressOnlyInternetGateway",
+			&ec2.CreateEgressOnlyInternetGatewayInput{ClientToken: tok},
+			ec2.CreateEgressOnlyInternetGatewayOutput{
+				EgressOnlyInternetGateway: &ec2.EgressOnlyInternetGateway{
+					EgressOnlyInternetGatewayId: aws.String("eigw-1"),
+				},
+			})
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, responseFields(t, first), responseFields(t, second))
+		assert.Contains(t, string(second), "eigw-1")
+	})
+
+	t.Run("CopyImage", func(t *testing.T) {
+		t.Parallel()
+		gw := newTokenGateway(t)
+		calls, first, second := dispatchTwice(t, gw, "CopyImage",
+			&ec2.CopyImageInput{Name: aws.String("copy"), ClientToken: tok},
+			ec2.CopyImageOutput{ImageId: aws.String("ami-1")})
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, responseFields(t, first), responseFields(t, second))
+		assert.Contains(t, string(second), "ami-1")
+	})
+
+	t.Run("CreateCapacityReservation", func(t *testing.T) {
+		t.Parallel()
+		gw := newTokenGateway(t)
+		calls, first, second := dispatchTwice(t, gw, "CreateCapacityReservation",
+			&ec2.CreateCapacityReservationInput{ClientToken: tok},
+			ec2.CreateCapacityReservationOutput{
+				CapacityReservation: &ec2.CapacityReservation{
+					CapacityReservationId: aws.String("cr-1"),
+				},
+			})
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, responseFields(t, first), responseFields(t, second))
+		assert.Contains(t, string(second), "cr-1")
+	})
+}
+
+// Actions share one bucket, so the same token on two actions must be two
+// separate pieces of work rather than one replaying the other's response.
+func TestIdempotentHandler_TokensAreScopedPerAction(t *testing.T) {
+	t.Parallel()
+	gw := newTokenGateway(t)
+	tok := aws.String("shared-token")
+
+	volumeCalls, _, _ := dispatchTwice(t, gw, "CreateVolume",
+		&ec2.CreateVolumeInput{ClientToken: tok}, ec2.Volume{VolumeId: aws.String("vol-1")})
+	require.Equal(t, 1, volumeCalls)
+
+	eigwCalls, _, second := dispatchTwice(t, gw, "CreateEgressOnlyInternetGateway",
+		&ec2.CreateEgressOnlyInternetGatewayInput{ClientToken: tok},
+		ec2.CreateEgressOnlyInternetGatewayOutput{
+			EgressOnlyInternetGateway: &ec2.EgressOnlyInternetGateway{
+				EgressOnlyInternetGatewayId: aws.String("eigw-1"),
+			},
+		})
+	assert.Equal(t, 1, eigwCalls, "a second action still runs its own create once")
+	assert.Contains(t, string(second), "eigw-1")
+	assert.NotContains(t, string(second), "vol-1")
+}
+
+// One token with changed parameters is the AWS mismatch case, and the create
+// must not run.
+func TestIdempotentHandler_ParamMismatchIsRejected(t *testing.T) {
+	t.Parallel()
+	gw := newTokenGateway(t)
+	calls := 0
+	handler := ec2IdempotentHandler(func(ctx context.Context, in *ec2.CreateVolumeInput, gw *GatewayConfig, accountID string) (ec2.Volume, error) {
+		calls++
+		return ec2.Volume{VolumeId: aws.String("vol-1")}, nil
+	})
+
+	_, err := handler.dispatch("CreateVolume",
+		&ec2.CreateVolumeInput{Size: aws.Int64(8), ClientToken: aws.String("tok-mm")}, gw, idemTestAccount, nil)
+	require.NoError(t, err)
+
+	_, err = handler.dispatch("CreateVolume",
+		&ec2.CreateVolumeInput{Size: aws.Int64(16), ClientToken: aws.String("tok-mm")}, gw, idemTestAccount, nil)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorIdempotentParameterMismatch, err.Error())
+	assert.Equal(t, 1, calls, "a mismatched token must not create anything")
+}
+
+// Without a token the client did not ask for idempotency, so each call creates.
+func TestIdempotentHandler_NoTokenCreatesEachTime(t *testing.T) {
+	t.Parallel()
+	gw := newTokenGateway(t)
+	calls, _, _ := dispatchTwice(t, gw, "CreateVolume",
+		&ec2.CreateVolumeInput{Size: aws.Int64(8)}, ec2.Volume{VolumeId: aws.String("vol-1")})
+	assert.Equal(t, 2, calls)
+}
+
+// A create that failed was never made, so retrying the token must attempt it
+// again rather than replay the failure.
+func TestIdempotentHandler_FailedCreateIsRetryable(t *testing.T) {
+	t.Parallel()
+	gw := newTokenGateway(t)
+	boom := errors.New("create failed")
+	calls := 0
+	handler := ec2IdempotentHandler(func(ctx context.Context, in *ec2.CreateVolumeInput, gw *GatewayConfig, accountID string) (ec2.Volume, error) {
+		calls++
+		if calls == 1 {
+			return ec2.Volume{}, boom
+		}
+		return ec2.Volume{VolumeId: aws.String("vol-1")}, nil
+	})
+	input := &ec2.CreateVolumeInput{Size: aws.Int64(8), ClientToken: aws.String("tok-retry")}
+
+	_, err := handler.dispatch("CreateVolume", input, gw, idemTestAccount, nil)
+	require.ErrorIs(t, err, boom, "the handler's own error reaches the caller unchanged")
+
+	out, err := handler.dispatch("CreateVolume", input, gw, idemTestAccount, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+	assert.Contains(t, string(out), "vol-1")
+}
+
+// The creates that leak or cost money on a duplicate must stay wired to the
+// idempotent constructor; reverting one to ec2Handler would silently drop it.
+func TestEC2Actions_CreatesHonourClientToken(t *testing.T) {
+	t.Parallel()
+	honoured := []string{
+		"CopyImage",
+		"CreateCapacityReservation",
+		"CreateEgressOnlyInternetGateway",
+		"CreateNatGateway",
+		"CreateNetworkInterface",
+		"CreateRouteTable",
+		"CreateVolume",
+	}
+	for _, action := range honoured {
+		entry, ok := ec2Actions[action]
+		require.True(t, ok, "%s must be a registered action", action)
+		assert.True(t, entry.idempotent, "%s must honour ClientToken", action)
+	}
+}

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -38,6 +38,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -105,7 +106,12 @@ type GatewayConfig struct {
 	activeNodesMu    sync.RWMutex
 	activeNodesCount int
 	activeNodesAt    time.Time
-	InternalSuffix   string // Internal DNS suffix for AWS-parity endpoints (e.g. spinifex.internal)
+	// The EC2 client-token KV binding, bound on first use and reused after, so
+	// the creates that honour ClientToken do not rebind it per request.
+	ec2TokenOnce   sync.Once
+	ec2TokenKV     jetstream.KeyValue
+	ec2TokenErr    error
+	InternalSuffix string // Internal DNS suffix for AWS-parity endpoints (e.g. spinifex.internal)
 	// RegistryPort is the gateway's advertised port, appended to the ECR
 	// registry host so docker login/tag/push dial the right port. Empty or
 	// "443" renders a port-less host (standard HTTPS parity).

--- a/spinifex/idempotency/do.go
+++ b/spinifex/idempotency/do.go
@@ -1,0 +1,54 @@
+package idempotency
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// ErrNoReplay signals a finalized record that carries no payload, so there is
+// nothing to return and re-running would defeat the token.
+var ErrNoReplay = fmt.Errorf("%w: completed token has no payload to replay", ErrUnavailable)
+
+// Do runs work under a token: the first caller runs it, duplicates replay its
+// result. Errors from work are returned as-is; the token errors are this
+// package's sentinels, which callers map onto their own API errors.
+//
+// EKS CreateCluster does not use this: it interleaves aborts through a long
+// create and replays by re-reading the cluster rather than from the payload.
+func Do[T any](
+	ctx context.Context,
+	store *Store[T],
+	accountID, token, paramHash string,
+	work func() (T, error),
+) (T, error) {
+	var zero T
+	replay, owned, err := store.Claim(ctx, accountID, token, paramHash)
+	if err != nil {
+		return zero, err
+	}
+	if replay != nil {
+		return *replay, nil
+	}
+	if !owned {
+		return zero, ErrNoReplay
+	}
+
+	result, werr := work()
+
+	// Settling the record outlives ctx: a caller that went away mid-request is
+	// exactly when it must be settled, and leaving it in-flight parks every retry
+	// of that token behind the poll deadline until the record ages out.
+	outcomeCtx := context.WithoutCancel(ctx)
+	if werr != nil {
+		store.Abort(outcomeCtx, accountID, token)
+		return zero, werr
+	}
+	if ferr := store.Finalize(outcomeCtx, accountID, token, paramHash, result); ferr != nil {
+		// The work succeeded; a finalize failure only weakens later dedup, and
+		// failing here would report a completed create as an error.
+		slog.WarnContext(ctx, "idempotency: failed to finalize token record",
+			"namespace", store.namespace, "token", token, "err", ferr)
+	}
+	return result, nil
+}

--- a/spinifex/idempotency/do_test.go
+++ b/spinifex/idempotency/do_test.go
@@ -1,0 +1,85 @@
+package idempotency_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/idempotency"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The property the whole feature rests on: one token, two calls, the work runs
+// once and both callers get the same result.
+func TestDo_RunsWorkOncePerToken(t *testing.T) {
+	t.Parallel()
+	store := newTestStore[payload](t)
+	const tok, hash = "do-1", "h"
+	runs := 0
+	work := func() (payload, error) {
+		runs++
+		return payload{ID: "r-1"}, nil
+	}
+
+	first, err := idempotency.Do(t.Context(), store, testAccount, tok, hash, work)
+	require.NoError(t, err)
+	second, err := idempotency.Do(t.Context(), store, testAccount, tok, hash, work)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, runs, "the duplicate must replay, not re-run the work")
+	assert.Equal(t, "r-1", first.ID)
+	assert.Equal(t, first, second, "the duplicate returns the first call's result")
+}
+
+// A failed attempt must not be replayed as if it had succeeded: the token is
+// released so a retry gets a real attempt.
+func TestDo_FailedWorkIsRetryable(t *testing.T) {
+	t.Parallel()
+	store := newTestStore[payload](t)
+	const tok, hash = "do-2", "h"
+	boom := errors.New("create failed")
+
+	_, err := idempotency.Do(t.Context(), store, testAccount, tok, hash, func() (payload, error) {
+		return payload{}, boom
+	})
+	require.ErrorIs(t, err, boom, "the work's own error passes through unwrapped")
+
+	runs := 0
+	out, err := idempotency.Do(t.Context(), store, testAccount, tok, hash, func() (payload, error) {
+		runs++
+		return payload{ID: "r-2"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, runs, "the retry re-runs the work")
+	assert.Equal(t, "r-2", out.ID)
+}
+
+// Reusing a token with different parameters is the caller's error, and must not
+// run the work at all.
+func TestDo_ParamMismatchDoesNotRunWork(t *testing.T) {
+	t.Parallel()
+	store := newTestStore[payload](t)
+	const tok = "do-3"
+
+	_, err := idempotency.Do(t.Context(), store, testAccount, tok, "hash-a", func() (payload, error) {
+		return payload{ID: "r-3"}, nil
+	})
+	require.NoError(t, err)
+
+	ran := false
+	_, err = idempotency.Do(t.Context(), store, testAccount, tok, "hash-b", func() (payload, error) {
+		ran = true
+		return payload{}, nil
+	})
+	assert.ErrorIs(t, err, idempotency.ErrParamMismatch)
+	assert.False(t, ran, "a mismatched token must not do the work")
+}
+
+// Callers map every non-mismatch token failure onto one API error, so they all
+// have to be reachable through ErrUnavailable.
+func TestTokenFailuresAreUnavailable(t *testing.T) {
+	t.Parallel()
+	assert.ErrorIs(t, idempotency.ErrWaitTimeout, idempotency.ErrUnavailable)
+	assert.ErrorIs(t, idempotency.ErrNoReplay, idempotency.ErrUnavailable)
+	assert.NotErrorIs(t, idempotency.ErrParamMismatch, idempotency.ErrUnavailable)
+}

--- a/spinifex/idempotency/store.go
+++ b/spinifex/idempotency/store.go
@@ -28,11 +28,16 @@ var (
 	pollStep    = 250 * time.Millisecond
 )
 
-// ErrParamMismatch signals a token reused with different request parameters.
-// ErrWaitTimeout signals a duplicate polled an in-flight owner past WaitTimeout.
+// ErrParamMismatch signals a token reused with different request parameters: a
+// caller error, and the only token failure that is not ErrUnavailable.
+var ErrParamMismatch = errors.New("idempotency: parameter mismatch")
+
+// ErrUnavailable signals the token record could not be read or settled, so the
+// request cannot be safely deduplicated. Every store failure wraps it, which is
+// what lets a caller map them all onto one API error.
 var (
-	ErrParamMismatch = errors.New("idempotency: parameter mismatch")
-	ErrWaitTimeout   = errors.New("idempotency: timed out waiting for the in-flight owner")
+	ErrUnavailable = errors.New("idempotency: token record unavailable")
+	ErrWaitTimeout = fmt.Errorf("%w: timed out waiting for the in-flight owner", ErrUnavailable)
 )
 
 // record is the per-token record stored in the KV bucket.
@@ -46,13 +51,14 @@ type record[T any] struct {
 // Store owns the token records for one kind of request. T is what a duplicate
 // caller replays: a whole response, or just the name of what was created.
 type Store[T any] struct {
-	kv jetstream.KeyValue
+	kv        jetstream.KeyValue
+	namespace string
 }
 
-// OpenStore binds the bucket, creating it with the given TTL if absent. The
-// caller owns the JetStream handle, so a store never outlives the connection it
-// was built from.
-func OpenStore[T any](ctx context.Context, js jetstream.JetStream, bucket string, ttl time.Duration) (*Store[T], error) {
+// OpenBucket binds the bucket, creating it with the given TTL if absent. Split
+// from NewStore so several typed stores can share one bucket without rebinding
+// it per request.
+func OpenBucket(ctx context.Context, js jetstream.JetStream, bucket string, ttl time.Duration) (jetstream.KeyValue, error) {
 	kv, err := js.KeyValue(ctx, bucket)
 	if errors.Is(err, jetstream.ErrBucketNotFound) {
 		kv, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
@@ -64,13 +70,41 @@ func OpenStore[T any](ctx context.Context, js jetstream.JetStream, bucket string
 	if err != nil {
 		return nil, fmt.Errorf("open idempotency bucket %s: %w", bucket, err)
 	}
-	return &Store[T]{kv: kv}, nil
+	return kv, nil
+}
+
+// NewStore builds a typed view over an already-bound bucket. Stores sharing a
+// bucket must use distinct namespaces, else one caller's record is decoded as
+// another caller's T.
+func NewStore[T any](kv jetstream.KeyValue, namespace string) *Store[T] {
+	return &Store[T]{kv: kv, namespace: namespace}
+}
+
+// OpenStore binds the bucket and takes the whole of it, with unprefixed keys.
+// The caller owns the JetStream handle, so a store never outlives the
+// connection it was built from.
+func OpenStore[T any](ctx context.Context, js jetstream.JetStream, bucket string, ttl time.Duration) (*Store[T], error) {
+	kv, err := OpenBucket(ctx, js, bucket, ttl)
+	if err != nil {
+		return nil, err
+	}
+	return NewStore[T](kv, ""), nil
 }
 
 // Key scopes a token to its account, so the same token from two accounts is two
 // separate pieces of work.
 func Key(accountID, token string) string {
 	return accountID + "." + token
+}
+
+// key prefixes Key with the store's namespace. An empty namespace yields the
+// bare account.token key, which is what the stores that predate namespacing
+// have on disk.
+func (s *Store[T]) key(accountID, token string) string {
+	if s.namespace == "" {
+		return Key(accountID, token)
+	}
+	return s.namespace + "." + Key(accountID, token)
 }
 
 // ParamHash hashes a request so a token reused with different parameters is
@@ -90,19 +124,19 @@ func ParamHash(request any) string {
 // when the caller owns it and must Finalize or Abort, (payload, false, nil) to
 // replay a completed one, or an error on mismatch or timeout.
 func (s *Store[T]) Claim(ctx context.Context, accountID, token, paramHash string) (*T, bool, error) {
-	key := Key(accountID, token)
+	key := s.key(accountID, token)
 	inflight, err := json.Marshal(record[T]{
 		Status:    statusInFlight,
 		ParamHash: paramHash,
 		StartedAt: time.Now().UTC(),
 	})
 	if err != nil {
-		return nil, false, fmt.Errorf("idempotency marshal: %w", err)
+		return nil, false, fmt.Errorf("%w: marshal: %w", ErrUnavailable, err)
 	}
 	if _, cerr := s.kv.Create(ctx, key, inflight); cerr == nil {
 		return nil, true, nil
 	} else if !errors.Is(cerr, jetstream.ErrKeyExists) {
-		return nil, false, fmt.Errorf("idempotency create %s: %w", key, cerr)
+		return nil, false, fmt.Errorf("%w: create %s: %w", ErrUnavailable, key, cerr)
 	}
 
 	deadline := time.Now().Add(waitTimeout)
@@ -114,15 +148,15 @@ func (s *Store[T]) Claim(ctx context.Context, accountID, token, paramHash string
 				if _, rcerr := s.kv.Create(ctx, key, inflight); rcerr == nil {
 					return nil, true, nil
 				} else if !errors.Is(rcerr, jetstream.ErrKeyExists) {
-					return nil, false, fmt.Errorf("idempotency recreate %s: %w", key, rcerr)
+					return nil, false, fmt.Errorf("%w: recreate %s: %w", ErrUnavailable, key, rcerr)
 				}
 				continue
 			}
-			return nil, false, fmt.Errorf("idempotency get %s: %w", key, gerr)
+			return nil, false, fmt.Errorf("%w: get %s: %w", ErrUnavailable, key, gerr)
 		}
 		var rec record[T]
 		if uerr := json.Unmarshal(entry.Value(), &rec); uerr != nil {
-			return nil, false, fmt.Errorf("idempotency unmarshal %s: %w", key, uerr)
+			return nil, false, fmt.Errorf("%w: unmarshal %s: %w", ErrUnavailable, key, uerr)
 		}
 		if rec.ParamHash != paramHash {
 			return nil, false, ErrParamMismatch
@@ -139,7 +173,7 @@ func (s *Store[T]) Claim(ctx context.Context, accountID, token, paramHash string
 
 // Finalize marks the token done with the payload duplicates should replay.
 func (s *Store[T]) Finalize(ctx context.Context, accountID, token, paramHash string, payload T) error {
-	key := Key(accountID, token)
+	key := s.key(accountID, token)
 	data, err := json.Marshal(record[T]{
 		Status:    statusDone,
 		ParamHash: paramHash,
@@ -157,12 +191,8 @@ func (s *Store[T]) Finalize(ctx context.Context, accountID, token, paramHash str
 
 // Abort drops the in-flight token so a retry can re-attempt the work.
 func (s *Store[T]) Abort(ctx context.Context, accountID, token string) {
-	key := Key(accountID, token)
+	key := s.key(accountID, token)
 	if err := s.kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 		slog.Warn("idempotency: failed to abort token record", "key", key, "err", err)
 	}
 }
-
-// There is deliberately no Do wrapper. The two callers orchestrate differently:
-// RunInstances wraps one launch closure, while CreateCluster interleaves aborts
-// through a long create and replays by name rather than from the payload.

--- a/spinifex/idempotency/store_test.go
+++ b/spinifex/idempotency/store_test.go
@@ -172,3 +172,45 @@ func TestParamHash_DistinguishesRequests(t *testing.T) {
 	assert.Equal(t, first, again, "the same request must always hash the same")
 	assert.NotEqual(t, first, changed, "a changed request must change the hash")
 }
+
+// Actions share one bucket, so one action's token must never be seen — or
+// decoded as the wrong type — by another.
+func TestStore_NamespacesDoNotCollide(t *testing.T) {
+	t.Parallel()
+	_, nc, _ := testutil.StartTestJetStream(t)
+	kv, err := idempotency.OpenBucket(t.Context(), testutil.NewJetStream(t, nc), "ns-tokens", time.Minute)
+	require.NoError(t, err)
+
+	volumes := idempotency.NewStore[payload](kv, "CreateVolume")
+	gateways := idempotency.NewStore[payload](kv, "CreateNatGateway")
+	const tok, hash = "shared-token", "h"
+
+	_, owned, err := volumes.Claim(t.Context(), testAccount, tok, hash)
+	require.NoError(t, err)
+	require.True(t, owned)
+	require.NoError(t, volumes.Finalize(t.Context(), testAccount, tok, hash, payload{ID: "vol-1"}))
+
+	replay, owned, err := gateways.Claim(t.Context(), testAccount, tok, hash)
+	require.NoError(t, err)
+	assert.True(t, owned, "a different action owns its own work under the same token")
+	assert.Nil(t, replay, "one action must never replay another's result")
+}
+
+// The stores that predate namespacing keep bare account.token keys: re-keying
+// live records would make a retry re-run the work instead of replaying it.
+func TestStore_EmptyNamespaceKeepsTheBareKey(t *testing.T) {
+	t.Parallel()
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	kv, err := idempotency.OpenBucket(t.Context(), js, "bare-tokens", time.Minute)
+	require.NoError(t, err)
+
+	store := idempotency.NewStore[payload](kv, "")
+	const tok, hash = "bare-1", "h"
+	_, owned, err := store.Claim(t.Context(), testAccount, tok, hash)
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	_, err = kv.Get(t.Context(), idempotency.Key(testAccount, tok))
+	assert.NoError(t, err, "the record must live at the unprefixed key")
+}


### PR DESCRIPTION
## Seven EC2 creates stop duplicating on a retry

`mulga-92hgk`. Seven EC2 actions parse a `ClientToken` and never read it, so a client that retries — an SDK resend, a Terraform retry, a dropped connection — gets a second resource. `CreateVolume` leaves an orphaned EBS volume, `CreateNetworkInterface` an ENI, `CreateNatGateway` a NAT gateway and its EIP association.

| Action | IDs minted per call today |
| --- | --- |
| `CreateVolume` | `vol-…` |
| `CreateNetworkInterface` | `eni-…` |
| `CreateNatGateway` | `nat-…` **and** `eipassoc-…` |
| `CreateRouteTable` | `rtb-…` **and** `rtbassoc-…` |
| `CreateEgressOnlyInternetGateway` | `eigw-…` |
| `CopyImage` | `snap-…` **and** `ami-…` |
| `CreateCapacityReservation` | `cr-…` |

Two of them mint a second ID for an association, so a replay has to return the whole response rather than an ID — which is why the stored payload is the action's output type.

### One decorator, not seven wrappers

Every EC2 action already funnels through one table in `gateway/ec2.go`, built by the generic `ec2Handler[In]`. All seven targets are single-expression closures returning a concrete SDK output type, so the table is where idempotency goes:

```go
"CreateVolume": ec2IdempotentHandler(func(ctx context.Context, input *ec2.CreateVolumeInput, gw *GatewayConfig, accountID string) (ec2.Volume, error) {
```

`ec2IdempotentHandler[In, Out]` differs from `ec2Handler[In]` only in pinning the output type — needed so the result can be stored and replayed — and wrapping the call in a token claim. Actions still opt in one at a time; this is **not** applied to everything that happens to have the field.

Wrapping the whole closure rather than the inner call also means a replay skips the quota enforcement `CreateVolume` does first, which is the point: a duplicate request must not be charged twice.

The token is read reflectively off the input struct in one helper, so the seven need no per-action accessor. No token means the client did not ask for idempotency and the request runs unwrapped, as AWS behaves.

### The `Do` wrapper the last PR argued against

#971 shipped `spinifex/idempotency` with no `Do` wrapper, on the grounds that its two callers orchestrate differently and a wrapper shaped for `RunInstances` would have had one caller. That was true then. These seven all share `runInstancesWithClientToken`'s exact shape — claim, replay, run, finalize, abort on failure, settle under a cancellation-free context — so `Do` now has eight callers and `runInstancesWithClientToken` is rewired onto it, keeping its EC2 error mapping. EKS `CreateCluster` still keeps its own orchestration for the reason originally given.

### Keys, and the one thing deliberately not re-keyed

The seven share `RunInstances`' bucket, keyed `<action>.<account>.<token>`. One bucket avoids seven more JetStream streams, and the action prefix stops one action's payload from ever being decoded as another's `Out` — there is a test for exactly that.

**`RunInstances`' own keys stay unprefixed.** Changing a live key format is not the same risk as #971's payload rename: an unreadable payload makes a duplicate *fail*, but an unfindable key makes a duplicate *re-run the work*, which is the outcome the token exists to prevent. So the two pre-existing stores keep their format and namespace only the new callers.

Store errors now wrap a single `idempotency.ErrUnavailable`, so a caller maps every non-mismatch token failure onto one API error. Without it, rewiring onto `Do` would have leaked raw NATS error text to API clients, since only the mismatch case was previously matched by name.

The KV binding moved from a package-level singleton onto `GatewayConfig`, next to the `activeNodes` cache it already carries. That removes process-global state and is what makes the decorator testable against an embedded JetStream.

### Found while testing, not fixed here

**EC2 response element order is already non-deterministic.** Rendering the *same* value twice gives different element order, including whether `requestId` comes first or last — `utils.WithRequestID` builds a map and the XML builder emits in map order. Confirmed against `main` behaviour, unrelated to this change, and cosmetic (XML element order is not significant to SDK parsers). It is why the replay tests compare a canonicalised field set rather than bytes. Worth a bead; not folded in here because it touches every EC2 response.

**`NormalizeXMLOutput` copies only the top level**, so it mutates through pointer fields into the caller's own struct. Also pre-existing, also not touched.

### Scope

Not converted, and why:

- `CreateLaunchTemplate`, `ModifyLaunchTemplate`, ECS `CreateService` — already effectively idempotent (name- or cluster+name-keyed), so a duplicate is already a no-op or a conflict rather than a leak.
- ECS `RunTask` — different layer, different store; separate PR.
- `CreateLaunchTemplateVersion` — follow-up.

`CreateCapacityReservation` is also reachable directly over NATS (`ec2.CreateCapacityReservation.<node>`). This covers the gateway path, which is the one a client retry hits; the same is true of `RunInstances` today.

### Tests

| Where | What |
| --- | --- |
| `gateway/ec2_idempotency_test.go` | per action, the bead's criterion: same token twice runs the create once and the duplicate gets the first response. Plus per-action token scoping, param mismatch → `IdempotentParameterMismatch` with no create, no token → creates each time, failed create is retryable |
| `gateway/ec2/idem/idem_test.go` | token extraction across all seven input types, absent/empty/nil/no-such-field, hash ignores the token, the input survives hashing intact |
| `idempotency/do_test.go` | `Do` runs work once per token, a failure releases the token, a mismatch does not run the work, every token failure is reachable through `ErrUnavailable` |
| `idempotency/store_test.go` | namespaces do not collide; the empty namespace still writes the bare `account.token` key |
| `gateway/ec2/instance/clienttoken_test.go` | unchanged — the regression signal that `Do` preserved `RunInstances` behaviour |

Checked by breaking the code:

- dropping the per-action namespace fails `TokensAreScopedPerAction`;
- ignoring the token fails all seven per-action subtests, the scoping test and the mismatch test.

`make preflight` passes.

---

Plan: `docs/development/bugs/ec2-create-idempotency.md`. Bead: `mulga-92hgk`.
