### PR TITLE
fix: render S3-scoped gateway errors in the flat S3 error envelope

### DIFF
--- a/spinifex/gateway/auth.go
+++ b/spinifex/gateway/auth.go
@@ -379,18 +379,28 @@ func (gw *GatewayConfig) writeSigV4Error(w http.ResponseWriter, r *http.Request,
 		errorMsg = awserrors.ErrorMessage{HTTPCode: 500, Message: "Internal error"}
 	}
 
+	svc := signedService(r)
+
 	// AWS JSON 1.1 services (bedrock family, EKS, …) need a JSON error body, or
 	// the SDK chokes deserializing our XML into its shape.
-	if svc, _ := gw.GetService(r); jsonErrorService(svc) {
+	if jsonErrorService(svc) {
 		w.Header().Set("Content-Type", eksJSONContentType)
 		w.WriteHeader(errorMsg.HTTPCode)
 		_, _ = w.Write(GenerateEKSErrorResponse(errorCode, errorMsg.Message, requestID))
 		return
 	}
 
-	xmlError := GenerateEC2ErrorResponse(errorCode, errorMsg.Message, requestID)
+	xmlError := xmlErrorBody(svc, errorCode, errorMsg.Message, requestID, r.URL.Path)
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(errorMsg.HTTPCode)
 	_, _ = w.Write(xmlError)
+}
+
+// signedService returns the credential-scope service the client signed with,
+// including a scope the gateway does not serve. A rejection has to render in
+// the client's format, and GetService reports those scopes as empty.
+func signedService(r *http.Request) string {
+	svc, _ := r.Context().Value(ctxService).(string)
+	return svc
 }

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -88,18 +89,25 @@ func init() {
 // hash agrees. An optional signingTime pins the clock for skew tests.
 func signTestRequest(t *testing.T, req *http.Request, body []byte, accessKey, secret string, signingTime ...time.Time) {
 	t.Helper()
-	sum := sha256.Sum256(body)
-	payloadHash := hex.EncodeToString(sum[:])
 	when := time.Now().UTC()
 	if len(signingTime) > 0 {
 		when = signingTime[0]
 	}
+	signTestRequestAs(t, req, body, accessKey, secret, testService, when)
+}
+
+// signTestRequestAs signs with an explicit credential-scope service, so a test
+// can drive a scope the gateway does not serve.
+func signTestRequestAs(t *testing.T, req *http.Request, body []byte, accessKey, secret, service string, when time.Time) {
+	t.Helper()
+	sum := sha256.Sum256(body)
+	payloadHash := hex.EncodeToString(sum[:])
 	// gwsign sets this header so the SDK signs it; sigv4 reproduces it when
 	// reconstructing the canonical request.
 	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
 	require.NoError(t, v4.NewSigner().SignHTTP(context.Background(),
 		aws.Credentials{AccessKeyID: accessKey, SecretAccessKey: secret},
-		req, payloadHash, testService, testRegion, when))
+		req, payloadHash, service, testRegion, when))
 }
 
 func setupTestApp(accessKey, secretKey string) http.Handler {
@@ -656,6 +664,54 @@ func TestWriteSigV4Error_IgnoresClientRequestID(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "<RequestID>") {
 		t.Errorf("Expected RequestID in response, got: %s", string(body))
+	}
+}
+
+// The gateway does not serve S3 — predastore does — so an S3-scoped request is
+// rejected on credential scope before any verb or path parsing. Every S3 verb
+// therefore takes one path, and all that varies below is the request shape.
+func TestSigV4Auth_S3ScopeReturnsFlatS3Error(t *testing.T) {
+	handler := setupTestApp(testAccessKey, testSecretKey)
+
+	testCases := []struct {
+		name   string
+		method string
+		path   string
+		body   []byte
+	}{
+		{"PutObject", http.MethodPut, "/bucket/key.txt", []byte("payload")},
+		{"ListObjectsV2", http.MethodGet, "/bucket?list-type=2&prefix=a%2F", nil},
+		{"CreateBucket", http.MethodPut, "/bucket", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(tc.body))
+			req.Host = "localhost:9999"
+			signTestRequestAs(t, req, tc.body, testAccessKey, testSecretKey, "s3", time.Now().UTC())
+
+			resp := doRequest(handler, req)
+			require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var parsed struct {
+				Code      string `xml:"Code"`
+				Message   string `xml:"Message"`
+				Resource  string `xml:"Resource"`
+				RequestID string `xml:"RequestId"`
+			}
+			require.NoError(t, xml.Unmarshal(body, &parsed), "body: %s", body)
+
+			// The flat root element is the whole point: an SDK that finds
+			// <Response> here reports an empty code and an empty message.
+			assert.Equal(t, "Error", xmlRootName(t, body))
+			assert.Equal(t, awserrors.ErrorSignatureDoesNotMatch, parsed.Code)
+			assert.NotEmpty(t, parsed.Message)
+			assert.NotEmpty(t, parsed.RequestID)
+			assert.Equal(t, req.URL.Path, parsed.Resource)
+		})
 	}
 }
 

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -241,6 +241,17 @@ type ErrorDetail struct {
 	Message string `xml:"Message"`
 }
 
+// S3ErrorResponse is the S3 REST error envelope: a flat <Error> document rather
+// than the query-API wrapper. SDKs look for a top-level <Error><Code> on an S3
+// response and report an empty code for anything else.
+type S3ErrorResponse struct {
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+	Resource  string   `xml:"Resource,omitempty"`
+	RequestID string   `xml:"RequestId"`
+}
+
 func (gw *GatewayConfig) SetupRoutes() http.Handler {
 	var logLevel slog.Level
 
@@ -348,9 +359,8 @@ func jsonErrorService(svc string) bool {
 const clusterUnavailableMsg = "cluster unavailable: NATS disconnected — check daemon /local/status"
 
 // writeClusterUnavailable writes a 503 ServiceUnavailable in the service-appropriate
-// format. It emits XML directly (not via GenerateEC2ErrorResponse) to ensure the
-// /local/status hint is preserved in <Message>.
-func (gw *GatewayConfig) writeClusterUnavailable(w http.ResponseWriter, _ *http.Request, svc string) {
+// format, carrying the /local/status hint in <Message>.
+func (gw *GatewayConfig) writeClusterUnavailable(w http.ResponseWriter, r *http.Request, svc string) {
 	requestID := uuid.NewV4().String()
 
 	// AWS JSON 1.1 services (EKS/ECS/bedrock family, …) get a JSON body.
@@ -364,32 +374,11 @@ func (gw *GatewayConfig) writeClusterUnavailable(w http.ResponseWriter, _ *http.
 		return
 	}
 
-	var xmlBody string
-	if svc == "iam" || svc == "sts" || svc == "rds" {
-		iam := IAMErrorResponse{
-			Error: IAMErrorDetail{
-				Type:    "Sender",
-				Code:    awserrors.ErrorServiceUnavailable,
-				Message: clusterUnavailableMsg,
-			},
-			RequestID: requestID,
-		}
-		out, err := xml.MarshalIndent(iam, "", "  ")
-		if err != nil {
-			slog.Error("Failed to marshal IAM cluster-unavailable XML", "err", err)
-			out = []byte(`<ErrorResponse><Error><Type>Sender</Type><Code>ServiceUnavailable</Code><Message>` + clusterUnavailableMsg + `</Message></Error><RequestId>` + requestID + `</RequestId></ErrorResponse>`)
-		}
-		xmlBody = xml.Header + string(out)
-	} else {
-		// ec2, elasticloadbalancing, account, spinifex all share the EC2 envelope.
-		xmlBody = xml.Header + `<Response><Errors><Error><Code>` + awserrors.ErrorServiceUnavailable +
-			`</Code><Message>` + clusterUnavailableMsg + `</Message></Error></Errors><RequestID>` +
-			requestID + `</RequestID></Response>`
-	}
+	xmlBody := xmlErrorBody(svc, awserrors.ErrorServiceUnavailable, clusterUnavailableMsg, requestID, r.URL.Path)
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(http.StatusServiceUnavailable)
-	if _, err := w.Write([]byte(xmlBody)); err != nil {
+	if _, err := w.Write(xmlBody); err != nil {
 		slog.Error("Failed to write cluster-unavailable response", "err", err)
 	}
 }
@@ -416,12 +405,7 @@ func (gw *GatewayConfig) writeThrottleError(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var xmlErr []byte
-	if svc == "iam" || svc == "sts" || svc == "elasticloadbalancing" || svc == "rds" {
-		xmlErr = GenerateIAMErrorResponse(errorCode, errorMsg.Message, requestID)
-	} else { // ec2, account, spinifex
-		xmlErr = GenerateEC2ErrorResponse(errorCode, errorMsg.Message, requestID)
-	}
+	xmlErr := xmlErrorBody(svc, errorCode, errorMsg.Message, requestID, r.URL.Path)
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(errorMsg.HTTPCode)
@@ -785,12 +769,7 @@ func (gw *GatewayConfig) ErrorHandler(w http.ResponseWriter, r *http.Request, er
 		return
 	}
 
-	var xmlError []byte
-	if svc == "iam" || svc == "sts" || svc == "elasticloadbalancing" || svc == "rds" {
-		xmlError = GenerateIAMErrorResponse(code, errorMsg.Message, requestId)
-	} else {
-		xmlError = GenerateEC2ErrorResponse(code, errorMsg.Message, requestId)
-	}
+	xmlError := xmlErrorBody(svc, code, errorMsg.Message, requestId, r.URL.Path)
 
 	slog.Debug("Generated error response", "error", err, "code", code, "xml", string(xmlError), "requestId", requestId)
 
@@ -892,6 +871,42 @@ func GenerateIAMErrorResponse(code, message, requestID string) (output []byte) {
 
 	output = append([]byte(xml.Header), output...)
 	return output
+}
+
+// GenerateS3ErrorResponse builds the flat S3 REST error document. resource is
+// the request path and is omitted when empty.
+func GenerateS3ErrorResponse(code, message, requestID, resource string) (output []byte) {
+	errorXml := S3ErrorResponse{
+		Code:      code,
+		Message:   message,
+		Resource:  resource,
+		RequestID: requestID,
+	}
+
+	output, err := xml.MarshalIndent(errorXml, "", "  ")
+	if err != nil {
+		slog.Error("Failed to build S3 error XML", "error", err)
+		return []byte(xml.Header + "<Error><Code>InternalError</Code><Message>Internal error</Message><RequestId>" + requestID + "</RequestId></Error>")
+	}
+
+	output = append([]byte(xml.Header), output...)
+	return output
+}
+
+// xmlErrorBody renders an error in the XML envelope svc's clients expect. The
+// one place the service-to-envelope mapping lives, so a service cannot be added
+// to some emitters and missed by others. JSON services never reach here — every
+// caller checks jsonErrorService first.
+func xmlErrorBody(svc, code, message, requestID, resource string) []byte {
+	switch svc {
+	case "s3":
+		return GenerateS3ErrorResponse(code, message, requestID, resource)
+	case "iam", "sts", "elasticloadbalancing", "rds":
+		return GenerateIAMErrorResponse(code, message, requestID)
+	default:
+		// ec2, account, spinifex, and any scope the gateway does not serve.
+		return GenerateEC2ErrorResponse(code, message, requestID)
+	}
 }
 
 // How long a discovered node count is reused before it is gathered again.

--- a/spinifex/gateway/gateway_test.go
+++ b/spinifex/gateway/gateway_test.go
@@ -82,6 +82,71 @@ func TestGenerateEC2ErrorResponse_Structure(t *testing.T) {
 	}
 }
 
+// xmlRootName returns the local name of body's root element, which is what
+// distinguishes the S3, IAM and EC2 error envelopes from each other.
+func xmlRootName(t *testing.T, body []byte) string {
+	t.Helper()
+	dec := xml.NewDecoder(strings.NewReader(string(body)))
+	for {
+		tok, err := dec.Token()
+		require.NoError(t, err)
+		if se, ok := tok.(xml.StartElement); ok {
+			return se.Name.Local
+		}
+	}
+}
+
+func TestGenerateS3ErrorResponse_FlatEnvelope(t *testing.T) {
+	output := GenerateS3ErrorResponse("SignatureDoesNotMatch", "bad signature", "req-s3-1", "/bucket/key.txt")
+	require.NotNil(t, output)
+
+	assert.True(t, strings.HasPrefix(string(output), xml.Header))
+	assert.Equal(t, "Error", xmlRootName(t, output))
+
+	var parsed struct {
+		Code      string `xml:"Code"`
+		Message   string `xml:"Message"`
+		Resource  string `xml:"Resource"`
+		RequestID string `xml:"RequestId"`
+	}
+	require.NoError(t, xml.Unmarshal(output, &parsed))
+
+	assert.Equal(t, "SignatureDoesNotMatch", parsed.Code)
+	assert.Equal(t, "bad signature", parsed.Message)
+	assert.Equal(t, "/bucket/key.txt", parsed.Resource)
+	assert.Equal(t, "req-s3-1", parsed.RequestID)
+}
+
+func TestGenerateS3ErrorResponse_OmitsEmptyResource(t *testing.T) {
+	output := GenerateS3ErrorResponse("AccessDenied", "denied", "req-s3-2", "")
+	assert.NotContains(t, string(output), "<Resource>")
+}
+
+func TestXMLErrorBody_EnvelopePerService(t *testing.T) {
+	tests := []struct {
+		svc  string
+		root string
+	}{
+		{"s3", "Error"},
+		{"iam", "ErrorResponse"},
+		{"sts", "ErrorResponse"},
+		{"elasticloadbalancing", "ErrorResponse"},
+		{"rds", "ErrorResponse"},
+		{"ec2", "Response"},
+		{"spinifex", "Response"},
+		{"unknown-service", "Response"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.svc, func(t *testing.T) {
+			body := xmlErrorBody(tc.svc, "AccessDenied", "denied", "req-1", "/path")
+
+			assert.Equal(t, tc.root, xmlRootName(t, body))
+			assert.Contains(t, string(body), "<Code>AccessDenied</Code>")
+		})
+	}
+}
+
 func TestGenerateEC2ErrorResponse_ValidXML(t *testing.T) {
 	output := GenerateEC2ErrorResponse("TestCode", "Test message", "req-999")
 	require.NotNil(t, output)


### PR DESCRIPTION
Closes `mulga-vxkh9`. Plan: `docs/development/archive/bugs/gateway-s3-error-envelope.md` in mulga.

## Problem

The bead was filed against predastore. It is not a predastore bug — `predastore/internal/gate/handlers/respond.go` already emits the correct flat `<Error>` document with a 4xx status on the `:8443` gate.

The envelope in the report comes from this repo. The gateway does not serve S3, so `SigV4AuthMiddleware` rejects an S3 credential scope at the `supportedServices` gate. That rejection goes through `writeSigV4Error`, which resolved the service with `GetService` — and `GetService` returns `""` for a scope the gateway does not serve, so the response fell through to `GenerateEC2ErrorResponse`. Any S3 client pointed at `:9999` instead of `:8443` got `<Response><Errors><Error>`, which botocore cannot parse as an S3 error. It reports `An error occurred () when calling the PutObject operation:` — empty code, empty message — and the operator sees what looks like a credential problem.

## Changes

- `S3ErrorResponse` + `GenerateS3ErrorResponse`, emitting the flat `<Error><Code><Message><Resource><RequestId></Error>` document. `Resource` carries the request path and is omitted when empty, matching predastore and real S3.
- `signedService` reads the raw credential-scope service that the middleware records before the `supportedServices` gate, so a rejected scope still renders in the client's format.
- `xmlErrorBody` becomes the single service-to-envelope mapping. The decision had been copied into four emitters and the copies had drifted: `writeClusterUnavailable` put `elasticloadbalancing` on the EC2 envelope while `ErrorHandler` and `writeThrottleError` put it on the IAM one. That divergence is fixed as a side effect.
- The stale comment on `writeClusterUnavailable` claiming `GenerateEC2ErrorResponse` would drop the `/local/status` hint is removed; the generator takes the message verbatim.

`s3` is deliberately **not** added to `supportedServices`. The gateway still rejects the scope; only the shape of the rejection changes.

## On the reported HTTP 200

Not reproducible. `writeSigV4Error` writes `errorMsg.HTTPCode`, and `ErrorLookup[SignatureDoesNotMatch]` is 403; the new middleware test asserts 403 on the wire. botocore prints the same empty-code message for an unparseable body at any status, so the 200 in the report was most likely inferred from that message rather than observed.

## Testing

- `TestSigV4Auth_S3ScopeReturnsFlatS3Error` drives the real middleware with a request signed under `service=s3` and asserts status 403, a root `<Error>` element, `Code == SignatureDoesNotMatch`, and the resource path. Three request shapes cover the PutObject, ListObjectsV2 and CreateBucket cases named in the bead — all three are rejected on credential scope before any verb or path parsing, so they share one code path.
- `TestGenerateS3ErrorResponse_FlatEnvelope`, `TestGenerateS3ErrorResponse_OmitsEmptyResource`, `TestXMLErrorBody_EnvelopePerService` (table over s3/ec2/iam/sts/elbv2/rds/spinifex/unknown).
- `go test ./spinifex/...` passes.

`make preflight` does **not** pass, and does not pass on a clean `dev` either: 48 pre-existing `tparallel` failures in `spinifex/handlers/iam/`, identical with and without this branch. Filed as `mulga-b39yh`. Lint runs before tests, so the test stage was run directly.