### PR TITLE
fix: tunnel apiserver controlplane egress through konnectivity

### DIFF
--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -87,9 +87,9 @@ const (
 	k3sConfigPath = "/etc/rancher/k3s/config.yaml"
 
 	// k3sEgressSelectorConfigPath is the EgressSelectorConfiguration the apiserver
-	// loads via --egress-selector-config-file. It points the `cluster` egress at the
-	// konnectivity-server UDS, so apiserver→pod/kubelet traffic (exec/logs/webhooks)
-	// rides the agent-initiated reverse tunnel instead of a direct (unroutable) IP.
+	// loads via --egress-selector-config-file. It points the `controlplane` and
+	// `cluster` egress at the konnectivity-server UDS, so apiserver→pod/kubelet
+	// traffic rides the agent-initiated reverse tunnel, not a direct IP.
 	k3sEgressSelectorConfigPath = "/etc/rancher/k3s/egress-selector-config.yaml"
 
 	// konnectivityUDSPath is the unix socket the konnectivity-server listens on for
@@ -469,20 +469,28 @@ func k3sServerJoinURL(ip string) string {
 }
 
 // egressSelectorConfigYAML renders the EgressSelectorConfiguration that wires the
-// apiserver `cluster` egress to the konnectivity-server UDS. v1beta1 is the schema
+// apiserver egress to the konnectivity-server UDS. v1beta1 is the schema
 // k3s/kube-apiserver accept for --egress-selector-config-file.
 func egressSelectorConfigYAML() string {
-	return strings.Join([]string{
+	lines := []string{
 		"apiVersion: apiserver.k8s.io/v1beta1",
 		"kind: EgressSelectorConfiguration",
 		"egressSelections:",
-		"  - name: cluster",
-		"    connection:",
-		"      proxyProtocol: GRPC",
-		"      transport:",
-		"        uds:",
-		"          udsName: " + konnectivityUDSPath,
-	}, "\n")
+	}
+	// controlplane carries admission-webhook and aggregated-apiserver dials;
+	// cluster carries kubelet exec/logs/portforward. Both must ride the tunnel:
+	// an undefined selection falls back to a direct, unroutable dial from the CP.
+	for _, name := range []string{"controlplane", "cluster"} {
+		lines = append(lines,
+			"  - name: "+name,
+			"    connection:",
+			"      proxyProtocol: GRPC",
+			"      transport:",
+			"        uds:",
+			"          udsName: "+konnectivityUDSPath,
+		)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // dedupeNonEmpty returns the input with empty strings dropped and duplicates

--- a/spinifex/handlers/eks/k3s_server_vm_test.go
+++ b/spinifex/handlers/eks/k3s_server_vm_test.go
@@ -440,6 +440,20 @@ func TestBuildK3sUserData_EgressSelectorDisabledWithKonnConfig(t *testing.T) {
 		"the EgressSelectorConfiguration file routes the cluster egress to the konn socket")
 }
 
+func TestEgressSelectorConfigYAML_TunnelsControlPlaneAndCluster(t *testing.T) {
+	cfg := egressSelectorConfigYAML()
+
+	// Admission webhooks and aggregated apiservers dial via `controlplane`; only
+	// kubelet exec/logs/portforward use `cluster`. Omitting controlplane leaves
+	// webhook dials direct, which cannot route from the CP VPC to the service CIDR.
+	assert.Contains(t, cfg, "  - name: controlplane",
+		"webhook dials use the controlplane egress and must ride the konnectivity tunnel")
+	assert.Contains(t, cfg, "  - name: cluster",
+		"kubelet exec/logs dials use the cluster egress")
+	assert.Equal(t, 2, strings.Count(cfg, "udsName: "+konnectivityUDSPath),
+		"both egress selections must terminate on the konnectivity socket")
+}
+
 func TestBuildK3sUserData_KonnectivityEnv(t *testing.T) {
 	in := validK3sInput()
 	in.PrivateEndpointIP = "10.32.100.4"


### PR DESCRIPTION
## Summary

The `EgressSelectorConfiguration` written to every EKS control-plane VM defined only the `cluster` egress selection, which carries kubelet exec/logs/portforward. Admission webhooks and aggregated apiservers dial via the `controlplane` selection instead, and an undefined selection falls back to a direct dial. The control-plane VM sits alone in its own VPC (`10.253.93.0/24`, `cp_vpc.go`) with no route to the service CIDR `10.43.0.0/16`, so every webhook call timed out after 10s.

This defines both selections on the konnectivity-server UDS so webhook traffic rides the agent-initiated reverse tunnel alongside kubelet traffic.

## How it surfaced

Found while diagnosing a UDS Core / Zarf airgap cluster where Grafana was stuck in `Init:0/2` and the API server appeared to be flapping. Resource pressure was never the cause: all nodes `Ready`, every PVC `Bound`, and the control plane carries a `CriticalAddonsOnly=true:NoExecute` taint so no user workload runs there.

The chain:

1. Zarf's `agent-pod.zarf.dev` and istiod's `validation.istio.io` webhooks time out, producing intermittent `failed calling webhook` on applies, which reads as an unstable API server.
2. Pepr's Keycloak client creation for `uds-core-admin-grafana` failed five times, and the Package went to `phase: Failed` and was then skipped permanently.
3. Secret `sso-client-uds-core-admin-grafana` was never created.
4. Grafana's `auth-generic-oauth-secret-mount` volume could not mount.

Konnectivity confirmed it at the tunnel: `DIAL_REQ` succeeded for `:10250` on all three nodes, and there was not a single `DIAL_REQ` to any `10.43.x.x:443`.

## Test plan

- `TestEgressSelectorConfigYAML_TunnelsControlPlaneAndCluster` asserts both selections are present and both terminate on the konnectivity socket.
- `make preflight` passes.
- Verified on a live cluster: the previously failing pods now come up.

## Note on delivery

The config reaches the guest through cloud-init `write_files` from daemon-generated userdata, not the image, and `k3s-prestart.sh` does not re-render it on boot. An image rebuild does not deliver this fix, and neither does rebooting an existing control plane, since `write_files` runs once per instance-id. Existing clusters need the corrected daemon plus a new control-plane instance, or an offline edit of the control-plane root volume.

Closes mulga-qdu7x