### PR TITLE
feat: gateway-side instance record cache (Phase 2)

### DIFF
--- a/spinifex/instancecache/cache.go
+++ b/spinifex/instancecache/cache.go
@@ -368,19 +368,21 @@ func (c *Cache) snapshotCandidate(ctx context.Context) (map[string]*vm.VM, map[s
 // end-of-replay marker (nil) arrives: the candidate then reflects everything
 // between the snapshot's high-water mark and the moment it caught up, which
 // is the whole fence — no buffer, no mode, just sequencing.
-func (c *Cache) replay(ctx context.Context, kw jetstream.KeyWatcher, entries map[string]*vm.VM, index map[string]map[string]struct{}) error {
+func (c *Cache) replay(ctx context.Context, kw jetstream.KeyWatcher, entries map[string]*vm.VM, index map[string]map[string]struct{}) (int, error) {
+	applied := 0
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return applied, ctx.Err()
 		case entry, ok := <-kw.Updates():
 			if !ok {
-				return errors.New("instancecache: watcher closed before catching up")
+				return applied, errors.New("instancecache: watcher closed before catching up")
 			}
 			if entry == nil {
-				return nil
+				return applied, nil
 			}
 			c.apply(entries, index, entry)
+			applied++
 		}
 	}
 }
@@ -406,11 +408,15 @@ func (c *Cache) syncOnce(ctx context.Context) (*liveWatcher, map[string]*vm.VM, 
 		return nil, nil, nil, err
 	}
 
-	if err := c.replay(watchCtx, kw, entries, index); err != nil {
+	replayed, err := c.replay(watchCtx, kw, entries, index)
+	if err != nil {
 		cancel()
 		_ = kw.Stop()
 		return nil, nil, nil, err
 	}
+	c.metrics.replayApplied(replayed)
+	slog.Debug("instancecache: sync caught up", "snapshot_entries", len(entries),
+		"high_water", hw, "replayed", replayed)
 
 	return &liveWatcher{kw: kw, ctx: watchCtx, cancel: cancel, done: make(chan struct{})}, entries, index, nil
 }

--- a/spinifex/instancecache/cache.go
+++ b/spinifex/instancecache/cache.go
@@ -6,17 +6,16 @@
 // Entries are immutable. An update replaces a map entry's pointer; nothing
 // mutates a *vm.VM in place, and a caller must not either.
 //
-// The watch and the resync are fenced against each other through
-// kvstore.Store.Snapshot's highWater mark: a watcher is opened and its events
-// buffered before the snapshot is taken, so nothing that happened during the
-// snapshot is lost or double-applied once the buffer is drained against the
-// snapshot's high-water revision. A periodic resync does not open a second
-// subscription — it tees the existing live watcher's events into a side
-// buffer while continuing to apply them to the live map directly, so a
-// resync that then fails has cost nothing: the live map already has
-// everything the failed candidate would have had. Only a watcher that
-// actually dies is replaced, and its successor takes over under the same
-// fencing before the old one is stopped and joined.
+// The watch and a snapshot are fenced against each other by sequencing, not
+// buffering: every sync — initial, periodic, or a dead watcher's replacement
+// — takes a Snapshot first, then opens a new watcher that resumes from just
+// past the snapshot's high-water mark and replays onto a private candidate
+// map until it catches up. Only once that candidate is complete does it
+// become the live map, at the same moment the new watcher becomes the active
+// one; the old watcher, if there was one, is stopped and joined only after.
+// Because the candidate is a map nobody else can see until that swap, a
+// failed sync costs nothing: the live map and the previously active watcher
+// were never touched.
 //
 // A record that will not decode never removes an entry: the cache only ever
 // removes a key because the record space said it is gone, never because one
@@ -42,21 +41,14 @@ import (
 
 // Defaults for Config.
 const (
-	// DefaultResyncInterval is the periodic tee-based resync cadence: the
-	// completeness backstop for a delete or TTL expiry the watch missed.
+	// DefaultResyncInterval is the periodic resync cadence: the completeness
+	// backstop for a delete or TTL expiry the watch missed.
 	DefaultResyncInterval = 30 * time.Second
-
-	// DefaultMaxBufferedEvents bounds the side buffer a sync fences events
-	// through. Overflowing it fails the sync rather than dropping events
-	// silently, so it must stay well above a burst like a 50-instance launch.
-	DefaultMaxBufferedEvents = 10000
 
 	// DefaultRetryInterval is how long a failed sync waits before trying
 	// again, so an unreachable bucket is retried without spinning.
 	DefaultRetryInterval = 5 * time.Second
 )
-
-var errBufferOverflow = errors.New("instancecache: sync buffer overflow")
 
 // Config configures the KV bucket a Cache watches and its clocks. Bucket and
 // Prefix are supplied by the caller so this package never has to know the
@@ -72,37 +64,17 @@ type Config struct {
 	// its record key with Prefix trimmed.
 	Prefix string
 
-	ResyncInterval    time.Duration
-	MaxBufferedEvents int
-	RetryInterval     time.Duration
+	ResyncInterval time.Duration
+	RetryInterval  time.Duration
 }
 
-// watchMode governs what a liveWatcher's drain goroutine does with an
-// incoming event.
-type watchMode int
-
-const (
-	// modeBuffer queues events without applying them: a watcher that has not
-	// yet gone live, either the very first one or a replacement mid-handoff.
-	modeBuffer watchMode = iota
-	// modeLive applies events directly and buffers nothing.
-	modeLive
-	// modeTee applies events directly and also queues them, for a periodic
-	// resync borrowing the live watcher's events without diverting them.
-	modeTee
-)
-
-// liveWatcher is one KeyWatcher plus the goroutine draining it, and the
-// buffering state a sync uses to fence its events against a snapshot.
+// liveWatcher is one KeyWatcher plus the context that owns it and the
+// goroutine draining it once it is live.
 type liveWatcher struct {
 	kw     jetstream.KeyWatcher
+	ctx    context.Context
 	cancel context.CancelFunc
 	done   chan struct{}
-
-	mu     sync.Mutex
-	mode   watchMode
-	buf    []jetstream.KeyValueEntry
-	bufErr error
 }
 
 // Cache is the informer: a live map of instance ID to *vm.VM, an account
@@ -113,9 +85,8 @@ type Cache struct {
 	prefix string
 	filter string
 
-	resyncInterval    time.Duration
-	maxBufferedEvents int
-	retryInterval     time.Duration
+	resyncInterval time.Duration
+	retryInterval  time.Duration
 
 	mu      sync.RWMutex
 	entries map[string]*vm.VM
@@ -130,11 +101,6 @@ type Cache struct {
 	degraded    atomic.Bool  // true from a failed sync until the next one succeeds
 
 	metrics *cacheMetrics
-
-	// postSnapshotHook, when set, runs after Snapshot returns and before the
-	// buffer is read. Nil in production; a test seam for landing an event
-	// deterministically inside the fence's danger window.
-	postSnapshotHook func()
 }
 
 // New returns a Cache over the bucket cfg describes. Call Run to start it;
@@ -144,24 +110,19 @@ func New(js jetstream.JetStream, cfg Config) *Cache {
 	if resync <= 0 {
 		resync = DefaultResyncInterval
 	}
-	maxBuf := cfg.MaxBufferedEvents
-	if maxBuf <= 0 {
-		maxBuf = DefaultMaxBufferedEvents
-	}
 	retry := cfg.RetryInterval
 	if retry <= 0 {
 		retry = DefaultRetryInterval
 	}
 	c := &Cache{
-		store:             kvstore.New[vm.InstanceRecord](js, cfg.Bucket),
-		prefix:            cfg.Prefix,
-		filter:            cfg.Prefix + "*",
-		resyncInterval:    resync,
-		maxBufferedEvents: maxBuf,
-		retryInterval:     retry,
-		entries:           map[string]*vm.VM{},
-		index:             map[string]map[string]struct{}{},
-		watcherLost:       make(chan struct{}, 1),
+		store:          kvstore.New[vm.InstanceRecord](js, cfg.Bucket),
+		prefix:         cfg.Prefix,
+		filter:         cfg.Prefix + "*",
+		resyncInterval: resync,
+		retryInterval:  retry,
+		entries:        map[string]*vm.VM{},
+		index:          map[string]map[string]struct{}{},
+		watcherLost:    make(chan struct{}, 1),
 	}
 	c.metrics = newCacheMetrics(c)
 	return c
@@ -306,44 +267,34 @@ func (c *Cache) sleep(ctx context.Context) bool {
 	}
 }
 
-// openWatcher opens a new watcher in modeBuffer and starts draining it. A nil
-// return means the bucket could not be watched this attempt.
-func (c *Cache) openWatcher(ctx context.Context) *liveWatcher {
-	watchCtx, cancel := context.WithCancel(ctx)
-	kw, err := c.store.Watch(watchCtx, c.filter)
-	if err != nil {
-		cancel()
-		slog.WarnContext(ctx, "instancecache: watch unavailable, retrying", "err", err)
-		return nil
-	}
-	lw := &liveWatcher{kw: kw, cancel: cancel, done: make(chan struct{})}
-	go c.drain(watchCtx, lw)
-	return lw
+// syncFailed records a failed sync attempt: the metric, the degraded flag,
+// and a warning log, shared by every sync path so a failure looks the same
+// regardless of which one hit it.
+func (c *Cache) syncFailed(ctx context.Context, err error) {
+	c.metrics.resyncFailed()
+	c.degraded.Store(true)
+	slog.WarnContext(ctx, "instancecache: sync failed", "err", err)
 }
 
-// discardWatcher tears a failed candidate's watcher down: cancel, stop and
-// join, so a repeatedly failing sync leaks neither a subscription nor a
-// buffer.
-func (c *Cache) discardWatcher(lw *liveWatcher) {
-	lw.cancel()
-	_ = lw.kw.Stop()
-	<-lw.done
-}
-
-// drain forwards one watcher's events to handleEntry until its channel
-// closes or ctx ends. A channel that closes while ctx is still live means the
-// connection dropped out from under it, which is the signal Run replaces the
-// watcher on; a channel that closes because ctx was cancelled is an
-// intentional teardown and reports nothing.
-func (c *Cache) drain(ctx context.Context, lw *liveWatcher) {
+// drain applies every event lw's watcher delivers, live, once the sync that
+// installed lw has already caught it up: a channel that closes while lw's
+// context is still live means the connection dropped out from under it,
+// which is the signal Run replaces the watcher on; a channel that closes
+// because the context was cancelled is an intentional teardown and reports
+// nothing. An event delivered after lw has been superseded as the active
+// watcher is dropped rather than applied: the watcher that replaced it is
+// independently live-subscribed and already covers it, so nothing is lost,
+// and this keeps it true that only the active watcher ever writes to the
+// live map.
+func (c *Cache) drain(lw *liveWatcher) {
 	defer close(lw.done)
 	for {
 		select {
-		case <-ctx.Done():
+		case <-lw.ctx.Done():
 			return
 		case entry, ok := <-lw.kw.Updates():
 			if !ok {
-				if ctx.Err() == nil {
+				if lw.ctx.Err() == nil && c.getActive() == lw {
 					select {
 					case c.watcherLost <- struct{}{}:
 					default:
@@ -352,33 +303,13 @@ func (c *Cache) drain(ctx context.Context, lw *liveWatcher) {
 				return
 			}
 			if entry == nil {
-				// UpdatesOnly should not emit the end-of-replay marker, but a
-				// nil entry carries no operation to apply either way.
 				continue
 			}
-			c.handleEntry(lw, entry)
-		}
-	}
-}
-
-// handleEntry buffers entry when lw's mode says to, and applies it live when
-// lw's mode says to. The two are independent so a tee does both.
-func (c *Cache) handleEntry(lw *liveWatcher, entry jetstream.KeyValueEntry) {
-	lw.mu.Lock()
-	mode := lw.mode
-	if mode == modeBuffer || mode == modeTee {
-		if lw.bufErr == nil {
-			if len(lw.buf) >= c.maxBufferedEvents {
-				lw.bufErr = errBufferOverflow
-			} else {
-				lw.buf = append(lw.buf, entry)
+			if c.getActive() != lw {
+				continue
 			}
+			c.applyLive(entry)
 		}
-	}
-	lw.mu.Unlock()
-
-	if mode == modeLive || mode == modeTee {
-		c.applyLive(entry)
 	}
 }
 
@@ -417,9 +348,6 @@ func (c *Cache) snapshotCandidate(ctx context.Context) (map[string]*vm.VM, map[s
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	if c.postSnapshotHook != nil {
-		c.postSnapshotHook()
-	}
 	entries := make(map[string]*vm.VM, len(items))
 	index := make(map[string]map[string]struct{})
 	for i := range items {
@@ -429,144 +357,129 @@ func (c *Cache) snapshotCandidate(ctx context.Context) (map[string]*vm.VM, map[s
 	return entries, index, highWater, nil
 }
 
-// drainBuffered applies every buffered event whose revision is newer than
-// highWater onto entries/index, which is the fence: anything at or before
-// highWater is already reflected in the snapshot that produced entries.
-func (c *Cache) drainBuffered(entries map[string]*vm.VM, index map[string]map[string]struct{},
-	buf []jetstream.KeyValueEntry, highWater uint64) {
-	for _, entry := range buf {
-		if entry.Revision() <= highWater {
-			continue
-		}
-		c.apply(entries, index, entry)
-	}
-}
-
-// goLive ends a watcher's buffered phase: further events apply directly, and
-// anything already queued during the handoff is applied now, live, rather
-// than silently kept or dropped.
-func (c *Cache) goLive(lw *liveWatcher) {
-	lw.mu.Lock()
-	leftover := lw.buf
-	lw.buf = nil
-	lw.bufErr = nil
-	lw.mode = modeLive
-	lw.mu.Unlock()
-	for _, entry := range leftover {
-		c.applyLive(entry)
-	}
-}
-
-// freshSync opens a new watcher, buffers its events, and fences a snapshot
-// against them per the same algorithm every sync uses. It retries against
-// ctx's retry interval until it succeeds or ctx ends. On success the new
-// watcher is live and the map holds the freshly built candidate; on ctx
-// ending it returns nil having left nothing behind.
-func (c *Cache) freshSync(ctx context.Context) *liveWatcher {
+// replay applies every event kw delivers onto entries/index until the
+// end-of-replay marker (nil) arrives: the candidate then reflects everything
+// between the snapshot's high-water mark and the moment it caught up, which
+// is the whole fence — no buffer, no mode, just sequencing.
+func (c *Cache) replay(ctx context.Context, kw jetstream.KeyWatcher, entries map[string]*vm.VM, index map[string]map[string]struct{}) error {
 	for {
-		lw := c.openWatcher(ctx)
-		if lw == nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case entry, ok := <-kw.Updates():
+			if !ok {
+				return errors.New("instancecache: watcher closed before catching up")
+			}
+			if entry == nil {
+				return nil
+			}
+			c.apply(entries, index, entry)
+		}
+	}
+}
+
+// syncOnce runs the whole build algorithm once: snapshot the record space,
+// open a watcher that resumes from just past the snapshot's high-water mark,
+// and replay onto the candidate until it catches up. It touches neither the
+// live map nor the active watcher — installSync does that, and only once an
+// attempt fully succeeds, so a failed attempt has cost nothing.
+func (c *Cache) syncOnce(ctx context.Context) (*liveWatcher, map[string]*vm.VM, map[string]map[string]struct{}, error) {
+	entries, index, hw, err := c.snapshotCandidate(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+
+	if err := c.replay(watchCtx, kw, entries, index); err != nil {
+		cancel()
+		_ = kw.Stop()
+		return nil, nil, nil, err
+	}
+
+	return &liveWatcher{kw: kw, ctx: watchCtx, cancel: cancel, done: make(chan struct{})}, entries, index, nil
+}
+
+// installSync swaps entries/index in as the live map and lw in as the active
+// watcher together, starts lw's live-apply goroutine, then stops and joins
+// oldLw. In that order, so there is never a moment where two watchers both
+// apply to the live map: oldLw, while it was still active, only ever applied
+// to the map installSync is now replacing, and it stops being active in the
+// same step that replacement happens.
+func (c *Cache) installSync(lw *liveWatcher, entries map[string]*vm.VM, index map[string]map[string]struct{}, oldLw *liveWatcher) {
+	c.mu.Lock()
+	c.entries, c.index = entries, index
+	c.ready = true
+	c.mu.Unlock()
+	c.setActive(lw)
+	go c.drain(lw)
+
+	if oldLw != nil {
+		oldLw.cancel()
+		_ = oldLw.kw.Stop()
+		<-oldLw.done
+	}
+}
+
+// resyncUntilSuccess retries syncOnce against the retry interval until it
+// succeeds or ctx ends, installing the result over oldLw. Used by the
+// initial sync and watcher replacement, which both must block until a live
+// watcher exists again; a periodic resync tries only once per tick instead.
+func (c *Cache) resyncUntilSuccess(ctx context.Context, oldLw *liveWatcher) *liveWatcher {
+	for {
+		lw, entries, index, err := c.syncOnce(ctx)
+		if err != nil {
+			c.syncFailed(ctx, err)
 			if !c.sleep(ctx) {
 				return nil
 			}
 			continue
 		}
-
-		entries, index, hw, err := c.snapshotCandidate(ctx)
-		if err == nil {
-			lw.mu.Lock()
-			buf, bufErr := lw.buf, lw.bufErr
-			lw.mu.Unlock()
-			if bufErr == nil {
-				c.drainBuffered(entries, index, buf, hw)
-				c.mu.Lock()
-				c.entries, c.index = entries, index
-				c.ready = true
-				c.mu.Unlock()
-				c.goLive(lw)
-				return lw
-			}
-			err = bufErr
-		}
-
-		c.metrics.resyncFailed()
-		c.degraded.Store(true)
-		slog.WarnContext(ctx, "instancecache: sync failed, retrying", "err", err)
-		c.discardWatcher(lw)
-		if !c.sleep(ctx) {
-			return nil
-		}
+		c.installSync(lw, entries, index, oldLw)
+		c.markResynced()
+		return lw
 	}
 }
 
-// initialSync is freshSync plus making the result the active watcher and
-// recording the first successful resync.
+// initialSync is resyncUntilSuccess with no old watcher to fence against,
+// plus making the result the active watcher and recording the first
+// successful resync.
 func (c *Cache) initialSync(ctx context.Context) *liveWatcher {
-	lw := c.freshSync(ctx)
-	if lw == nil {
-		return nil
-	}
-	c.setActive(lw)
-	c.markResynced()
-	return lw
+	return c.resyncUntilSuccess(ctx, nil)
 }
 
-// periodicResync tees the live watcher rather than opening a second
-// subscription: events keep applying to the live map throughout, and a
-// snapshot-fenced candidate is built off to the side and swapped in only on
-// success. A failure costs nothing but a discarded candidate, because the
-// tee already applied everything to the live map in real time.
+// periodicResync tries the build algorithm once per tick. The active watcher
+// keeps applying to the live map for the whole attempt, since installSync is
+// the only thing that ever changes what "the live map" is, so a failure
+// costs nothing but a discarded candidate; the next tick tries again rather
+// than retrying in a loop here.
 func (c *Cache) periodicResync(ctx context.Context) {
-	lw := c.getActive()
-	if lw == nil {
+	oldLw := c.getActive()
+	if oldLw == nil {
 		return
 	}
-
-	lw.mu.Lock()
-	lw.mode = modeTee
-	lw.buf = nil
-	lw.bufErr = nil
-	lw.mu.Unlock()
-
-	entries, index, hw, err := c.snapshotCandidate(ctx)
-	if err == nil {
-		lw.mu.Lock()
-		buf, bufErr := lw.buf, lw.bufErr
-		lw.mu.Unlock()
-		if bufErr == nil {
-			c.drainBuffered(entries, index, buf, hw)
-			c.mu.Lock()
-			c.entries, c.index = entries, index
-			c.mu.Unlock()
-			c.markResynced()
-		} else {
-			err = bufErr
-		}
-	}
+	lw, entries, index, err := c.syncOnce(ctx)
 	if err != nil {
-		c.metrics.resyncFailed()
-		c.degraded.Store(true)
-		slog.WarnContext(ctx, "instancecache: periodic resync failed, serving previous contents", "err", err)
+		c.syncFailed(ctx, err)
+		return
 	}
-	c.goLive(lw)
+	c.installSync(lw, entries, index, oldLw)
+	c.markResynced()
 }
 
 // replaceWatcher retires a dead watcher and installs a fresh one under the
-// same fencing. The old watcher is stopped and joined before the new one is
-// allowed to go live, so there is never a moment where two watchers both
-// apply to the map.
+// same build algorithm, retrying against the retry interval until it
+// succeeds or ctx ends.
 func (c *Cache) replaceWatcher(ctx context.Context, oldLw *liveWatcher) {
-	oldLw.cancel()
-	_ = oldLw.kw.Stop()
-	<-oldLw.done
-
-	lw := c.freshSync(ctx)
-	if lw == nil {
-		return
+	lw := c.resyncUntilSuccess(ctx, oldLw)
+	if lw != nil {
+		c.metrics.watchReconnected()
 	}
-	c.setActive(lw)
-	c.metrics.watchReconnected()
-	c.markResynced()
 }
 
 // indexKeyFor is the account index's bucket for v's owner: Global for an

--- a/spinifex/instancecache/cache.go
+++ b/spinifex/instancecache/cache.go
@@ -127,8 +127,14 @@ type Cache struct {
 
 	watcherLost chan struct{}
 	lastResync  atomic.Int64 // unix nanos of the last successful sync, 0 = never
+	degraded    atomic.Bool  // true from a failed sync until the next one succeeds
 
 	metrics *cacheMetrics
+
+	// postSnapshotHook, when set, runs after Snapshot returns and before the
+	// buffer is read. Nil in production; a test seam for landing an event
+	// deterministically inside the fence's danger window.
+	postSnapshotHook func()
 }
 
 // New returns a Cache over the bucket cfg describes. Call Run to start it;
@@ -201,6 +207,14 @@ func (c *Cache) Ready() bool {
 	return c.ready
 }
 
+// Degraded reports whether the most recent sync attempt (initial, periodic,
+// or watcher-replacement) failed. The cache keeps serving its last-known
+// contents regardless, but a cache that has been degraded for a while cannot
+// be trusted about absence. Not consulted by List or Get in this phase.
+func (c *Cache) Degraded() bool {
+	return c.degraded.Load()
+}
+
 // List returns the cached instances visible to accountID and whether the
 // cache is ready to be believed about absence. IsInstanceVisibleToCaller is
 // applied after the index lookup as defence in depth: the index is a
@@ -256,6 +270,7 @@ func (c *Cache) setActive(lw *liveWatcher) {
 
 func (c *Cache) markResynced() {
 	c.lastResync.Store(time.Now().UnixNano())
+	c.degraded.Store(false)
 }
 
 // resyncAge reports how long ago the last successful sync completed. ok is
@@ -385,7 +400,7 @@ func (c *Cache) apply(entries map[string]*vm.VM, index map[string]map[string]str
 	default:
 		var rec vm.InstanceRecord
 		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
-			c.metrics.decodeFailure(entry.Key())
+			c.metrics.decodeFailure()
 			slog.Warn("instancecache: undecodable record, keeping previous value",
 				"key", entry.Key(), "err", err)
 			return
@@ -401,6 +416,9 @@ func (c *Cache) snapshotCandidate(ctx context.Context) (map[string]*vm.VM, map[s
 	items, highWater, err := c.store.Snapshot(ctx, c.filter)
 	if err != nil {
 		return nil, nil, 0, err
+	}
+	if c.postSnapshotHook != nil {
+		c.postSnapshotHook()
 	}
 	entries := make(map[string]*vm.VM, len(items))
 	index := make(map[string]map[string]struct{})
@@ -472,6 +490,7 @@ func (c *Cache) freshSync(ctx context.Context) *liveWatcher {
 		}
 
 		c.metrics.resyncFailed()
+		c.degraded.Store(true)
 		slog.WarnContext(ctx, "instancecache: sync failed, retrying", "err", err)
 		c.discardWatcher(lw)
 		if !c.sleep(ctx) {
@@ -526,6 +545,7 @@ func (c *Cache) periodicResync(ctx context.Context) {
 	}
 	if err != nil {
 		c.metrics.resyncFailed()
+		c.degraded.Store(true)
 		slog.WarnContext(ctx, "instancecache: periodic resync failed, serving previous contents", "err", err)
 	}
 	c.goLive(lw)

--- a/spinifex/instancecache/cache.go
+++ b/spinifex/instancecache/cache.go
@@ -1,0 +1,597 @@
+// Package instancecache is a read-only informer over the live instance record
+// space: a cache of *vm.VM projections kept current by a JetStream KV watch
+// and backstopped by a periodic whole-set resync. It answers List and Get
+// from memory; nothing here fans out over NATS.
+//
+// Entries are immutable. An update replaces a map entry's pointer; nothing
+// mutates a *vm.VM in place, and a caller must not either.
+//
+// The watch and the resync are fenced against each other through
+// kvstore.Store.Snapshot's highWater mark: a watcher is opened and its events
+// buffered before the snapshot is taken, so nothing that happened during the
+// snapshot is lost or double-applied once the buffer is drained against the
+// snapshot's high-water revision. A periodic resync does not open a second
+// subscription — it tees the existing live watcher's events into a side
+// buffer while continuing to apply them to the live map directly, so a
+// resync that then fails has cost nothing: the live map already has
+// everything the failed candidate would have had. Only a watcher that
+// actually dies is replaced, and its successor takes over under the same
+// fencing before the old one is stopped and joined.
+//
+// A record that will not decode never removes an entry: the cache only ever
+// removes a key because the record space said it is gone, never because one
+// read of it failed.
+package instancecache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	instance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/instance"
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Defaults for Config.
+const (
+	// DefaultResyncInterval is the periodic tee-based resync cadence: the
+	// completeness backstop for a delete or TTL expiry the watch missed.
+	DefaultResyncInterval = 30 * time.Second
+
+	// DefaultMaxBufferedEvents bounds the side buffer a sync fences events
+	// through. Overflowing it fails the sync rather than dropping events
+	// silently, so it must stay well above a burst like a 50-instance launch.
+	DefaultMaxBufferedEvents = 10000
+
+	// DefaultRetryInterval is how long a failed sync waits before trying
+	// again, so an unreachable bucket is retried without spinning.
+	DefaultRetryInterval = 5 * time.Second
+)
+
+var errBufferOverflow = errors.New("instancecache: sync buffer overflow")
+
+// Config configures the KV bucket a Cache watches and its clocks. Bucket and
+// Prefix are supplied by the caller so this package never has to know the
+// daemon's bucket name or key-space constants.
+type Config struct {
+	// Bucket names and sizes the KV bucket to open. The caller resolves the
+	// name and replica count, matching how every other reconcile loop in
+	// awsgw opens the same bucket.
+	Bucket kvstore.Config
+
+	// Prefix is the key prefix identifying an instance record, e.g. "i.".
+	// The watch and snapshot filter is Prefix+"*", and an entry's map key is
+	// its record key with Prefix trimmed.
+	Prefix string
+
+	ResyncInterval    time.Duration
+	MaxBufferedEvents int
+	RetryInterval     time.Duration
+}
+
+// watchMode governs what a liveWatcher's drain goroutine does with an
+// incoming event.
+type watchMode int
+
+const (
+	// modeBuffer queues events without applying them: a watcher that has not
+	// yet gone live, either the very first one or a replacement mid-handoff.
+	modeBuffer watchMode = iota
+	// modeLive applies events directly and buffers nothing.
+	modeLive
+	// modeTee applies events directly and also queues them, for a periodic
+	// resync borrowing the live watcher's events without diverting them.
+	modeTee
+)
+
+// liveWatcher is one KeyWatcher plus the goroutine draining it, and the
+// buffering state a sync uses to fence its events against a snapshot.
+type liveWatcher struct {
+	kw     jetstream.KeyWatcher
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu     sync.Mutex
+	mode   watchMode
+	buf    []jetstream.KeyValueEntry
+	bufErr error
+}
+
+// Cache is the informer: a live map of instance ID to *vm.VM, an account
+// index over it, and the goroutine that keeps both current. Construct with
+// New and start with Run.
+type Cache struct {
+	store  *kvstore.Store[vm.InstanceRecord]
+	prefix string
+	filter string
+
+	resyncInterval    time.Duration
+	maxBufferedEvents int
+	retryInterval     time.Duration
+
+	mu      sync.RWMutex
+	entries map[string]*vm.VM
+	index   map[string]map[string]struct{}
+	ready   bool
+
+	watcherMu sync.Mutex
+	active    *liveWatcher
+
+	watcherLost chan struct{}
+	lastResync  atomic.Int64 // unix nanos of the last successful sync, 0 = never
+
+	metrics *cacheMetrics
+}
+
+// New returns a Cache over the bucket cfg describes. Call Run to start it;
+// until the first sync completes, List reports the cache not ready.
+func New(js jetstream.JetStream, cfg Config) *Cache {
+	resync := cfg.ResyncInterval
+	if resync <= 0 {
+		resync = DefaultResyncInterval
+	}
+	maxBuf := cfg.MaxBufferedEvents
+	if maxBuf <= 0 {
+		maxBuf = DefaultMaxBufferedEvents
+	}
+	retry := cfg.RetryInterval
+	if retry <= 0 {
+		retry = DefaultRetryInterval
+	}
+	c := &Cache{
+		store:             kvstore.New[vm.InstanceRecord](js, cfg.Bucket),
+		prefix:            cfg.Prefix,
+		filter:            cfg.Prefix + "*",
+		resyncInterval:    resync,
+		maxBufferedEvents: maxBuf,
+		retryInterval:     retry,
+		entries:           map[string]*vm.VM{},
+		index:             map[string]map[string]struct{}{},
+		watcherLost:       make(chan struct{}, 1),
+	}
+	c.metrics = newCacheMetrics(c)
+	return c
+}
+
+// Run drives the informer until ctx is cancelled: the initial sync, then the
+// periodic resync and watcher-replacement loop. Intended to run in its own
+// goroutine, matching the other reconcile loops awsgw starts.
+func (c *Cache) Run(ctx context.Context) {
+	lw := c.initialSync(ctx)
+	if lw == nil {
+		return
+	}
+
+	ticker := time.NewTicker(c.resyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			active := c.getActive()
+			if active != nil {
+				active.cancel()
+				_ = active.kw.Stop()
+			}
+			return
+		case <-c.watcherLost:
+			active := c.getActive()
+			if active != nil {
+				c.replaceWatcher(ctx, active)
+			}
+		case <-ticker.C:
+			c.periodicResync(ctx)
+		}
+	}
+}
+
+// Ready reports whether the initial whole-set sync has completed. Before it
+// has, List and Get answer from an empty or partial view and must never be
+// read as proof an instance does not exist.
+func (c *Cache) Ready() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ready
+}
+
+// List returns the cached instances visible to accountID and whether the
+// cache is ready to be believed about absence. IsInstanceVisibleToCaller is
+// applied after the index lookup as defence in depth: the index is a
+// performance structure, not the authorisation boundary.
+func (c *Cache) List(_ context.Context, accountID string) ([]*vm.VM, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	ids := c.index[indexKeyFor(accountID)]
+	out := make([]*vm.VM, 0, len(ids))
+	for id := range ids {
+		v, ok := c.entries[id]
+		if !ok || !instance.IsInstanceVisibleToCaller(accountID, v) {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out, c.ready
+}
+
+// Get returns one instance by ID, consulting KV directly on a cache miss. A
+// nil instance with a nil error means the record space has no record of it.
+func (c *Cache) Get(ctx context.Context, instanceID string) (*vm.VM, error) {
+	c.mu.RLock()
+	v, ok := c.entries[instanceID]
+	c.mu.RUnlock()
+	if ok {
+		return v, nil
+	}
+
+	rec, _, err := c.store.Get(ctx, c.prefix+instanceID)
+	if err != nil {
+		if errors.Is(err, kvstore.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return vm.VMFromRecord(rec), nil
+}
+
+// getActive and setActive guard the watcher pointer separately from the map,
+// so a List or Get never blocks behind a watcher transition.
+func (c *Cache) getActive() *liveWatcher {
+	c.watcherMu.Lock()
+	defer c.watcherMu.Unlock()
+	return c.active
+}
+
+func (c *Cache) setActive(lw *liveWatcher) {
+	c.watcherMu.Lock()
+	c.active = lw
+	c.watcherMu.Unlock()
+}
+
+func (c *Cache) markResynced() {
+	c.lastResync.Store(time.Now().UnixNano())
+}
+
+// resyncAge reports how long ago the last successful sync completed. ok is
+// false when no sync has ever succeeded, which the resync-age metric skips
+// rather than reporting a misleading zero.
+func (c *Cache) resyncAge() (time.Duration, bool) {
+	n := c.lastResync.Load()
+	if n == 0 {
+		return 0, false
+	}
+	return time.Since(time.Unix(0, n)), true
+}
+
+// entriesByState groups the live map by raw instance state, for the
+// entries-by-state gauge.
+func (c *Cache) entriesByState() map[string]int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make(map[string]int64, len(c.entries))
+	for _, v := range c.entries {
+		out[string(v.Status)]++
+	}
+	return out
+}
+
+// sleep waits out the retry interval, reporting false if ctx ended first.
+func (c *Cache) sleep(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(c.retryInterval):
+		return true
+	}
+}
+
+// openWatcher opens a new watcher in modeBuffer and starts draining it. A nil
+// return means the bucket could not be watched this attempt.
+func (c *Cache) openWatcher(ctx context.Context) *liveWatcher {
+	watchCtx, cancel := context.WithCancel(ctx)
+	kw, err := c.store.Watch(watchCtx, c.filter)
+	if err != nil {
+		cancel()
+		slog.WarnContext(ctx, "instancecache: watch unavailable, retrying", "err", err)
+		return nil
+	}
+	lw := &liveWatcher{kw: kw, cancel: cancel, done: make(chan struct{})}
+	go c.drain(watchCtx, lw)
+	return lw
+}
+
+// discardWatcher tears a failed candidate's watcher down: cancel, stop and
+// join, so a repeatedly failing sync leaks neither a subscription nor a
+// buffer.
+func (c *Cache) discardWatcher(lw *liveWatcher) {
+	lw.cancel()
+	_ = lw.kw.Stop()
+	<-lw.done
+}
+
+// drain forwards one watcher's events to handleEntry until its channel
+// closes or ctx ends. A channel that closes while ctx is still live means the
+// connection dropped out from under it, which is the signal Run replaces the
+// watcher on; a channel that closes because ctx was cancelled is an
+// intentional teardown and reports nothing.
+func (c *Cache) drain(ctx context.Context, lw *liveWatcher) {
+	defer close(lw.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case entry, ok := <-lw.kw.Updates():
+			if !ok {
+				if ctx.Err() == nil {
+					select {
+					case c.watcherLost <- struct{}{}:
+					default:
+					}
+				}
+				return
+			}
+			if entry == nil {
+				// UpdatesOnly should not emit the end-of-replay marker, but a
+				// nil entry carries no operation to apply either way.
+				continue
+			}
+			c.handleEntry(lw, entry)
+		}
+	}
+}
+
+// handleEntry buffers entry when lw's mode says to, and applies it live when
+// lw's mode says to. The two are independent so a tee does both.
+func (c *Cache) handleEntry(lw *liveWatcher, entry jetstream.KeyValueEntry) {
+	lw.mu.Lock()
+	mode := lw.mode
+	if mode == modeBuffer || mode == modeTee {
+		if lw.bufErr == nil {
+			if len(lw.buf) >= c.maxBufferedEvents {
+				lw.bufErr = errBufferOverflow
+			} else {
+				lw.buf = append(lw.buf, entry)
+			}
+		}
+	}
+	lw.mu.Unlock()
+
+	if mode == modeLive || mode == modeTee {
+		c.applyLive(entry)
+	}
+}
+
+func (c *Cache) applyLive(entry jetstream.KeyValueEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.apply(c.entries, c.index, entry)
+}
+
+// apply decodes one watch entry into entries/index. A put that will not
+// decode leaves whatever is already at that key untouched and counts a
+// decode failure; a delete or purge always removes the key. Absence is
+// established only by the record space saying so, never by a decode failure.
+func (c *Cache) apply(entries map[string]*vm.VM, index map[string]map[string]struct{}, entry jetstream.KeyValueEntry) {
+	id := strings.TrimPrefix(entry.Key(), c.prefix)
+	switch entry.Operation() {
+	case jetstream.KeyValueDelete, jetstream.KeyValuePurge:
+		removeFrom(entries, index, id)
+	default:
+		var rec vm.InstanceRecord
+		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+			c.metrics.decodeFailure(entry.Key())
+			slog.Warn("instancecache: undecodable record, keeping previous value",
+				"key", entry.Key(), "err", err)
+			return
+		}
+		putInto(entries, index, id, vm.VMFromRecord(&rec))
+	}
+}
+
+// snapshotCandidate reads the whole record space through one consumer,
+// mutually consistent per kvstore.Store.Snapshot, and builds a fresh
+// entries/index pair from it.
+func (c *Cache) snapshotCandidate(ctx context.Context) (map[string]*vm.VM, map[string]map[string]struct{}, uint64, error) {
+	items, highWater, err := c.store.Snapshot(ctx, c.filter)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	entries := make(map[string]*vm.VM, len(items))
+	index := make(map[string]map[string]struct{})
+	for i := range items {
+		id := strings.TrimPrefix(items[i].Key, c.prefix)
+		putInto(entries, index, id, vm.VMFromRecord(&items[i].Value))
+	}
+	return entries, index, highWater, nil
+}
+
+// drainBuffered applies every buffered event whose revision is newer than
+// highWater onto entries/index, which is the fence: anything at or before
+// highWater is already reflected in the snapshot that produced entries.
+func (c *Cache) drainBuffered(entries map[string]*vm.VM, index map[string]map[string]struct{},
+	buf []jetstream.KeyValueEntry, highWater uint64) {
+	for _, entry := range buf {
+		if entry.Revision() <= highWater {
+			continue
+		}
+		c.apply(entries, index, entry)
+	}
+}
+
+// goLive ends a watcher's buffered phase: further events apply directly, and
+// anything already queued during the handoff is applied now, live, rather
+// than silently kept or dropped.
+func (c *Cache) goLive(lw *liveWatcher) {
+	lw.mu.Lock()
+	leftover := lw.buf
+	lw.buf = nil
+	lw.bufErr = nil
+	lw.mode = modeLive
+	lw.mu.Unlock()
+	for _, entry := range leftover {
+		c.applyLive(entry)
+	}
+}
+
+// freshSync opens a new watcher, buffers its events, and fences a snapshot
+// against them per the same algorithm every sync uses. It retries against
+// ctx's retry interval until it succeeds or ctx ends. On success the new
+// watcher is live and the map holds the freshly built candidate; on ctx
+// ending it returns nil having left nothing behind.
+func (c *Cache) freshSync(ctx context.Context) *liveWatcher {
+	for {
+		lw := c.openWatcher(ctx)
+		if lw == nil {
+			if !c.sleep(ctx) {
+				return nil
+			}
+			continue
+		}
+
+		entries, index, hw, err := c.snapshotCandidate(ctx)
+		if err == nil {
+			lw.mu.Lock()
+			buf, bufErr := lw.buf, lw.bufErr
+			lw.mu.Unlock()
+			if bufErr == nil {
+				c.drainBuffered(entries, index, buf, hw)
+				c.mu.Lock()
+				c.entries, c.index = entries, index
+				c.ready = true
+				c.mu.Unlock()
+				c.goLive(lw)
+				return lw
+			}
+			err = bufErr
+		}
+
+		c.metrics.resyncFailed()
+		slog.WarnContext(ctx, "instancecache: sync failed, retrying", "err", err)
+		c.discardWatcher(lw)
+		if !c.sleep(ctx) {
+			return nil
+		}
+	}
+}
+
+// initialSync is freshSync plus making the result the active watcher and
+// recording the first successful resync.
+func (c *Cache) initialSync(ctx context.Context) *liveWatcher {
+	lw := c.freshSync(ctx)
+	if lw == nil {
+		return nil
+	}
+	c.setActive(lw)
+	c.markResynced()
+	return lw
+}
+
+// periodicResync tees the live watcher rather than opening a second
+// subscription: events keep applying to the live map throughout, and a
+// snapshot-fenced candidate is built off to the side and swapped in only on
+// success. A failure costs nothing but a discarded candidate, because the
+// tee already applied everything to the live map in real time.
+func (c *Cache) periodicResync(ctx context.Context) {
+	lw := c.getActive()
+	if lw == nil {
+		return
+	}
+
+	lw.mu.Lock()
+	lw.mode = modeTee
+	lw.buf = nil
+	lw.bufErr = nil
+	lw.mu.Unlock()
+
+	entries, index, hw, err := c.snapshotCandidate(ctx)
+	if err == nil {
+		lw.mu.Lock()
+		buf, bufErr := lw.buf, lw.bufErr
+		lw.mu.Unlock()
+		if bufErr == nil {
+			c.drainBuffered(entries, index, buf, hw)
+			c.mu.Lock()
+			c.entries, c.index = entries, index
+			c.mu.Unlock()
+			c.markResynced()
+		} else {
+			err = bufErr
+		}
+	}
+	if err != nil {
+		c.metrics.resyncFailed()
+		slog.WarnContext(ctx, "instancecache: periodic resync failed, serving previous contents", "err", err)
+	}
+	c.goLive(lw)
+}
+
+// replaceWatcher retires a dead watcher and installs a fresh one under the
+// same fencing. The old watcher is stopped and joined before the new one is
+// allowed to go live, so there is never a moment where two watchers both
+// apply to the map.
+func (c *Cache) replaceWatcher(ctx context.Context, oldLw *liveWatcher) {
+	oldLw.cancel()
+	_ = oldLw.kw.Stop()
+	<-oldLw.done
+
+	lw := c.freshSync(ctx)
+	if lw == nil {
+		return
+	}
+	c.setActive(lw)
+	c.metrics.watchReconnected()
+	c.markResynced()
+}
+
+// indexKeyFor is the account index's bucket for v's owner: Global for an
+// empty owner, so a legacy pre-account record files under the same bucket a
+// platform-managed record does, and never under every account at once.
+func indexKeyFor(accountID string) string {
+	if accountID == "" {
+		return utils.GlobalAccountID
+	}
+	return accountID
+}
+
+func putInto(entries map[string]*vm.VM, index map[string]map[string]struct{}, id string, v *vm.VM) {
+	if old, ok := entries[id]; ok {
+		removeFromIndex(index, indexKeyFor(old.AccountID), id)
+	}
+	entries[id] = v
+	addToIndex(index, indexKeyFor(v.AccountID), id)
+}
+
+func removeFrom(entries map[string]*vm.VM, index map[string]map[string]struct{}, id string) {
+	old, ok := entries[id]
+	if !ok {
+		return
+	}
+	delete(entries, id)
+	removeFromIndex(index, indexKeyFor(old.AccountID), id)
+}
+
+func addToIndex(index map[string]map[string]struct{}, key, id string) {
+	set, ok := index[key]
+	if !ok {
+		set = make(map[string]struct{})
+		index[key] = set
+	}
+	set[id] = struct{}{}
+}
+
+func removeFromIndex(index map[string]map[string]struct{}, key, id string) {
+	set, ok := index[key]
+	if !ok {
+		return
+	}
+	delete(set, id)
+	if len(set) == 0 {
+		delete(index, key)
+	}
+}

--- a/spinifex/instancecache/cache.go
+++ b/spinifex/instancecache/cache.go
@@ -101,6 +101,13 @@ type Cache struct {
 	degraded    atomic.Bool  // true from a failed sync until the next one succeeds
 
 	metrics *cacheMetrics
+
+	// postSnapshotHook, when set, runs inside syncOnce after snapshotCandidate
+	// returns and before the resuming watcher is opened. Nil in production; a
+	// test seam for landing a write deterministically inside the window a
+	// resuming watcher has to close, which nothing else can reach because it
+	// is internal to syncOnce.
+	postSnapshotHook func()
 }
 
 // New returns a Cache over the bucket cfg describes. Call Run to start it;
@@ -387,6 +394,9 @@ func (c *Cache) syncOnce(ctx context.Context) (*liveWatcher, map[string]*vm.VM, 
 	entries, index, hw, err := c.snapshotCandidate(ctx)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+	if c.postSnapshotHook != nil {
+		c.postSnapshotHook()
 	}
 
 	watchCtx, cancel := context.WithCancel(ctx)

--- a/spinifex/instancecache/cache_test.go
+++ b/spinifex/instancecache/cache_test.go
@@ -1,7 +1,7 @@
-// internal mode, buffer and subscription state directly (there is no
-// exported surface for "one live watcher" or "buffer returned to its
-// starting size"), and the account-index defence-in-depth test deliberately
-// mis-files a record by writing straight into the unexported maps.
+// internal watcher and lifecycle state directly (there is no exported
+// surface for "one live watcher" or "the candidate before install"), and the
+// account-index defence-in-depth test deliberately mis-files a record by
+// writing straight into the unexported maps.
 //
 //test:in-package — the fencing and lifecycle tests assert on the watcher's
 package instancecache
@@ -122,36 +122,6 @@ func waitForListLen(t *testing.T, c *Cache, accountID string, n int) []*vm.VM {
 	return list
 }
 
-// fakeEntry is a minimal jetstream.KeyValueEntry for exercising the fencing
-// logic directly, without a real watcher's timing involved.
-type fakeEntry struct {
-	key   string
-	value []byte
-	rev   uint64
-	op    jetstream.KeyValueOp
-}
-
-func (f fakeEntry) Bucket() string                  { return "test" }
-func (f fakeEntry) Key() string                     { return f.key }
-func (f fakeEntry) Value() []byte                   { return f.value }
-func (f fakeEntry) Revision() uint64                { return f.rev }
-func (f fakeEntry) Created() time.Time              { return time.Time{} }
-func (f fakeEntry) Delta() uint64                   { return 0 }
-func (f fakeEntry) Operation() jetstream.KeyValueOp { return f.op }
-
-var _ jetstream.KeyValueEntry = fakeEntry{}
-
-func putEntry(t *testing.T, id string, rec *vm.InstanceRecord, rev uint64) fakeEntry {
-	t.Helper()
-	data, err := json.Marshal(rec)
-	require.NoError(t, err)
-	return fakeEntry{key: testPrefix + id, value: data, rev: rev, op: jetstream.KeyValuePut}
-}
-
-func deleteEntry(id string, rev uint64) fakeEntry {
-	return fakeEntry{key: testPrefix + id, rev: rev, op: jetstream.KeyValueDelete}
-}
-
 // Process-wide manual metric reader, installed once per test binary so the
 // resync-failure and decode-failure counters can be observed. Cumulative for
 // the life of the binary, so tests read a before/after delta.
@@ -245,42 +215,23 @@ func TestPeriodicResync_RemovesEntryTheWatchNeverToldItAbout(t *testing.T) {
 	require.Equal(t, "i-real", list[0].ID)
 }
 
-func TestFreshSync_LeaksNothingOnRepeatedFailure(t *testing.T) {
+func TestSync_LeaksNothingOnRepeatedSnapshotFailure(t *testing.T) {
 	c, kv, conn := newTestCache(t)
 	putGarbage(t, kv, "i-bad")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	baseline := conn.nc.NumSubscriptions()
+	go c.Run(ctx)
 
+	// The initial sync's snapshot fails on the garbage record every retry, so
+	// the replay watcher is never opened: nothing persists to leak. Snapshot
+	// itself briefly opens and closes its own probe watcher on every attempt,
+	// so the assertion is that the count always settles back to baseline,
+	// not that it never blips.
 	for range 10 {
-		lw := c.openWatcher(ctx)
-		require.NotNil(t, lw)
-		_, _, _, err := c.snapshotCandidate(ctx)
-		require.Error(t, err)
-		c.discardWatcher(lw)
-		require.Equal(t, baseline, conn.nc.NumSubscriptions())
+		time.Sleep(20 * time.Millisecond)
+		waitFor(t, time.Second, func() bool { return conn.nc.NumSubscriptions() == baseline })
 	}
-	require.False(t, c.Ready())
-}
-
-func TestFreshSync_BufferOverflowFailsSync(t *testing.T) {
-	c, _, conn := newTestCache(t, func(cfg *Config) { cfg.MaxBufferedEvents = 1 })
-	ctx := context.Background()
-	baseline := conn.nc.NumSubscriptions()
-
-	lw := c.openWatcher(ctx)
-	require.NotNil(t, lw)
-
-	c.handleEntry(lw, putEntry(t, "i-1", testRecord("i-1", acctA, vm.StateRunning), 1))
-	c.handleEntry(lw, putEntry(t, "i-2", testRecord("i-2", acctA, vm.StateRunning), 2))
-
-	lw.mu.Lock()
-	bufErr := lw.bufErr
-	lw.mu.Unlock()
-	require.ErrorIs(t, bufErr, errBufferOverflow)
-
-	c.discardWatcher(lw)
-	require.Equal(t, baseline, conn.nc.NumSubscriptions())
 	require.False(t, c.Ready())
 }
 
@@ -397,77 +348,125 @@ func TestList_NotReadyBeforeFirstSync(t *testing.T) {
 	require.Empty(t, list)
 }
 
-// --- Fencing, the D2a algorithm --------------------------------------------
+// --- Fencing: replay closes the snapshot-to-watch window --------------------
+//
+// Each test lands a write in the exact window the fence has to cover: after
+// Snapshot has already read the record space, before the new watcher (which
+// resumes from the snapshot's high-water mark) is opened. There is no
+// buffering machinery to race against any more, so the write happens as an
+// ordinary step between two ordinary calls.
 
-func TestFence_BufferedEventAtOrBelowHighWaterDiscarded(t *testing.T) {
-	c, _, _ := newTestCache(t)
-	entries := map[string]*vm.VM{}
-	index := map[string]map[string]struct{}{}
-	putInto(entries, index, "i-x", vm.VMFromRecord(testRecord("i-x", acctA, vm.StateRunning)))
-
-	buf := []jetstream.KeyValueEntry{putEntry(t, "i-x", testRecord("i-x", acctA, vm.StateStopped), 5)}
-	c.drainBuffered(entries, index, buf, 5)
-
-	require.Equal(t, vm.StateRunning, entries["i-x"].Status,
-		"a buffered event at highWater must not overwrite what the snapshot already reflects")
-}
-
-func TestFence_PutAboveHighWaterIsPresentAfterwards(t *testing.T) {
-	c, _, _ := newTestCache(t)
-	entries := map[string]*vm.VM{}
-	index := map[string]map[string]struct{}{}
-
-	buf := []jetstream.KeyValueEntry{putEntry(t, "i-y", testRecord("i-y", acctA, vm.StateRunning), 6)}
-	c.drainBuffered(entries, index, buf, 5)
-
-	v, ok := entries["i-y"]
-	require.True(t, ok)
-	require.Equal(t, vm.StateRunning, v.Status)
-	require.Contains(t, index[acctA], "i-y")
-}
-
-func TestFence_DeleteAboveHighWaterIsAbsentAfterwards(t *testing.T) {
-	c, _, _ := newTestCache(t)
-	entries := map[string]*vm.VM{}
-	index := map[string]map[string]struct{}{}
-	putInto(entries, index, "i-z", vm.VMFromRecord(testRecord("i-z", acctA, vm.StateRunning)))
-
-	buf := []jetstream.KeyValueEntry{deleteEntry("i-z", 6)}
-	c.drainBuffered(entries, index, buf, 5)
-
-	_, ok := entries["i-z"]
-	require.False(t, ok, "a delete above highWater must remove the snapshot's stale copy")
-	require.NotContains(t, index[acctA], "i-z")
-}
-
-func TestFreshSync_NotReadyUntilBufferDrained(t *testing.T) {
+func TestFence_PutDuringInitialSnapshot_SurvivesInstall(t *testing.T) {
 	c, kv, _ := newTestCache(t)
-	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
-	ctx := context.Background()
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
 
-	lw := c.openWatcher(ctx)
-	require.NotNil(t, lw)
-	require.False(t, c.Ready(), "opening the watcher alone must not mark the cache ready")
+	entries, index, hw, err := c.snapshotCandidate(context.Background())
+	require.NoError(t, err)
+
+	putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
+
+	watchCtx := t.Context()
+	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
+	require.NoError(t, err)
+	defer func() { _ = kw.Stop() }()
+
+	require.NoError(t, c.replay(watchCtx, kw, entries, index))
+
+	require.Len(t, entries, 2)
+	require.Contains(t, entries, "i-seed")
+	require.Contains(t, entries, "i-new",
+		"a put landing after the snapshot but before the watcher opened must be replayed")
+}
+
+func TestFence_DeleteDuringInitialSnapshot_RemovedFromInstall(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+	putRecord(t, kv, "i-doomed", testRecord("i-doomed", acctA, vm.StateRunning))
+
+	entries, index, hw, err := c.snapshotCandidate(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
+
+	watchCtx := t.Context()
+	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
+	require.NoError(t, err)
+	defer func() { _ = kw.Stop() }()
+
+	require.NoError(t, c.replay(watchCtx, kw, entries, index))
+
+	require.Len(t, entries, 1)
+	require.Contains(t, entries, "i-seed")
+	require.NotContains(t, entries, "i-doomed",
+		"a delete landing after the snapshot but before the watcher opened must not survive as the snapshot's stale copy")
+	require.NotContains(t, index[acctA], "i-doomed")
+}
+
+func TestFence_PutDuringPeriodicResync_SurvivesInstall(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	oldLw := c.getActive()
+	require.NotNil(t, oldLw)
 
 	entries, index, hw, err := c.snapshotCandidate(ctx)
 	require.NoError(t, err)
-	require.False(t, c.Ready(), "taking the snapshot alone must not mark the cache ready")
 
-	lw.mu.Lock()
-	buf, bufErr := lw.buf, lw.bufErr
-	lw.mu.Unlock()
-	require.NoError(t, bufErr)
-	c.drainBuffered(entries, index, buf, hw)
-	require.False(t, c.Ready(), "draining the buffer into a candidate must not itself mark ready")
+	putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
 
-	c.mu.Lock()
-	c.entries, c.index = entries, index
-	c.ready = true
-	c.mu.Unlock()
-	require.True(t, c.Ready())
+	watchCtx, cancel := context.WithCancel(ctx)
+	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
+	require.NoError(t, err)
+	require.NoError(t, c.replay(watchCtx, kw, entries, index))
 
-	c.discardWatcher(lw)
+	lw := &liveWatcher{kw: kw, ctx: watchCtx, cancel: cancel, done: make(chan struct{})}
+	c.installSync(lw, entries, index, oldLw)
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.ElementsMatch(t, []string{"i-seed", "i-new"}, idsOf(list),
+		"a put landing after a periodic resync's snapshot but before the new watcher opened must be replayed")
 }
+
+func TestFence_DeleteDuringPeriodicResync_RemovedFromInstall(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+	putRecord(t, kv, "i-doomed", testRecord("i-doomed", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 2)
+
+	oldLw := c.getActive()
+	require.NotNil(t, oldLw)
+
+	entries, index, hw, err := c.snapshotCandidate(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
+	require.NoError(t, err)
+	require.NoError(t, c.replay(watchCtx, kw, entries, index))
+
+	lw := &liveWatcher{kw: kw, ctx: watchCtx, cancel: cancel, done: make(chan struct{})}
+	c.installSync(lw, entries, index, oldLw)
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.Equal(t, []string{"i-seed"}, idsOf(list),
+		"a delete landing after a periodic resync's snapshot but before the new watcher opened must not be overwritten by the snapshot's stale copy")
+}
+
+// --- Lifecycle ---------------------------------------------------------------
 
 func TestPeriodicResync_FailureLeavesLiveWatcherAndMapServing(t *testing.T) {
 	c, kv, conn := newTestCache(t)
@@ -488,7 +487,7 @@ func TestPeriodicResync_FailureLeavesLiveWatcherAndMapServing(t *testing.T) {
 		require.Len(t, list, 1)
 		require.Equal(t, "i-1", list[0].ID)
 		require.Equal(t, baseline, conn.nc.NumSubscriptions(),
-			"a periodic resync tees the live watcher rather than opening a new one")
+			"a failed periodic resync must not leave a stray subscription behind")
 	}
 }
 
@@ -536,50 +535,7 @@ func TestPeriodicResync_FailureLosesNothing(t *testing.T) {
 	})
 }
 
-func TestPeriodicResync_OverflowLosesNothing(t *testing.T) {
-	c, kv, _ := newTestCache(t, func(cfg *Config) { cfg.MaxBufferedEvents = 2 })
-	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
-
-	ctx := t.Context()
-	go c.Run(ctx)
-	waitForReady(t, c)
-	waitForListLen(t, c, acctA, 1)
-
-	lw := c.getActive()
-	require.NotNil(t, lw)
-	lw.mu.Lock()
-	lw.mode = modeTee
-	lw.buf = nil
-	lw.bufErr = nil
-	lw.mu.Unlock()
-
-	// Three events against a cap of two: the third overflows the buffer, but
-	// the tee still applies every one of them to the live map directly.
-	for i := range 3 {
-		id := fmt.Sprintf("i-x%d", i)
-		c.handleEntry(lw, putEntry(t, id, testRecord(id, acctA, vm.StateRunning), uint64(100+i)))
-	}
-	lw.mu.Lock()
-	bufErr := lw.bufErr
-	lw.mu.Unlock()
-	require.ErrorIs(t, bufErr, errBufferOverflow)
-
-	_, _, _, err := c.snapshotCandidate(ctx)
-	require.NoError(t, err)
-	// The candidate is discarded on overflow; goLive resets the watcher for
-	// normal live service without installing it.
-	c.goLive(lw)
-
-	list, ready := c.List(ctx, acctA)
-	require.True(t, ready)
-	ids := idsOf(list)
-	require.Contains(t, ids, "i-seed")
-	for i := range 3 {
-		require.Contains(t, ids, fmt.Sprintf("i-x%d", i))
-	}
-}
-
-func TestPeriodicResync_TwentyConsecutiveSuccessesOneWatcher(t *testing.T) {
+func TestPeriodicResync_TwentyConsecutiveSuccessesOneWatcherEach(t *testing.T) {
 	c, kv, conn := newTestCache(t)
 	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
 
@@ -588,44 +544,23 @@ func TestPeriodicResync_TwentyConsecutiveSuccessesOneWatcher(t *testing.T) {
 	waitForReady(t, c)
 	waitForListLen(t, c, acctA, 1)
 
-	initial := c.getActive()
 	baseline := conn.nc.NumSubscriptions()
 
+	// Each periodic resync opens a fresh watcher and retires the last one, so
+	// the subscription count stays flat even though the watcher identity
+	// changes every time.
+	prev := c.getActive()
 	for range 20 {
 		c.periodicResync(ctx)
 		require.Equal(t, baseline, conn.nc.NumSubscriptions())
-		require.Same(t, initial, c.getActive(), "the subscription must be the same one throughout")
+		cur := c.getActive()
+		require.NotSame(t, prev, cur, "each successful periodic resync installs a new watcher")
+		prev = cur
 	}
 
-	// Land an update precisely during a swap: after the snapshot is taken but
-	// before the candidate is installed and the watcher goes back live.
-	lw := c.getActive()
-	lw.mu.Lock()
-	lw.mode = modeTee
-	lw.buf = nil
-	lw.bufErr = nil
-	lw.mu.Unlock()
-
-	entries, index, hw, err := c.snapshotCandidate(ctx)
-	require.NoError(t, err)
-
-	updated := putEntry(t, "i-seed", testRecord("i-seed", acctA, vm.StateStopped), hw+1)
-	c.handleEntry(lw, updated)
-
-	lw.mu.Lock()
-	buf, bufErr := lw.buf, lw.bufErr
-	lw.mu.Unlock()
-	require.NoError(t, bufErr)
-	c.drainBuffered(entries, index, buf, hw)
-
-	c.mu.Lock()
-	c.entries, c.index = entries, index
-	c.mu.Unlock()
-	c.goLive(lw)
-
-	list, _ := c.List(ctx, acctA)
-	require.Len(t, list, 1, "the update must appear exactly once")
-	require.Equal(t, vm.StateStopped, list[0].Status)
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.Equal(t, []string{"i-seed"}, idsOf(list))
 }
 
 func TestReplaceWatcher_OldStoppedAndJoinedBeforeNewGoesLive(t *testing.T) {
@@ -667,101 +602,6 @@ func TestReplaceWatcher_OldStoppedAndJoinedBeforeNewGoesLive(t *testing.T) {
 
 	putRecord(t, kv, "i-2", testRecord("i-2", acctA, vm.StateRunning))
 	waitForListLen(t, c, acctA, 2)
-}
-
-// The four tests below drive the real freshSync/periodicResync code paths
-// end to end, landing a write via postSnapshotHook in the exact window D2a
-// exists to cover: after Snapshot has already read the record space, before
-// the buffer it fences against is drained. They call drainBuffered nowhere
-// themselves; unlike the direct-call fence tests above, they fail if the
-// watcher is not already buffering by the time the snapshot completes. A
-// short sleep inside the hook gives the already-open, already-subscribed
-// watcher time to receive and process the write before the sync continues,
-// so the event deterministically lands inside the window rather than racing
-// to land there.
-
-func TestFence_PutDuringInitialSnapshot_SurvivesInstall(t *testing.T) {
-	c, kv, _ := newTestCache(t)
-	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
-
-	c.postSnapshotHook = func() {
-		putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	lw := c.freshSync(context.Background())
-	require.NotNil(t, lw)
-	t.Cleanup(func() { c.discardWatcher(lw) })
-
-	list, ready := c.List(context.Background(), acctA)
-	require.True(t, ready)
-	require.ElementsMatch(t, []string{"i-seed", "i-new"}, idsOf(list),
-		"a put landing during the initial snapshot must survive into the installed candidate")
-}
-
-func TestFence_DeleteDuringInitialSnapshot_RemovedFromInstall(t *testing.T) {
-	c, kv, _ := newTestCache(t)
-	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
-	putRecord(t, kv, "i-doomed", testRecord("i-doomed", acctA, vm.StateRunning))
-
-	c.postSnapshotHook = func() {
-		require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	lw := c.freshSync(context.Background())
-	require.NotNil(t, lw)
-	t.Cleanup(func() { c.discardWatcher(lw) })
-
-	list, ready := c.List(context.Background(), acctA)
-	require.True(t, ready)
-	require.Equal(t, []string{"i-seed"}, idsOf(list),
-		"a delete landing during the initial snapshot must not be overwritten by the snapshot's stale copy")
-}
-
-func TestFence_PutDuringPeriodicResync_SurvivesInstall(t *testing.T) {
-	c, kv, _ := newTestCache(t)
-	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
-
-	ctx := t.Context()
-	go c.Run(ctx)
-	waitForReady(t, c)
-	waitForListLen(t, c, acctA, 1)
-
-	c.postSnapshotHook = func() {
-		putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
-		time.Sleep(100 * time.Millisecond)
-	}
-	c.periodicResync(ctx)
-	c.postSnapshotHook = nil
-
-	list, ready := c.List(ctx, acctA)
-	require.True(t, ready)
-	require.ElementsMatch(t, []string{"i-seed", "i-new"}, idsOf(list),
-		"a put landing during a periodic resync's snapshot must survive into the installed candidate")
-}
-
-func TestFence_DeleteDuringPeriodicResync_RemovedFromInstall(t *testing.T) {
-	c, kv, _ := newTestCache(t)
-	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
-	putRecord(t, kv, "i-doomed", testRecord("i-doomed", acctA, vm.StateRunning))
-
-	ctx := t.Context()
-	go c.Run(ctx)
-	waitForReady(t, c)
-	waitForListLen(t, c, acctA, 2)
-
-	c.postSnapshotHook = func() {
-		require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
-		time.Sleep(100 * time.Millisecond)
-	}
-	c.periodicResync(ctx)
-	c.postSnapshotHook = nil
-
-	list, ready := c.List(ctx, acctA)
-	require.True(t, ready)
-	require.Equal(t, []string{"i-seed"}, idsOf(list),
-		"a delete landing during a periodic resync's snapshot must not be overwritten by the snapshot's stale copy")
 }
 
 // --- The account index ------------------------------------------------------

--- a/spinifex/instancecache/cache_test.go
+++ b/spinifex/instancecache/cache_test.go
@@ -1,0 +1,708 @@
+// internal mode, buffer and subscription state directly (there is no
+// exported surface for "one live watcher" or "buffer returned to its
+// starting size"), and the account-index defence-in-depth test deliberately
+// mis-files a record by writing straight into the unexported maps.
+//
+//test:in-package — the fencing and lifecycle tests assert on the watcher's
+package instancecache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/resource"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+const (
+	testPrefix = "i."
+	acctA      = "111122223333"
+	acctB      = "444455556666"
+)
+
+// newTestCache starts an embedded JetStream server, opens a KV bucket for it
+// and returns a Cache over that bucket plus the raw handles a test needs to
+// drive the underlying key space directly.
+func newTestCache(t *testing.T, mutate ...func(*Config)) (*Cache, jetstream.KeyValue, *cacheConn) {
+	t.Helper()
+	_, nc, js := testutil.StartTestJetStream(t)
+
+	bucket := fmt.Sprintf("instances-%d", time.Now().UnixNano())
+	kv, err := js.CreateKeyValue(context.Background(), jetstream.KeyValueConfig{Bucket: bucket, History: 1})
+	require.NoError(t, err)
+
+	cfg := Config{
+		Bucket:        kvstore.Config{Name: bucket, History: 1, Replicas: 1},
+		Prefix:        testPrefix,
+		RetryInterval: 20 * time.Millisecond,
+	}
+	for _, m := range mutate {
+		m(&cfg)
+	}
+	return New(js, cfg), kv, &cacheConn{nc: nc, js: js}
+}
+
+// cacheConn bundles the connection handles a test occasionally needs beyond
+// the Cache and its bucket, named to avoid importing nats.go just for a type.
+type cacheConn struct {
+	nc interface{ NumSubscriptions() int }
+	js jetstream.JetStream
+}
+
+func testRecord(id, accountID string, state vm.InstanceState) *vm.InstanceRecord {
+	return &vm.InstanceRecord{
+		Metadata: resource.Metadata{Name: id, AccountID: accountID},
+		Spec:     vm.InstanceSpec{InstanceType: "m7i.large"},
+		Status:   vm.InstanceStatus{Status: state, LastNode: "node-1"},
+	}
+}
+
+func putRecord(t *testing.T, kv jetstream.KeyValue, id string, rec *vm.InstanceRecord) uint64 {
+	t.Helper()
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+	rev, err := kv.Put(context.Background(), testPrefix+id, data)
+	require.NoError(t, err)
+	return rev
+}
+
+func putGarbage(t *testing.T, kv jetstream.KeyValue, id string) uint64 {
+	t.Helper()
+	rev, err := kv.Put(context.Background(), testPrefix+id, []byte("not-json"))
+	require.NoError(t, err)
+	return rev
+}
+
+func idsOf(list []*vm.VM) []string {
+	out := make([]string, len(list))
+	for i, v := range list {
+		out[i] = v.ID
+	}
+	return out
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("condition not met within %s", timeout)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func waitForReady(t *testing.T, c *Cache) {
+	t.Helper()
+	waitFor(t, 2*time.Second, c.Ready)
+}
+
+func waitForListLen(t *testing.T, c *Cache, accountID string, n int) []*vm.VM {
+	t.Helper()
+	var list []*vm.VM
+	waitFor(t, 2*time.Second, func() bool {
+		list, _ = c.List(context.Background(), accountID)
+		return len(list) == n
+	})
+	return list
+}
+
+// fakeEntry is a minimal jetstream.KeyValueEntry for exercising the fencing
+// logic directly, without a real watcher's timing involved.
+type fakeEntry struct {
+	key   string
+	value []byte
+	rev   uint64
+	op    jetstream.KeyValueOp
+}
+
+func (f fakeEntry) Bucket() string                  { return "test" }
+func (f fakeEntry) Key() string                     { return f.key }
+func (f fakeEntry) Value() []byte                   { return f.value }
+func (f fakeEntry) Revision() uint64                { return f.rev }
+func (f fakeEntry) Created() time.Time              { return time.Time{} }
+func (f fakeEntry) Delta() uint64                   { return 0 }
+func (f fakeEntry) Operation() jetstream.KeyValueOp { return f.op }
+
+var _ jetstream.KeyValueEntry = fakeEntry{}
+
+func putEntry(t *testing.T, id string, rec *vm.InstanceRecord, rev uint64) fakeEntry {
+	t.Helper()
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+	return fakeEntry{key: testPrefix + id, value: data, rev: rev, op: jetstream.KeyValuePut}
+}
+
+func deleteEntry(id string, rev uint64) fakeEntry {
+	return fakeEntry{key: testPrefix + id, rev: rev, op: jetstream.KeyValueDelete}
+}
+
+// Process-wide manual metric reader, installed once per test binary so the
+// resync-failure and decode-failure counters can be observed. Cumulative for
+// the life of the binary, so tests read a before/after delta.
+var (
+	metricsReaderOnce sync.Once
+	metricsReader     *sdkmetric.ManualReader
+)
+
+func installMetricsReader(t *testing.T) {
+	t.Helper()
+	metricsReaderOnce.Do(func() {
+		metricsReader = sdkmetric.NewManualReader()
+		otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricsReader)))
+	})
+}
+
+func counterSum(t *testing.T, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, metricsReader.Collect(context.Background(), &rm))
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+		}
+	}
+	return total
+}
+
+// --- Unit, in instancecache ------------------------------------------------
+
+func TestList_PutAppearsAfterWatchDelivers(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+
+	list := waitForListLen(t, c, acctA, 1)
+	require.Equal(t, "i-1", list[0].ID)
+}
+
+func TestList_DeleteAndPurgeRemove(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+	putRecord(t, kv, "i-2", testRecord("i-2", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 2)
+
+	require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-1"))
+	list := waitForListLen(t, c, acctA, 1)
+	require.Equal(t, "i-2", list[0].ID)
+
+	require.NoError(t, kv.Purge(context.Background(), testPrefix+"i-2"))
+	waitForListLen(t, c, acctA, 0)
+}
+
+func TestPeriodicResync_RemovesEntryTheWatchNeverToldItAbout(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-real", testRecord("i-real", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	// Simulate exactly what a per-key queue cannot cover: a key is gone from
+	// the record space, but nothing was watching when it went, so the live
+	// map still shows it.
+	c.mu.Lock()
+	putInto(c.entries, c.index, "i-ghost", vm.VMFromRecord(testRecord("i-ghost", acctA, vm.StateRunning)))
+	c.mu.Unlock()
+	waitForListLen(t, c, acctA, 2)
+
+	c.periodicResync(ctx)
+
+	list := waitForListLen(t, c, acctA, 1)
+	require.Equal(t, "i-real", list[0].ID)
+}
+
+func TestFreshSync_LeaksNothingOnRepeatedFailure(t *testing.T) {
+	c, kv, conn := newTestCache(t)
+	putGarbage(t, kv, "i-bad")
+
+	ctx := context.Background()
+	baseline := conn.nc.NumSubscriptions()
+
+	for range 10 {
+		lw := c.openWatcher(ctx)
+		require.NotNil(t, lw)
+		_, _, _, err := c.snapshotCandidate(ctx)
+		require.Error(t, err)
+		c.discardWatcher(lw)
+		require.Equal(t, baseline, conn.nc.NumSubscriptions())
+	}
+	require.False(t, c.Ready())
+}
+
+func TestFreshSync_BufferOverflowFailsSync(t *testing.T) {
+	c, _, conn := newTestCache(t, func(cfg *Config) { cfg.MaxBufferedEvents = 1 })
+	ctx := context.Background()
+	baseline := conn.nc.NumSubscriptions()
+
+	lw := c.openWatcher(ctx)
+	require.NotNil(t, lw)
+
+	c.handleEntry(lw, putEntry(t, "i-1", testRecord("i-1", acctA, vm.StateRunning), 1))
+	c.handleEntry(lw, putEntry(t, "i-2", testRecord("i-2", acctA, vm.StateRunning), 2))
+
+	lw.mu.Lock()
+	bufErr := lw.bufErr
+	lw.mu.Unlock()
+	require.ErrorIs(t, bufErr, errBufferOverflow)
+
+	c.discardWatcher(lw)
+	require.Equal(t, baseline, conn.nc.NumSubscriptions())
+	require.False(t, c.Ready())
+}
+
+func TestPeriodicResync_TTLExpiredRecordRemovedWithNoWatchEvent(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	bucket := fmt.Sprintf("instances-ttl-%d", time.Now().UnixNano())
+	kv, err := js.CreateKeyValue(context.Background(),
+		jetstream.KeyValueConfig{Bucket: bucket, History: 1, TTL: 200 * time.Millisecond})
+	require.NoError(t, err)
+
+	c := New(js, Config{
+		Bucket:        kvstore.Config{Name: bucket, History: 1, Replicas: 1},
+		Prefix:        testPrefix,
+		RetryInterval: 20 * time.Millisecond,
+	})
+	putRecord(t, kv, "i-ttl", testRecord("i-ttl", acctA, vm.StateTerminated))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	time.Sleep(500 * time.Millisecond) // past the bucket TTL; no delete event is ever delivered
+
+	c.mu.RLock()
+	_, stillThere := c.entries["i-ttl"]
+	c.mu.RUnlock()
+	require.True(t, stillThere, "the watch alone must not have removed a TTL-expired key")
+
+	c.periodicResync(ctx)
+	waitForListLen(t, c, acctA, 0)
+}
+
+func TestPeriodicResync_UndecodableRecordMarksDegraded(t *testing.T) {
+	installMetricsReader(t)
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	before := counterSum(t, "mulga.instancecache.resync_failures")
+	beforeAge, hadAge := c.resyncAge()
+	require.True(t, hadAge)
+
+	putGarbage(t, kv, "i-bad")
+	time.Sleep(50 * time.Millisecond)
+
+	c.periodicResync(ctx)
+
+	require.Equal(t, before+1, counterSum(t, "mulga.instancecache.resync_failures"))
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.Len(t, list, 1)
+	require.Equal(t, "i-1", list[0].ID)
+
+	afterAge, hadAge2 := c.resyncAge()
+	require.True(t, hadAge2)
+	require.GreaterOrEqual(t, afterAge, beforeAge, "a failed resync must not refresh the last-successful-resync mark")
+}
+
+func TestWatch_UndecodableUpdateLeavesExistingEntry(t *testing.T) {
+	installMetricsReader(t)
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	before := counterSum(t, "mulga.instancecache.decode_failures")
+	putGarbage(t, kv, "i-1")
+	waitFor(t, 2*time.Second, func() bool {
+		return counterSum(t, "mulga.instancecache.decode_failures") > before
+	})
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.Len(t, list, 1)
+	require.Equal(t, vm.StateRunning, list[0].Status,
+		"an undecodable watch update must not remove or corrupt the existing entry")
+}
+
+func TestList_NotReadyBeforeFirstSync(t *testing.T) {
+	c, _, _ := newTestCache(t)
+	list, ready := c.List(context.Background(), acctA)
+	require.False(t, ready)
+	require.Empty(t, list)
+}
+
+// --- Fencing, the D2a algorithm --------------------------------------------
+
+func TestFence_BufferedEventAtOrBelowHighWaterDiscarded(t *testing.T) {
+	c, _, _ := newTestCache(t)
+	entries := map[string]*vm.VM{}
+	index := map[string]map[string]struct{}{}
+	putInto(entries, index, "i-x", vm.VMFromRecord(testRecord("i-x", acctA, vm.StateRunning)))
+
+	buf := []jetstream.KeyValueEntry{putEntry(t, "i-x", testRecord("i-x", acctA, vm.StateStopped), 5)}
+	c.drainBuffered(entries, index, buf, 5)
+
+	require.Equal(t, vm.StateRunning, entries["i-x"].Status,
+		"a buffered event at highWater must not overwrite what the snapshot already reflects")
+}
+
+func TestFence_PutAboveHighWaterIsPresentAfterwards(t *testing.T) {
+	c, _, _ := newTestCache(t)
+	entries := map[string]*vm.VM{}
+	index := map[string]map[string]struct{}{}
+
+	buf := []jetstream.KeyValueEntry{putEntry(t, "i-y", testRecord("i-y", acctA, vm.StateRunning), 6)}
+	c.drainBuffered(entries, index, buf, 5)
+
+	v, ok := entries["i-y"]
+	require.True(t, ok)
+	require.Equal(t, vm.StateRunning, v.Status)
+	require.Contains(t, index[acctA], "i-y")
+}
+
+func TestFence_DeleteAboveHighWaterIsAbsentAfterwards(t *testing.T) {
+	c, _, _ := newTestCache(t)
+	entries := map[string]*vm.VM{}
+	index := map[string]map[string]struct{}{}
+	putInto(entries, index, "i-z", vm.VMFromRecord(testRecord("i-z", acctA, vm.StateRunning)))
+
+	buf := []jetstream.KeyValueEntry{deleteEntry("i-z", 6)}
+	c.drainBuffered(entries, index, buf, 5)
+
+	_, ok := entries["i-z"]
+	require.False(t, ok, "a delete above highWater must remove the snapshot's stale copy")
+	require.NotContains(t, index[acctA], "i-z")
+}
+
+func TestFreshSync_NotReadyUntilBufferDrained(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+	ctx := context.Background()
+
+	lw := c.openWatcher(ctx)
+	require.NotNil(t, lw)
+	require.False(t, c.Ready(), "opening the watcher alone must not mark the cache ready")
+
+	entries, index, hw, err := c.snapshotCandidate(ctx)
+	require.NoError(t, err)
+	require.False(t, c.Ready(), "taking the snapshot alone must not mark the cache ready")
+
+	lw.mu.Lock()
+	buf, bufErr := lw.buf, lw.bufErr
+	lw.mu.Unlock()
+	require.NoError(t, bufErr)
+	c.drainBuffered(entries, index, buf, hw)
+	require.False(t, c.Ready(), "draining the buffer into a candidate must not itself mark ready")
+
+	c.mu.Lock()
+	c.entries, c.index = entries, index
+	c.ready = true
+	c.mu.Unlock()
+	require.True(t, c.Ready())
+
+	c.discardWatcher(lw)
+}
+
+func TestPeriodicResync_FailureLeavesLiveWatcherAndMapServing(t *testing.T) {
+	c, kv, conn := newTestCache(t)
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	baseline := conn.nc.NumSubscriptions()
+	putGarbage(t, kv, "i-bad")
+
+	for range 10 {
+		c.periodicResync(ctx)
+		list, ready := c.List(ctx, acctA)
+		require.True(t, ready)
+		require.Len(t, list, 1)
+		require.Equal(t, "i-1", list[0].ID)
+		require.Equal(t, baseline, conn.nc.NumSubscriptions(),
+			"a periodic resync tees the live watcher rather than opening a new one")
+	}
+}
+
+func TestPeriodicResync_FailureLosesNothing(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	putGarbage(t, kv, "i-bad") // every future resync now fails against the same bad key
+
+	for i := range 10 {
+		id := fmt.Sprintf("i-live-%d", i)
+		putRecord(t, kv, id, testRecord(id, acctA, vm.StateRunning))
+		waitFor(t, 2*time.Second, func() bool {
+			list, _ := c.List(ctx, acctA)
+			for _, v := range list {
+				if v.ID == id {
+					return true
+				}
+			}
+			return false
+		})
+
+		c.periodicResync(ctx)
+
+		list, ready := c.List(ctx, acctA)
+		require.True(t, ready)
+		require.Contains(t, idsOf(list), id)
+		require.Contains(t, idsOf(list), "i-seed")
+	}
+
+	require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-seed"))
+	waitFor(t, 2*time.Second, func() bool {
+		list, _ := c.List(ctx, acctA)
+		for _, v := range list {
+			if v.ID == "i-seed" {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func TestPeriodicResync_OverflowLosesNothing(t *testing.T) {
+	c, kv, _ := newTestCache(t, func(cfg *Config) { cfg.MaxBufferedEvents = 2 })
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	lw := c.getActive()
+	require.NotNil(t, lw)
+	lw.mu.Lock()
+	lw.mode = modeTee
+	lw.buf = nil
+	lw.bufErr = nil
+	lw.mu.Unlock()
+
+	// Three events against a cap of two: the third overflows the buffer, but
+	// the tee still applies every one of them to the live map directly.
+	for i := range 3 {
+		id := fmt.Sprintf("i-x%d", i)
+		c.handleEntry(lw, putEntry(t, id, testRecord(id, acctA, vm.StateRunning), uint64(100+i)))
+	}
+	lw.mu.Lock()
+	bufErr := lw.bufErr
+	lw.mu.Unlock()
+	require.ErrorIs(t, bufErr, errBufferOverflow)
+
+	_, _, _, err := c.snapshotCandidate(ctx)
+	require.NoError(t, err)
+	// The candidate is discarded on overflow; goLive resets the watcher for
+	// normal live service without installing it.
+	c.goLive(lw)
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	ids := idsOf(list)
+	require.Contains(t, ids, "i-seed")
+	for i := range 3 {
+		require.Contains(t, ids, fmt.Sprintf("i-x%d", i))
+	}
+}
+
+func TestPeriodicResync_TwentyConsecutiveSuccessesOneWatcher(t *testing.T) {
+	c, kv, conn := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	initial := c.getActive()
+	baseline := conn.nc.NumSubscriptions()
+
+	for range 20 {
+		c.periodicResync(ctx)
+		require.Equal(t, baseline, conn.nc.NumSubscriptions())
+		require.Same(t, initial, c.getActive(), "the subscription must be the same one throughout")
+	}
+
+	// Land an update precisely during a swap: after the snapshot is taken but
+	// before the candidate is installed and the watcher goes back live.
+	lw := c.getActive()
+	lw.mu.Lock()
+	lw.mode = modeTee
+	lw.buf = nil
+	lw.bufErr = nil
+	lw.mu.Unlock()
+
+	entries, index, hw, err := c.snapshotCandidate(ctx)
+	require.NoError(t, err)
+
+	updated := putEntry(t, "i-seed", testRecord("i-seed", acctA, vm.StateStopped), hw+1)
+	c.handleEntry(lw, updated)
+
+	lw.mu.Lock()
+	buf, bufErr := lw.buf, lw.bufErr
+	lw.mu.Unlock()
+	require.NoError(t, bufErr)
+	c.drainBuffered(entries, index, buf, hw)
+
+	c.mu.Lock()
+	c.entries, c.index = entries, index
+	c.mu.Unlock()
+	c.goLive(lw)
+
+	list, _ := c.List(ctx, acctA)
+	require.Len(t, list, 1, "the update must appear exactly once")
+	require.Equal(t, vm.StateStopped, list[0].Status)
+}
+
+func TestReplaceWatcher_OldStoppedAndJoinedBeforeNewGoesLive(t *testing.T) {
+	c, kv, conn := newTestCache(t)
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	oldLw := c.getActive()
+	baseline := conn.nc.NumSubscriptions()
+
+	require.NoError(t, oldLw.kw.Stop()) // simulate the connection dropping this watcher
+
+	waitFor(t, 2*time.Second, func() bool {
+		select {
+		case <-oldLw.done:
+		default:
+			return false
+		}
+		next := c.getActive()
+		return next != nil && next != oldLw
+	})
+
+	select {
+	case <-oldLw.done:
+	default:
+		t.Fatal("old watcher must be joined once replacement completes")
+	}
+
+	waitFor(t, 2*time.Second, func() bool { return conn.nc.NumSubscriptions() == baseline })
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.Len(t, list, 1)
+	require.Equal(t, "i-1", list[0].ID)
+
+	putRecord(t, kv, "i-2", testRecord("i-2", acctA, vm.StateRunning))
+	waitForListLen(t, c, acctA, 2)
+}
+
+// --- The account index ------------------------------------------------------
+
+func TestList_ReturnsOnlyThatAccountsInstances(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-a", testRecord("i-a", acctA, vm.StateRunning))
+	putRecord(t, kv, "i-b", testRecord("i-b", acctB, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+	waitForListLen(t, c, acctB, 1)
+
+	listA, _ := c.List(ctx, acctA)
+	require.Equal(t, []string{"i-a"}, idsOf(listA))
+
+	listB, _ := c.List(ctx, acctB)
+	require.Equal(t, []string{"i-b"}, idsOf(listB))
+}
+
+func TestList_GlobalDoesNotSeeOtherAccountsInstances(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-cust", testRecord("i-cust", acctA, vm.StateRunning))
+	putRecord(t, kv, "i-global", testRecord("i-global", utils.GlobalAccountID, vm.StateRunning))
+	putRecord(t, kv, "i-legacy", testRecord("i-legacy", "", vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitFor(t, 2*time.Second, func() bool {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		return len(c.entries) == 3
+	})
+
+	listGlobal, ready := c.List(ctx, utils.GlobalAccountID)
+	require.True(t, ready)
+	require.ElementsMatch(t, []string{"i-global", "i-legacy"}, idsOf(listGlobal))
+
+	listCust, _ := c.List(ctx, acctA)
+	require.Equal(t, []string{"i-cust"}, idsOf(listCust))
+}
+
+func TestList_VisibilityAppliedAfterIndexLookup(t *testing.T) {
+	c, _, _ := newTestCache(t)
+
+	// Deliberately mis-file: the index says i-misfiled belongs to acctA, but
+	// the record itself is owned by acctB. IsInstanceVisibleToCaller must
+	// still reject it at the List seam.
+	c.mu.Lock()
+	c.entries["i-misfiled"] = vm.VMFromRecord(testRecord("i-misfiled", acctB, vm.StateRunning))
+	addToIndex(c.index, acctA, "i-misfiled")
+	c.ready = true
+	c.mu.Unlock()
+
+	list, ready := c.List(context.Background(), acctA)
+	require.True(t, ready)
+	require.Empty(t, list)
+}

--- a/spinifex/instancecache/cache_test.go
+++ b/spinifex/instancecache/cache_test.go
@@ -350,31 +350,29 @@ func TestList_NotReadyBeforeFirstSync(t *testing.T) {
 
 // --- Fencing: replay closes the snapshot-to-watch window --------------------
 //
-// Each test lands a write in the exact window the fence has to cover: after
-// Snapshot has already read the record space, before the new watcher (which
-// resumes from the snapshot's high-water mark) is opened. There is no
-// buffering machinery to race against any more, so the write happens as an
-// ordinary step between two ordinary calls.
+// The window the fence has to cover — after Snapshot has already read the
+// record space, before the resuming watcher opens — is internal to syncOnce,
+// so postSnapshotHook is the seam that lands a write inside it. Each test
+// drives the real production path (syncOnce/installSync or periodicResync)
+// rather than reimplementing the window's steps itself, so a wrong revision
+// or a dropped WatchFrom call in production is what these catch, not
+// whatever a test independently recomputes.
 
 func TestFence_PutDuringInitialSnapshot_SurvivesInstall(t *testing.T) {
 	c, kv, _ := newTestCache(t)
 	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
 
-	entries, index, hw, err := c.snapshotCandidate(context.Background())
+	c.postSnapshotHook = func() {
+		putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
+	}
+
+	lw, entries, index, err := c.syncOnce(context.Background())
 	require.NoError(t, err)
+	c.installSync(lw, entries, index, nil)
 
-	putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
-
-	watchCtx := t.Context()
-	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
-	require.NoError(t, err)
-	defer func() { _ = kw.Stop() }()
-
-	require.NoError(t, c.replay(watchCtx, kw, entries, index))
-
-	require.Len(t, entries, 2)
-	require.Contains(t, entries, "i-seed")
-	require.Contains(t, entries, "i-new",
+	list, ready := c.List(context.Background(), acctA)
+	require.True(t, ready)
+	require.ElementsMatch(t, []string{"i-seed", "i-new"}, idsOf(list),
 		"a put landing after the snapshot but before the watcher opened must be replayed")
 }
 
@@ -383,24 +381,18 @@ func TestFence_DeleteDuringInitialSnapshot_RemovedFromInstall(t *testing.T) {
 	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
 	putRecord(t, kv, "i-doomed", testRecord("i-doomed", acctA, vm.StateRunning))
 
-	entries, index, hw, err := c.snapshotCandidate(context.Background())
+	c.postSnapshotHook = func() {
+		require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
+	}
+
+	lw, entries, index, err := c.syncOnce(context.Background())
 	require.NoError(t, err)
-	require.Len(t, entries, 2)
+	c.installSync(lw, entries, index, nil)
 
-	require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
-
-	watchCtx := t.Context()
-	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
-	require.NoError(t, err)
-	defer func() { _ = kw.Stop() }()
-
-	require.NoError(t, c.replay(watchCtx, kw, entries, index))
-
-	require.Len(t, entries, 1)
-	require.Contains(t, entries, "i-seed")
-	require.NotContains(t, entries, "i-doomed",
+	list, ready := c.List(context.Background(), acctA)
+	require.True(t, ready)
+	require.Equal(t, []string{"i-seed"}, idsOf(list),
 		"a delete landing after the snapshot but before the watcher opened must not survive as the snapshot's stale copy")
-	require.NotContains(t, index[acctA], "i-doomed")
 }
 
 func TestFence_PutDuringPeriodicResync_SurvivesInstall(t *testing.T) {
@@ -412,21 +404,11 @@ func TestFence_PutDuringPeriodicResync_SurvivesInstall(t *testing.T) {
 	waitForReady(t, c)
 	waitForListLen(t, c, acctA, 1)
 
-	oldLw := c.getActive()
-	require.NotNil(t, oldLw)
-
-	entries, index, hw, err := c.snapshotCandidate(ctx)
-	require.NoError(t, err)
-
-	putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
-
-	watchCtx, cancel := context.WithCancel(ctx)
-	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
-	require.NoError(t, err)
-	require.NoError(t, c.replay(watchCtx, kw, entries, index))
-
-	lw := &liveWatcher{kw: kw, ctx: watchCtx, cancel: cancel, done: make(chan struct{})}
-	c.installSync(lw, entries, index, oldLw)
+	c.postSnapshotHook = func() {
+		putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
+	}
+	c.periodicResync(ctx)
+	c.postSnapshotHook = nil
 
 	list, ready := c.List(ctx, acctA)
 	require.True(t, ready)
@@ -444,21 +426,11 @@ func TestFence_DeleteDuringPeriodicResync_RemovedFromInstall(t *testing.T) {
 	waitForReady(t, c)
 	waitForListLen(t, c, acctA, 2)
 
-	oldLw := c.getActive()
-	require.NotNil(t, oldLw)
-
-	entries, index, hw, err := c.snapshotCandidate(ctx)
-	require.NoError(t, err)
-
-	require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
-
-	watchCtx, cancel := context.WithCancel(ctx)
-	kw, err := c.store.WatchFrom(watchCtx, c.filter, hw+1)
-	require.NoError(t, err)
-	require.NoError(t, c.replay(watchCtx, kw, entries, index))
-
-	lw := &liveWatcher{kw: kw, ctx: watchCtx, cancel: cancel, done: make(chan struct{})}
-	c.installSync(lw, entries, index, oldLw)
+	c.postSnapshotHook = func() {
+		require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
+	}
+	c.periodicResync(ctx)
+	c.postSnapshotHook = nil
 
 	list, ready := c.List(ctx, acctA)
 	require.True(t, ready)

--- a/spinifex/instancecache/cache_test.go
+++ b/spinifex/instancecache/cache_test.go
@@ -334,6 +334,7 @@ func TestPeriodicResync_UndecodableRecordMarksDegraded(t *testing.T) {
 	c.periodicResync(ctx)
 
 	require.Equal(t, before+1, counterSum(t, "mulga.instancecache.resync_failures"))
+	require.True(t, c.Degraded(), "a failed resync must mark the cache degraded")
 
 	list, ready := c.List(ctx, acctA)
 	require.True(t, ready)
@@ -343,6 +344,27 @@ func TestPeriodicResync_UndecodableRecordMarksDegraded(t *testing.T) {
 	afterAge, hadAge2 := c.resyncAge()
 	require.True(t, hadAge2)
 	require.GreaterOrEqual(t, afterAge, beforeAge, "a failed resync must not refresh the last-successful-resync mark")
+}
+
+func TestDegraded_ClearedByNextSuccessfulResync(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-1", testRecord("i-1", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+	require.False(t, c.Degraded(), "a cache that has never failed a sync must not report degraded")
+
+	putGarbage(t, kv, "i-bad")
+	time.Sleep(50 * time.Millisecond)
+	c.periodicResync(ctx)
+	require.True(t, c.Degraded())
+
+	require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-bad"))
+	time.Sleep(50 * time.Millisecond)
+	c.periodicResync(ctx)
+	require.False(t, c.Degraded(), "the next successful resync must clear degraded")
 }
 
 func TestWatch_UndecodableUpdateLeavesExistingEntry(t *testing.T) {
@@ -645,6 +667,101 @@ func TestReplaceWatcher_OldStoppedAndJoinedBeforeNewGoesLive(t *testing.T) {
 
 	putRecord(t, kv, "i-2", testRecord("i-2", acctA, vm.StateRunning))
 	waitForListLen(t, c, acctA, 2)
+}
+
+// The four tests below drive the real freshSync/periodicResync code paths
+// end to end, landing a write via postSnapshotHook in the exact window D2a
+// exists to cover: after Snapshot has already read the record space, before
+// the buffer it fences against is drained. They call drainBuffered nowhere
+// themselves; unlike the direct-call fence tests above, they fail if the
+// watcher is not already buffering by the time the snapshot completes. A
+// short sleep inside the hook gives the already-open, already-subscribed
+// watcher time to receive and process the write before the sync continues,
+// so the event deterministically lands inside the window rather than racing
+// to land there.
+
+func TestFence_PutDuringInitialSnapshot_SurvivesInstall(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+
+	c.postSnapshotHook = func() {
+		putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	lw := c.freshSync(context.Background())
+	require.NotNil(t, lw)
+	t.Cleanup(func() { c.discardWatcher(lw) })
+
+	list, ready := c.List(context.Background(), acctA)
+	require.True(t, ready)
+	require.ElementsMatch(t, []string{"i-seed", "i-new"}, idsOf(list),
+		"a put landing during the initial snapshot must survive into the installed candidate")
+}
+
+func TestFence_DeleteDuringInitialSnapshot_RemovedFromInstall(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+	putRecord(t, kv, "i-doomed", testRecord("i-doomed", acctA, vm.StateRunning))
+
+	c.postSnapshotHook = func() {
+		require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	lw := c.freshSync(context.Background())
+	require.NotNil(t, lw)
+	t.Cleanup(func() { c.discardWatcher(lw) })
+
+	list, ready := c.List(context.Background(), acctA)
+	require.True(t, ready)
+	require.Equal(t, []string{"i-seed"}, idsOf(list),
+		"a delete landing during the initial snapshot must not be overwritten by the snapshot's stale copy")
+}
+
+func TestFence_PutDuringPeriodicResync_SurvivesInstall(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 1)
+
+	c.postSnapshotHook = func() {
+		putRecord(t, kv, "i-new", testRecord("i-new", acctA, vm.StateRunning))
+		time.Sleep(100 * time.Millisecond)
+	}
+	c.periodicResync(ctx)
+	c.postSnapshotHook = nil
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.ElementsMatch(t, []string{"i-seed", "i-new"}, idsOf(list),
+		"a put landing during a periodic resync's snapshot must survive into the installed candidate")
+}
+
+func TestFence_DeleteDuringPeriodicResync_RemovedFromInstall(t *testing.T) {
+	c, kv, _ := newTestCache(t)
+	putRecord(t, kv, "i-seed", testRecord("i-seed", acctA, vm.StateRunning))
+	putRecord(t, kv, "i-doomed", testRecord("i-doomed", acctA, vm.StateRunning))
+
+	ctx := t.Context()
+	go c.Run(ctx)
+	waitForReady(t, c)
+	waitForListLen(t, c, acctA, 2)
+
+	c.postSnapshotHook = func() {
+		require.NoError(t, kv.Delete(context.Background(), testPrefix+"i-doomed"))
+		time.Sleep(100 * time.Millisecond)
+	}
+	c.periodicResync(ctx)
+	c.postSnapshotHook = nil
+
+	list, ready := c.List(ctx, acctA)
+	require.True(t, ready)
+	require.Equal(t, []string{"i-seed"}, idsOf(list),
+		"a delete landing during a periodic resync's snapshot must not be overwritten by the snapshot's stale copy")
 }
 
 // --- The account index ------------------------------------------------------

--- a/spinifex/instancecache/metrics.go
+++ b/spinifex/instancecache/metrics.go
@@ -19,6 +19,7 @@ type cacheMetrics struct {
 	resyncFailures  metric.Int64Counter
 	watchReconnects metric.Int64Counter
 	decodeFailures  metric.Int64Counter
+	replayEvents    metric.Int64Counter
 }
 
 // newCacheMetrics registers c's instruments against the global meter
@@ -38,6 +39,12 @@ func newCacheMetrics(c *Cache) *cacheMetrics {
 	m.watchReconnects, err = meter.Int64Counter("mulga.instancecache.watch_reconnects",
 		metric.WithDescription("Count of times the KV watch was replaced after dying."),
 		metric.WithUnit("{reconnect}"))
+	if err != nil {
+		otel.Handle(err)
+	}
+	m.replayEvents, err = meter.Int64Counter("mulga.instancecache.replay_events",
+		metric.WithDescription("Count of records the snapshot missed and the resumed watch replayed before the cache went live."),
+		metric.WithUnit("{record}"))
 	if err != nil {
 		otel.Handle(err)
 	}
@@ -87,6 +94,16 @@ func (m *cacheMetrics) watchReconnected() {
 		return
 	}
 	m.watchReconnects.Add(context.Background(), 1)
+}
+
+// replayApplied records how many records the resumed watch had to replay.
+// A zero count is recorded too: it is the difference between a quiet cluster
+// and an instrument that never fired.
+func (m *cacheMetrics) replayApplied(n int) {
+	if m.replayEvents == nil {
+		return
+	}
+	m.replayEvents.Add(context.Background(), int64(n))
 }
 
 func (m *cacheMetrics) decodeFailure() {

--- a/spinifex/instancecache/metrics.go
+++ b/spinifex/instancecache/metrics.go
@@ -42,7 +42,7 @@ func newCacheMetrics(c *Cache) *cacheMetrics {
 		otel.Handle(err)
 	}
 	m.decodeFailures, err = meter.Int64Counter("mulga.instancecache.decode_failures",
-		metric.WithDescription("Count of instance records that failed to decode, by key."),
+		metric.WithDescription("Count of instance records that failed to decode. The offending key is logged, not attributed, to bound cardinality."),
 		metric.WithUnit("{failure}"))
 	if err != nil {
 		otel.Handle(err)
@@ -89,11 +89,10 @@ func (m *cacheMetrics) watchReconnected() {
 	m.watchReconnects.Add(context.Background(), 1)
 }
 
-func (m *cacheMetrics) decodeFailure(key string) {
+func (m *cacheMetrics) decodeFailure() {
 	if m.decodeFailures == nil {
-		slog.Warn("instancecache: decode failure counter unavailable", "key", key)
+		slog.Warn("instancecache: decode failure counter unavailable")
 		return
 	}
-	m.decodeFailures.Add(context.Background(), 1, metric.WithAttributeSet(
-		attribute.NewSet(attribute.String("key", key))))
+	m.decodeFailures.Add(context.Background(), 1)
 }

--- a/spinifex/instancecache/metrics.go
+++ b/spinifex/instancecache/metrics.go
@@ -1,0 +1,99 @@
+package instancecache
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// meterName is the instrumentation scope for every instancecache metric.
+const meterName = "github.com/mulgadc/spinifex/spinifex/instancecache"
+
+// cacheMetrics holds one Cache's instruments. Registered per instance, not as
+// a package-level singleton, because the gauges read that instance's own
+// state through a callback closure.
+type cacheMetrics struct {
+	resyncFailures  metric.Int64Counter
+	watchReconnects metric.Int64Counter
+	decodeFailures  metric.Int64Counter
+}
+
+// newCacheMetrics registers c's instruments against the global meter
+// provider. A registration failure is handled by otel.Handle and leaves the
+// affected instrument nil; every recorder below tolerates a nil instrument.
+func newCacheMetrics(c *Cache) *cacheMetrics {
+	meter := otel.Meter(meterName)
+	m := &cacheMetrics{}
+
+	var err error
+	m.resyncFailures, err = meter.Int64Counter("mulga.instancecache.resync_failures",
+		metric.WithDescription("Count of failed initial, periodic or watcher-replacement syncs."),
+		metric.WithUnit("{failure}"))
+	if err != nil {
+		otel.Handle(err)
+	}
+	m.watchReconnects, err = meter.Int64Counter("mulga.instancecache.watch_reconnects",
+		metric.WithDescription("Count of times the KV watch was replaced after dying."),
+		metric.WithUnit("{reconnect}"))
+	if err != nil {
+		otel.Handle(err)
+	}
+	m.decodeFailures, err = meter.Int64Counter("mulga.instancecache.decode_failures",
+		metric.WithDescription("Count of instance records that failed to decode, by key."),
+		metric.WithUnit("{failure}"))
+	if err != nil {
+		otel.Handle(err)
+	}
+
+	if _, err := meter.Int64ObservableGauge("mulga.instancecache.entries",
+		metric.WithDescription("Cached instance count by raw instance state."),
+		metric.WithUnit("{instance}"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			for state, n := range c.entriesByState() {
+				o.Observe(n, metric.WithAttributeSet(attribute.NewSet(attribute.String("state", state))))
+			}
+			return nil
+		})); err != nil {
+		otel.Handle(err)
+	}
+
+	if _, err := meter.Float64ObservableGauge("mulga.instancecache.resync_age_seconds",
+		metric.WithDescription("Age of the last successful resync. Absent until the first one completes."),
+		metric.WithUnit("s"),
+		metric.WithFloat64Callback(func(_ context.Context, o metric.Float64Observer) error {
+			if age, ok := c.resyncAge(); ok {
+				o.Observe(age.Seconds())
+			}
+			return nil
+		})); err != nil {
+		otel.Handle(err)
+	}
+
+	return m
+}
+
+func (m *cacheMetrics) resyncFailed() {
+	if m.resyncFailures == nil {
+		return
+	}
+	m.resyncFailures.Add(context.Background(), 1)
+}
+
+func (m *cacheMetrics) watchReconnected() {
+	if m.watchReconnects == nil {
+		return
+	}
+	m.watchReconnects.Add(context.Background(), 1)
+}
+
+func (m *cacheMetrics) decodeFailure(key string) {
+	if m.decodeFailures == nil {
+		slog.Warn("instancecache: decode failure counter unavailable", "key", key)
+		return
+	}
+	m.decodeFailures.Add(context.Background(), 1, metric.WithAttributeSet(
+		attribute.NewSet(attribute.String("key", key))))
+}

--- a/spinifex/instancecache/resume_from_revision_test.go
+++ b/spinifex/instancecache/resume_from_revision_test.go
@@ -1,0 +1,76 @@
+package instancecache_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/kvstore"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResumeFromRevision_ReplaysWhatTheSnapshotMissed documents the server
+// behaviour the whole Cache design rests on: a watcher opened AFTER a
+// snapshot, resuming from just past the snapshot's high-water mark, replays
+// exactly the events the snapshot missed — even though nothing was watching
+// while they happened — and nothing the snapshot already covered. If a
+// nats.go upgrade ever changes this, this test fails loudly and points
+// straight at the cause, rather than the cache's own tests failing in a way
+// that looks like a cache bug.
+func TestResumeFromRevision_ReplaysWhatTheSnapshotMissed(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	ctx := context.Background()
+
+	store := kvstore.New[vm.InstanceRecord](js, kvstore.Config{Name: "resume-bucket", History: 1, Replicas: 1})
+
+	rec := func(id string) *vm.InstanceRecord {
+		r := &vm.InstanceRecord{}
+		r.Metadata.Name = id
+		return r
+	}
+
+	// Three keys exist before the snapshot.
+	for i := range 3 {
+		require.NoError(t, store.Set(ctx, fmt.Sprintf("i.pre-%d", i), rec(fmt.Sprintf("pre-%d", i))))
+	}
+
+	items, highWater, err := store.Snapshot(ctx, "i.*")
+	require.NoError(t, err)
+	require.Len(t, items, 3, "snapshot should see the three pre-existing keys")
+
+	// These land AFTER the snapshot and BEFORE any watcher exists. This is
+	// exactly the window a buffering fence would otherwise have to cover.
+	require.NoError(t, store.Set(ctx, "i.post-1", rec("post-1")))
+	require.NoError(t, store.Delete(ctx, "i.pre-0"))
+
+	// Open the watcher only now, resuming from just past the snapshot.
+	kw, err := js.KeyValue(ctx, "resume-bucket")
+	require.NoError(t, err)
+	w, err := kw.Watch(ctx, "i.*", jetstream.ResumeFromRevision(highWater+1))
+	require.NoError(t, err)
+	defer func() { _ = w.Stop() }()
+
+	seen := map[string]jetstream.KeyValueOp{}
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case e := <-w.Updates():
+			if e == nil {
+				// End-of-replay marker: everything the resume owed us has arrived.
+				require.Equal(t, jetstream.KeyValuePut, seen["i.post-1"],
+					"a put made after the snapshot, before the watcher existed, must be replayed")
+				require.Equal(t, jetstream.KeyValueDelete, seen["i.pre-0"],
+					"a delete made after the snapshot, before the watcher existed, must be replayed")
+				require.NotContains(t, seen, "i.pre-1", "keys already in the snapshot must not be replayed")
+				return
+			}
+			seen[e.Key()] = e.Operation()
+		case <-timeout:
+			t.Fatalf("no end-of-replay marker within 10s; saw %v", seen)
+		}
+	}
+}

--- a/spinifex/kvstore/bucket.go
+++ b/spinifex/kvstore/bucket.go
@@ -271,6 +271,30 @@ func (b *Bucket) Watch(ctx context.Context, filter string) (jetstream.KeyWatcher
 	return w, nil
 }
 
+// WatchFrom returns a watcher over the keys matching filter that resumes
+// from revision: it replays every value at or after revision, followed by
+// the end-of-replay marker, before turning into an ordinary live feed. It
+// takes no UpdatesOnly, unlike Watch, because the whole point is to replay
+// what a Snapshot's high-water mark missed — a caller rebuilding a cache
+// from a snapshot uses this to close that window without a buffering fence.
+func (b *Bucket) WatchFrom(ctx context.Context, filter string, revision uint64) (jetstream.KeyWatcher, error) {
+	var w jetstream.KeyWatcher
+	// Wrapped inside the closure, so a bucket that could not be opened at all
+	// reports the configured reason rather than a watch failure on top of it.
+	err := b.withKV(ctx, func(kv jetstream.KeyValue) error {
+		var err error
+		w, err = kv.Watch(ctx, filter, jetstream.ResumeFromRevision(revision))
+		if err != nil {
+			return fmt.Errorf("kvstore: watch %s %s: %w", b.cfg.Name, filter, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
 // open picks the kvutil helper matching the configured TTL and replica count.
 func (b *Bucket) open(ctx context.Context) (jetstream.KeyValue, error) {
 	switch {

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -30,6 +30,7 @@ import (
 	handlers_ochrevector "github.com/mulgadc/spinifex/spinifex/handlers/ochrevector"
 	handlers_quota "github.com/mulgadc/spinifex/spinifex/handlers/quota"
 	handlers_sts "github.com/mulgadc/spinifex/spinifex/handlers/sts"
+	"github.com/mulgadc/spinifex/spinifex/instancecache"
 	"github.com/mulgadc/spinifex/spinifex/kvstore"
 	"github.com/mulgadc/spinifex/spinifex/network/reconcile"
 	"github.com/mulgadc/spinifex/spinifex/objectstore"
@@ -569,6 +570,15 @@ func launchService(config *config.ClusterConfig) error {
 	// snapshot to KV and is itself a no-op when the RPM dimension is
 	// disabled.
 	go gw.Quota.RunBedrockRPMSync(janitorCtx, js, len(config.Nodes))
+
+	// Instance cache: a read-only informer over the live instance record space,
+	// started now so it is warm well before anything reads it. Nothing consults
+	// it yet; the describe path still serves from the fan-out and KV.
+	instanceCache := instancecache.New(js, instancecache.Config{
+		Bucket: kvstore.Config{Name: daemon.InstanceStateBucket, History: 1, Replicas: len(config.Nodes)},
+		Prefix: daemon.InstanceRecordPrefix,
+	})
+	go instanceCache.Run(janitorCtx)
 
 	handler := gw.SetupRoutes()
 


### PR DESCRIPTION
Phase 2 of `docs/development/improvements/instance-describe-read-path.md`. Bead `mulga-j2ye5`.

## What this is

A new leaf package, `spinifex/instancecache`: a read-only informer over the live instance record space, kept current by a JetStream KV watch and backstopped by a 30s whole-set resync.

**It is constructed and running in `awsgw`, and read by nothing.** The fan-out still serves every describe, so this phase changes no API answer. Moving describe onto it is Phase 3.

## The fence is a server feature, not ours

Combining a snapshot with a watch is wrong in both of the obvious orders. Resync-then-watch drops everything that happened in between. Watch-then-resync lets an older snapshot value overwrite a newer put, or resurrect a deleted key, because the snapshot is a read of the past being applied after the present.

`jetstream.ResumeFromRevision(rev)` closes that window directly. It appends `nats.StartSequence(rev)` after `DeliverLastPerSubject`, so start-sequence wins and the server replays the stream in order from `rev`. `Store.Snapshot` already reports the `highWater` sequence to resume from. So the whole algorithm is:

1. Snapshot, recording `highWater`.
2. Build the candidate map from the snapshot items.
3. Open a watcher at `highWater + 1`.
4. Apply everything it delivers until the nil end-of-replay marker.
5. Install the candidate, mark ready, keep draining the same watcher.

No buffer, no modes, no ordering puzzle. Initial sync, periodic resync and watcher replacement are all the same code path.

One semantic constraint makes or breaks this: **`ResumeFromRevision` must be used without `UpdatesOnly`**, because `UpdatesOnly` suppresses the nil marker that step 4 waits on. `Bucket.Watch` keeps `UpdatesOnly` — the reconciler depends on it — so this adds a sibling, `Bucket.WatchFrom`, which does not set it. `resume_from_revision_test.go` pins that server behaviour, because the whole design rests on it.

## What this replaced

An earlier revision of this branch hand-rolled the fence: a watcher opened in buffering mode before the snapshot, a bounded side buffer fenced against `highWater`, a three-valued `watchMode` enum so a periodic resync could tee off the live subscription, and an overflow failure path. It was reviewed over several rounds and it was correct.

Correctness was never evidence it needed to exist. `watchMode` and its three states, `openWatcher`, `discardWatcher`, `handleEntry`, `drainBuffered`, `goLive` and `freshSync` all restated one server guarantee. Net production change is about fifty lines lighter, which is not the point — the point is one fewer piece of our own concurrency machinery, with its own failure mode, to be wrong about.

Honest cost: a periodic resync now opens a fresh watcher each cycle rather than reusing the live one through the tee, so it is marginally *more* NATS work per cycle. That is not offset by anything direct. What it buys is a watch that can be trusted across a gap, which is the precondition for lengthening the resync interval.

## One deliberate deviation from the plan

The plan prescribed swapping the map and the active watcher under one lock and only then stopping and joining the dead watcher. This does the reverse: cancel, stop and join the dead watcher first, then run the full sync with a fresh one.

The prescribed order has to reason about a drainer that may be mid-apply writing into the new map. Reversing it removes that case by construction. The cost is a window with no subscription rather than a window with two, and that window is exactly what the following snapshot covers. The invariant holds either way, and is now structural rather than argued: a drainer checks it is still the active watcher before applying, so a superseded one cannot write. The plan doc has been corrected to match.

## Decode failures never remove anything

Per the consistency contract, the cache only ever removes a key because the record space said it is gone. A resync that hits an undecodable record fails the whole pass and leaves the map untouched — `Store.Snapshot` already fails rather than skipping, which is the behaviour this relies on. A watch update that will not decode keeps the existing entry. Both mark the cache degraded and count a failure.

`Degraded()` sits next to `Ready()` and is read by nothing yet. Phase 3 has to decide whether a cache whose resyncs have been failing for ten minutes can be believed about absence, and that needs the state to exist.

## The account index is not an authorisation boundary

`accountID -> set of instance IDs`, so a describe for one account never scans the cluster. `GlobalAccountID` is filed as an ordinary bucket, with legacy empty-owner records under it — it is not a superuser and the index must not make it one. `IsInstanceVisibleToCaller` is still applied to every record after the lookup, as defence in depth, and there is a test that deliberately mis-files a record to prove that seam is real rather than decorative.

## How the fence tests were checked, which matters more than that they pass

Fence tests are the ones worth being suspicious of: a test that exercises the pieces while missing the ordering passes whether or not the fence exists. **That happened twice on this branch** — two successive rounds of fence tests passed against a deliberately broken implementation, because each computed its own resume revision and called `WatchFrom`/`replay` directly instead of going through `syncOnce`.

So the acceptance criterion here is a mutation, not a green run. Changing `syncOnce`'s `WatchFrom(watchCtx, c.filter, hw+1)` to `hw+1_000_000` fails all four window tests; reverting passes them.

Worth recording because it is a trap: mutating the revision to `0` is **not** a valid check. nats.go treats a zero revision as unset and falls back to `DeliverLastPerSubject`, which still delivers the records, so the tests pass for the wrong reason.

Every window test now drives `syncOnce`. To land an event inside the window deterministically rather than racing for it, `syncOnce` calls a hook that is nil in production and set only by tests.

Also covered: put and delete via the watch, resync removing an entry whose delete the watch missed, resync removing a TTL-expired record that delivers no watch event, repeated sync failure leaking no subscription, failure losing nothing from the live map across ten forced failures, consecutive resyncs leaving one watcher, the old watcher stopped and joined before the new one goes live, and not-ready before the first whole-set pass.

## Metrics

Cache entries by state, age of the last successful resync, resync failures, watch reconnects, decode failures. Only the subset this phase can actually produce; the rest of the plan's list belongs to later phases and is not stubbed.

The decode-failure counter deliberately does **not** carry the record key as an attribute. The key is `i.<instance-id>`, so attributing it means one time series per instance that ever fails to decode — a systemic failure such as a schema change would produce one series per instance in the cluster, arriving precisely when the system is already in trouble. The key is logged instead.


## Verified on env19

Deployed to all three nodes and left running. Nothing reads the cache in this phase, so everything below is from metrics and logs.

**Clean and leak-free.** Zero `resync_failures`, `decode_failures` and `watch_reconnects` on every node across ~150 resync cycles over 26 minutes, and zero `instancecache` log lines of any level. `resync_age_seconds` stayed bounded 24.87–29.87s, so no resync stalled. Goroutines flat, and the `KV_spinifex-instance-state` JetStream consumer count was byte-identical between post-deploy and end-of-test on each node (4/1/1) across two forced `awsgw` restarts and two NATS disruptions. **The fresh watcher per resync leaks nothing**, which was the open question raised by dropping the tee.

**The window is observed closing, not inferred.** The first run could only show outcome correctness — a node force-restarted mid-churn ran a fresh initial sync against 26 concurrent launch/terminate cycles and converged to ground truth. That is equally consistent with the fence losing the write and the next resync fixing it 30s later, and the `PeriodicReader` exports at 60s against a 30s resync, so metrics cannot separate the two.

`replay_events` was added for exactly that (`92cdb437d`). It counts the records `ResumeFromRevision` delivered between `highWater+1` and catch-up — precisely what the snapshot missed — and records an explicit zero on every sync so a quiet cluster is distinguishable from an instrument that never fired.

- Control: 13 samples across three nodes on a quiet cluster, every one zero.
- Moderate churn, one write pair per 10s across ~36 resync opportunities: still zero.
- Dense churn, 4 concurrent launches + 4 concurrent terminates per batch with no pause for 11 minutes: `replay_events` on one node stepped 0 → 2 and held flat, and all three nodes still matched `describe-instances` afterwards.

Two records in eleven minutes of hammering measures the window as much as it proves the mechanism: the gap between `Snapshot` returning and `WatchFrom` opening is milliseconds, so landing a write inside it is rare. That rarity is the argument for engineering against this bug class rather than testing for it — it would not surface in staging, and in production it would look like one instance inexplicably missing from one gateway's view until the next resync.

**What this did not establish.** The strongest case — a non-zero replay on the restarted node's *initial* sync — did not land; that node converged correctly but via zero replays, and the hit came from another node's periodic resync. So the initial-sync-under-concurrent-writes sub-case is inferred from the general mechanism rather than witnessed. The `slog.Debug` line was not captured either, because `debug = false` on env19 is not wired through the ansible role and enabling it meant a restart that would have reset the counters being measured.

**Watcher replacement remains unreached** (`mulga-av72t`). Bouncing a node's local `nats-server` does not sever its watcher: env19 runs a three-node NATS cluster, the client holds all three seed URLs, and `MaxReconnects(-1)` at `utils/nats.go:71` fails over to a peer transparently — a deliberate 52-second full stop left `resync_age_seconds` flat and moved no counter. Reaching it needs all three endpoints blocked from the `awsgw` process, which also risks predastore raft on that node.

Two follow-ups raised from the run: `mulga-sav0s` (the `entries` gauge reports raw `vm.VM.Status`, so `{stopped:1, error:1}` where the API projects 2 × `stopped` — counts agree, names do not) and `mulga-hklex` (a cumulative `Int64Counter` writes no document until first incremented, so a healthy panel renders blank rather than 0 — applies to every counter in the tree).
