### PR TITLE
fix: take the volume lease when snapshotting an unmounted volume

### DIFF
--- a/spinifex/services/viperblockd/provider_handlers.go
+++ b/spinifex/services/viperblockd/provider_handlers.go
@@ -1066,14 +1066,7 @@ func completeCreateSnapshot(ctx context.Context, cfg *Config, nc *nats.Conn, req
 	snapshot, err := snapshotVolumeEngine(ctx, cfg, req.VolumeID, req.SnapshotID)
 	if err != nil {
 		slog.Error("ebs.provider.snapshot.create: snapshot failed", "volume", req.VolumeID, "snapshot", req.SnapshotID, "err", err)
-		code := ebsprovider.ErrorCodeInternal
-		switch {
-		case errors.Is(err, viperblock.ErrStateNotFound):
-			code = ebsprovider.ErrorCodeNotFound
-		case errors.Is(err, errSnapshotExistsElsewhere):
-			code = ebsprovider.ErrorCodeAlreadyExists
-		}
-		completion.Error = &ebsprovider.ProviderError{Code: code, Message: err.Error()}
+		completion.Error = &ebsprovider.ProviderError{Code: snapshotErrorCode(err), Message: err.Error()}
 	} else {
 		completion.Snapshot = snapshot
 	}
@@ -1085,6 +1078,25 @@ func completeCreateSnapshot(ctx context.Context, cfg *Config, nc *nats.Conn, req
 	}
 	if err := nc.Publish(completionSubject, data); err != nil {
 		slog.Error("ebs.provider.snapshot.create: failed to publish completion", "subject", completionSubject, "err", err)
+	}
+}
+
+// snapshotErrorCode classifies a failed snapshot for the caller. Only
+// ErrorCodeUnavailable invites a retry, so a refusal that will clear on its own
+// has to be told apart from one that will not.
+func snapshotErrorCode(err error) ebsprovider.ErrorCode {
+	switch {
+	case errors.Is(err, viperblock.ErrStateNotFound):
+		return ebsprovider.ErrorCodeNotFound
+	case errors.Is(err, errSnapshotExistsElsewhere):
+		return ebsprovider.ErrorCodeAlreadyExists
+	case errors.Is(err, errVolumeLeaseHeld), errors.Is(err, errNoVolumeLeaseStore):
+		// Exclusive access could not be established. The holder gives the
+		// volume up on detach, so this is worth repeating rather than the
+		// permanent failure an internal error reads as.
+		return ebsprovider.ErrorCodeUnavailable
+	default:
+		return ebsprovider.ErrorCodeInternal
 	}
 }
 
@@ -1109,48 +1121,30 @@ func checkSnapshotIDFree(vb *viperblock.VB, volumeID, snapshotID string) error {
 // preferring an already-mounted VB over opening a second engine on the same
 // volume. Draining the volume so the checkpoint is current is the caller's
 // responsibility (see handleCreateSnapshot).
+//
+// The unmounted branch opens through openVolumeVB, so it holds the volume's
+// cluster-wide lease for as long as the engine is open: a snapshot taken
+// beside a live writer on another node is two engines on one volume.
 func snapshotVolumeEngine(ctx context.Context, cfg *Config, volumeID, snapshotID string) (*ebsprovider.Snapshot, error) {
 	if mv, ok := findMountedVolume(cfg, volumeID); ok && mv.VB != nil {
-		if err := checkSnapshotIDFree(mv.VB, volumeID, snapshotID); err != nil {
-			return nil, err
-		}
-		if err := mv.VB.LoadLiveCheckpoint(); err != nil {
-			return nil, fmt.Errorf("load live checkpoint: %w", err)
-		}
-		if _, err := mv.VB.CreateSnapshot(snapshotID); err != nil {
-			return nil, fmt.Errorf("create snapshot: %w", err)
-		}
-		return &ebsprovider.Snapshot{
-			ID:             snapshotID,
-			SourceVolumeID: volumeID,
-			SizeBytes:      safecast.Uint64ToInt64(mv.VB.GetVolumeSize()),
-			CreatedAt:      time.Now().UTC(),
-			State:          ebsprovider.SnapshotStateCompleted,
-			Handle:         snapshotHandle(snapshotID),
-		}, nil
+		return createSnapshotWithVB(mv.VB, volumeID, snapshotID)
 	}
 
-	s3cfg := cfg.volumeS3Config(volumeID)
-	vbconfig := &viperblock.VB{
-		VolumeName:        volumeID,
-		VolumeSize:        1, // Recalculated on LoadState.
-		BaseDir:           cfg.BaseDir,
-		Cache:             viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
-		MasterKey:         cfg.masterKey,
-		EncryptionEnabled: cfg.masterKey != nil,
-		GCEnabled:         cfg.GCEnabled,
-	}
-	vb, err := viperblock.New(vbconfig, "s3", s3cfg)
+	vb, lease, err := openVolumeVB(ctx, cfg, volumeID)
 	if err != nil {
-		return nil, fmt.Errorf("new viperblock: %w", err)
+		return nil, err
 	}
-	defer vb.Detach()
-	if err := vb.Backend.InitCtx(ctx); err != nil {
-		return nil, fmt.Errorf("backend init: %w", err)
-	}
-	if err := loadStateWithRetry(ctx, cfg, vb, volumeID); err != nil {
-		return nil, fmt.Errorf("load state: %w", err)
-	}
+	defer func() {
+		vb.Detach()
+		cfg.releaseVolumeLease(ctx, lease)
+	}()
+	return createSnapshotWithVB(vb, volumeID, snapshotID)
+}
+
+// createSnapshotWithVB takes the snapshot against an already-resolved VB,
+// shared by snapshotVolumeEngine's mounted and freshly-opened branches so the
+// two cannot drift on what a snapshot of a volume means.
+func createSnapshotWithVB(vb *viperblock.VB, volumeID, snapshotID string) (*ebsprovider.Snapshot, error) {
 	if err := checkSnapshotIDFree(vb, volumeID, snapshotID); err != nil {
 		return nil, err
 	}

--- a/spinifex/services/viperblockd/volume_lease.go
+++ b/spinifex/services/viperblockd/volume_lease.go
@@ -33,6 +33,11 @@ const volumeLeaseRenewInterval = 15 * time.Second
 // one lease failure a caller can do something about, so it is distinguishable.
 var errVolumeLeaseHeld = errors.New("volume is leased by another owner")
 
+// errNoVolumeLeaseStore reports that exclusive access could not be established
+// at all. Distinguishable from a refusal so a caller can tell "somebody else
+// holds this" from "nobody can say who does".
+var errNoVolumeLeaseStore = errors.New("no volume lease store")
+
 // volumeLeaseKeyPattern is what JetStream KV accepts as a key. Volume names
 // reach here from the wire, and a name carrying "." or ">" would address
 // somebody else's key.
@@ -321,7 +326,7 @@ func (cfg *Config) leaseOwner() string {
 // it refuses rather than opening blind.
 func (cfg *Config) acquireVolumeLease(ctx context.Context, volumeName string) (*volumeLease, error) {
 	if cfg.leases == nil {
-		return nil, fmt.Errorf("no volume lease store: cannot establish exclusive access to %s", volumeName)
+		return nil, fmt.Errorf("%w: cannot establish exclusive access to %s", errNoVolumeLeaseStore, volumeName)
 	}
 	return cfg.leases.acquire(ctx, volumeName)
 }

--- a/spinifex/services/viperblockd/volume_lease_test.go
+++ b/spinifex/services/viperblockd/volume_lease_test.go
@@ -3,8 +3,10 @@ package viperblockd
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/mulgadc/spinifex/spinifex/ebsprovider"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
@@ -118,6 +120,51 @@ func TestVolumeLease_OpenRefusesWithoutALeaseStore(t *testing.T) {
 	lease, err := cfg.acquireVolumeLease(t.Context(), "vol-nostore00000001")
 	require.Error(t, err, "no lease store must refuse the open, not wave it through")
 	assert.Nil(t, lease)
+}
+
+// TestVolumeLease_UnmountedSnapshotIsRefusedByTheHolder is the bead's case: a
+// snapshot request that lands on a node without the volume mounted must not
+// open a second engine over storage another node is writing.
+func TestVolumeLease_UnmountedSnapshotIsRefusedByTheHolder(t *testing.T) {
+	_, natsURL := setupEmbeddedNATS(t)
+
+	const volumeName = "vol-snapshotexcl01"
+	holder := newTestLeases(t, natsURL, "node-a")
+	_, err := holder.acquire(t.Context(), volumeName)
+	require.NoError(t, err)
+
+	// node-b has nothing mounted, so this is the unmounted branch.
+	cfg := &Config{NodeName: "node-b", BaseDir: t.TempDir(), leases: newTestLeases(t, natsURL, "node-b")}
+	snapshot, err := snapshotVolumeEngine(t.Context(), cfg, volumeName, "snap-excl0000000001")
+
+	require.ErrorIs(t, err, errVolumeLeaseHeld, "a snapshot must not open an engine on a volume another node holds")
+	assert.Nil(t, snapshot)
+	assert.Equal(t, ebsprovider.ErrorCodeUnavailable, snapshotErrorCode(err),
+		"the holder detaches eventually, so the caller has to be told this is worth retrying")
+	assert.Empty(t, dirEntries(t, cfg.BaseDir), "the refusal must come before any engine touches the volume's directory")
+}
+
+// TestVolumeLease_UnmountedSnapshotRefusesWithoutALeaseStore pins the
+// fail-closed default on the snapshot path specifically. A daemon that cannot
+// reach JetStream cannot establish that it is the only opener.
+func TestVolumeLease_UnmountedSnapshotRefusesWithoutALeaseStore(t *testing.T) {
+	cfg := &Config{NodeName: "node-a", BaseDir: t.TempDir()}
+
+	snapshot, err := snapshotVolumeEngine(t.Context(), cfg, "vol-snapshotnostor", "snap-nostore00000001")
+
+	require.ErrorIs(t, err, errNoVolumeLeaseStore, "unprovable exclusion must refuse the snapshot, not wave it through")
+	assert.Nil(t, snapshot)
+	assert.Equal(t, ebsprovider.ErrorCodeUnavailable, snapshotErrorCode(err))
+	assert.Empty(t, dirEntries(t, cfg.BaseDir))
+}
+
+// dirEntries lists dir, which a refused open must have left alone.
+func dirEntries(t *testing.T, dir string) []os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	return entries
 }
 
 // conflictKV fails every Update with a wrong-last-sequence response under the


### PR DESCRIPTION
## Problem

`snapshotVolumeEngine`'s unmounted branch built its engine by hand — `viperblock.New` + `Backend.InitCtx` + `loadStateWithRetry` — instead of going through `openVolumeVB`. That is `openVolumeVB`'s body minus the lease acquisition, so it was the last control-plane path that opened an engine over a volume without holding the cluster-wide lease.

A snapshot request landing on a node that does not have the volume mounted therefore opened a second engine over storage another node was writing. Confirmed live on env19 on 2026-08-12: a 1 GiB volume created on `env19-ironbark` and snapshotted while detached had `env19-bottlebrush` open its own engine to serve the snapshot.

This is not only a consistency question. viperblock's AES-GCM nonce is `BE56(SeqNum) || VolumeUUID[4] || domain`, fully consumed, with no room for a fencing epoch. Two engines opening one encrypted volume read the same `SeqNumHighWater` and issue the same SeqNums, which under GCM discloses the XOR of the plaintexts and permits recovery of the authentication subkey — integrity goes too, not just confidentiality.

The sibling path was already correct: `copySnapshotOnVolume`, whose comment says it mirrors `snapshotVolumeEngine`, takes the lease. This was a missed call site, not an open design question.

## Change

Route the unmounted branch through `openVolumeVB` and give the lease the engine's lifetime, releasing it alongside the `Detach` the branch already did.

The snapshot tail both branches duplicated moves into `createSnapshotWithVB`, mirroring `copySnapshotMetaWithVB` next to it, so the mounted and freshly-opened paths cannot drift on what taking a snapshot means.

A lease refusal is now reported as `ErrorCodeUnavailable` rather than `ErrorCodeInternal`. `Unavailable` is the only code `Retryable()` admits, and this refusal clears on its own when the holder detaches, so a caller should retry rather than treat a live mount elsewhere as permanent. The classification moves out of `completeCreateSnapshot` into `snapshotErrorCode` so it is assertable directly.

`acquireVolumeLease`'s "no lease store" failure now wraps a sentinel, so a caller can tell "somebody else holds this" from "nobody can say who does".

## Testing

Two tests in `volume_lease_test.go`, each falsified by restoring the old unleased open — both went red:

- `UnmountedSnapshotIsRefusedByTheHolder` — one node holds the lease, a second node's snapshot of the unmounted volume is refused with `errVolumeLeaseHeld`, classifies as `Unavailable`, and leaves the base directory untouched, which is what shows the refusal landed before any engine work.
- `UnmountedSnapshotRefusesWithoutALeaseStore` — the fail-closed default on this path specifically.

`make preflight` passes.

## Scope

The bead's other acceptance criterion — a snapshot for a volume mounted on another node is answered by that node — was already met and is unchanged here: `NATSProvider.CreateSnapshot` calls `requestOwnerFirst` against `SnapshotCreateOwnerSubject`, and the fallback to the queue subject fires only on `nats.ErrNoResponders`, never on a timeout.

`mulga-uau0z` stays open for its phases 2 and 3 (the object-store fence, and stating the exclusion semantics in the wire contract). Neither is needed for this: phase 1's guarantee is "an engine is not opened without a lease", and this was the last path outside it.

Not done: the live env19 re-check. No cluster is currently reachable from this host.
