### PR TITLE
feat: record a launch before replying to the caller

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2625,8 +2625,11 @@ func (d *Daemon) persistState(nodeID string, vms map[string]*vm.VM) error {
 	if d.jsManager != nil {
 		kvStart := time.Now()
 		d.jsManager.WriteNodeMarkerBestEffort(nodeID, kvSyncTimeout)
-		d.jsManager.WriteRunningSet(nodeID, d.config.AZ, vms)
-		recordStateWrite("kv", len(vms), time.Since(kvStart))
+		res := d.jsManager.WriteRunningSet(nodeID, d.config.AZ, vms)
+		// The digest guard means only changed records are written, so the KV
+		// write's cost tracks that count, not the whole set the local write
+		// rewrites.
+		recordStateWrite("kv", res.Written+res.Retired, time.Since(kvStart))
 	}
 
 	if localErr != nil {

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2609,7 +2609,9 @@ func (d *Daemon) persistState(nodeID string, vms map[string]*vm.VM) error {
 	// the local failure. Revision only advances when the local write (the
 	// source of truth Revision() describes) actually landed.
 	path := d.localStatePath()
+	localStart := time.Now()
 	localErr := WriteLocalStateBytes(path, localData)
+	recordStateWrite("local", len(vms), time.Since(localStart))
 	if localErr != nil {
 		slog.Error("Local state write failed", "path", path, "error", localErr)
 	} else {
@@ -2621,8 +2623,10 @@ func (d *Daemon) persistState(nodeID string, vms map[string]*vm.VM) error {
 	// a set that has not been written yet. vms is the caller's snapshot and
 	// cannot change underneath either write.
 	if d.jsManager != nil {
+		kvStart := time.Now()
 		d.jsManager.WriteNodeMarkerBestEffort(nodeID, kvSyncTimeout)
 		d.jsManager.WriteRunningSet(nodeID, d.config.AZ, vms)
+		recordStateWrite("kv", len(vms), time.Since(kvStart))
 	}
 
 	if localErr != nil {

--- a/spinifex/daemon/daemon_handlers_instance.go
+++ b/spinifex/daemon/daemon_handlers_instance.go
@@ -184,12 +184,9 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) string {
 		}
 		return outcomeError
 	}
-	if err := msg.Respond(jsonResponse); err != nil {
-		slog.Error("Failed to respond to NATS request", "err", err)
-	}
-
-	// Spanned separately from the launch: this is the work that would move
-	// onto the response path if the respond were gated on the local write.
+	// Record before responding: a caller that holds an instance ID must be
+	// able to find it. IMDS reads this node's on-disk state, so a guest can
+	// query it the moment the reservation reaches the customer.
 	_, recordSpan := otel.Tracer(daemonTracerName).Start(ctx, "ec2.RecordRunInstances",
 		trace.WithAttributes(attribute.Int("instance.count", len(instances))))
 	for _, instance := range instances {
@@ -198,13 +195,30 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) string {
 	writeErr := d.WriteState()
 	endOpSpan(recordSpan, writeErr)
 	if writeErr != nil {
+		// The local file is the source of truth this node restores from, so a
+		// launch it does not record is a launch nothing can recover. Fail the
+		// request and undo, rather than run instances the caller was told
+		// failed.
 		slog.Error("handleEC2RunInstances failed to write initial state", "err", writeErr)
+		for _, instance := range instances {
+			// DeleteIf, so a slot another path has already reclaimed is left
+			// alone. The failed write means the file never gained these
+			// entries, so removing them returns memory and disk to agreement.
+			d.vmMgr.DeleteIf(instance.ID, instance)
+			if reservationID == "" {
+				d.resourceMgr.deallocate(instanceType)
+			} else {
+				d.resourceMgr.ReleaseToReservation(reservationID, instanceType)
+			}
+		}
+		respondWithError(d.node, msg, awserrors.ErrorServerInternal)
+		return outcomeError
 	}
 	slog.Info("Instances added to state with pending status", "count", len(instances))
 
 	// Project launch tags into the central tag store so describe-tags agrees
-	// with the record from birth. Best-effort: the reservation is already
-	// returned, so a failed write is logged rather than failing the launch.
+	// with the record from birth. Best-effort: a failed write is logged rather
+	// than failing the launch.
 	for _, instance := range instances {
 		if instance.Instance == nil || len(instance.Instance.Tags) == 0 {
 			continue
@@ -216,8 +230,9 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) string {
 		}
 	}
 
-	// Subscribe per-instance NATS topics so terminate/stop reach this daemon
-	// while volumes prepare. LaunchInstance replaces these on success.
+	// Subscribe per-instance NATS topics before responding, so a terminate or
+	// stop issued the instant the caller has the ID reaches this daemon rather
+	// than finding no responder. LaunchInstance replaces these on success.
 	d.mu.Lock()
 	for _, instance := range instances {
 		sub, subErr := d.natsConn.Subscribe(fmt.Sprintf("ec2.cmd.%s", instance.ID), d.handleEC2Events)
@@ -228,6 +243,10 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) string {
 		}
 	}
 	d.mu.Unlock()
+
+	if err := msg.Respond(jsonResponse); err != nil {
+		slog.Error("Failed to respond to NATS request", "err", err)
+	}
 
 	_, launchSpan := otel.Tracer(daemonTracerName).Start(ctx, "ec2.LaunchRunInstances",
 		trace.WithAttributes(attribute.Int("instance.count", len(instances))))

--- a/spinifex/daemon/daemon_handlers_instance.go
+++ b/spinifex/daemon/daemon_handlers_instance.go
@@ -188,11 +188,17 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) string {
 		slog.Error("Failed to respond to NATS request", "err", err)
 	}
 
+	// Spanned separately from the launch: this is the work that would move
+	// onto the response path if the respond were gated on the local write.
+	_, recordSpan := otel.Tracer(daemonTracerName).Start(ctx, "ec2.RecordRunInstances",
+		trace.WithAttributes(attribute.Int("instance.count", len(instances))))
 	for _, instance := range instances {
 		d.vmMgr.Insert(instance)
 	}
-	if err := d.WriteState(); err != nil {
-		slog.Error("handleEC2RunInstances failed to write initial state", "err", err)
+	writeErr := d.WriteState()
+	endOpSpan(recordSpan, writeErr)
+	if writeErr != nil {
+		slog.Error("handleEC2RunInstances failed to write initial state", "err", writeErr)
 	}
 	slog.Info("Instances added to state with pending status", "count", len(instances))
 

--- a/spinifex/daemon/daemon_handlers_instance_persist_test.go
+++ b/spinifex/daemon/daemon_handlers_instance_persist_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// breakLocalStateWrite makes the daemon's local state write fail by occupying
+// its parent directory path with a regular file, so MkdirAll returns ENOTDIR.
+// Everything else rooted at DataDir keeps working.
+func breakLocalStateWrite(t *testing.T, d *Daemon) {
+	t.Helper()
+	stateDir := filepath.Dir(d.localStatePath())
+	require.NoError(t, os.RemoveAll(stateDir))
+	require.NoError(t, os.WriteFile(stateDir, []byte("not a directory"), 0o600))
+	require.Error(t, d.WriteState(), "state write must fail once the path is blocked")
+}
+
+func countVMs(d *Daemon) int {
+	n := 0
+	d.vmMgr.View(func(vms map[string]*vm.VM) { n = len(vms) })
+	return n
+}
+
+// A launch whose local state write fails is reported as a failure and leaves
+// nothing behind: no record in the manager, and the capacity it reserved is
+// returned. The customer is never told "no" about an instance that exists.
+func TestHandleEC2RunInstances_LocalWriteFailureLaunchesNothing(t *testing.T) {
+	daemon, memStore := createFullTestDaemonWithStore(t, sharedNATSURL)
+	seedTestAMI(t, memStore, daemon.config.Predastore.Bucket, "ami-writefail")
+
+	instanceType := getTestInstanceType(t)
+	typeInfo := daemon.resourceMgr.InstanceTypes()[instanceType]
+	require.NotNil(t, typeInfo)
+	capacityBefore := daemon.resourceMgr.CanAllocate(typeInfo, 64)
+
+	sub, err := daemon.natsConn.QueueSubscribe("ec2.RunInstances.writefail", "spinifex-workers", asMsgHandler(daemon.handleEC2RunInstances))
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	breakLocalStateWrite(t, daemon)
+
+	input := &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-writefail"),
+		InstanceType: aws.String(instanceType),
+		MinCount:     aws.Int64(1),
+		MaxCount:     aws.Int64(1),
+	}
+	reply, err := natsRequest(daemon.natsConn, "ec2.RunInstances.writefail", mustMarshal(t, input), 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, awserrors.ErrorServerInternal, decodeError(t, reply.Data)["Code"],
+		"a launch that could not be recorded must be reported as an error: %s", reply.Data)
+
+	var reservation ec2.Reservation
+	if json.Unmarshal(reply.Data, &reservation) == nil {
+		assert.Empty(t, reservation.Instances, "no instance may be returned to the caller")
+	}
+
+	assert.Zero(t, countVMs(daemon), "the failed launch must leave no record behind")
+	assert.Equal(t, capacityBefore, daemon.resourceMgr.CanAllocate(typeInfo, 64),
+		"capacity reserved for the failed launch must be returned")
+}

--- a/spinifex/daemon/daemon_handlers_instance_tags_test.go
+++ b/spinifex/daemon/daemon_handlers_instance_tags_test.go
@@ -153,7 +153,7 @@ func TestHandleSetInstanceTags_CrossAccountRejected(t *testing.T) {
 
 // RunInstances with instance-scoped TagSpecifications projects the launch tags
 // into the central tag store, so describe-tags sees them from birth. The write
-// happens after the reservation reply, hence the Eventually.
+// is best-effort, so the assertion tolerates it landing slightly late.
 func TestHandleEC2RunInstances_LaunchTagsWriteCentralStore(t *testing.T) {
 	daemon, memStore := createFullTestDaemonWithStore(t, sharedNATSURL)
 	seedTestAMI(t, memStore, daemon.config.Predastore.Bucket, "ami-launchtags")

--- a/spinifex/daemon/state_write_metrics.go
+++ b/spinifex/daemon/state_write_metrics.go
@@ -44,9 +44,9 @@ func stateWriteMetrics() stateWriteInstruments {
 		if err != nil {
 			otel.Handle(err)
 		}
-		stateWriteInst.vms, err = meter.Int64Counter("mulga.daemon.state_write.vms.sum",
-			metric.WithDescription("Summed instance count seen by each state write. Divide by ops for the mean set size."),
-			metric.WithUnit("{instance}"))
+		stateWriteInst.vms, err = meter.Int64Counter("mulga.daemon.state_write.records.sum",
+			metric.WithDescription("Summed records each write actually handled: the whole set for store=local, only the changed ones for store=kv. Divide by ops for the mean."),
+			metric.WithUnit("{record}"))
 		if err != nil {
 			otel.Handle(err)
 		}
@@ -54,9 +54,10 @@ func stateWriteMetrics() stateWriteInstruments {
 	return stateWriteInst
 }
 
-// recordStateWrite reports one write of store ("local" or "kv") over vmCount
-// instances. Every recorder tolerates a nil instrument.
-func recordStateWrite(store string, vmCount int, d time.Duration) {
+// recordStateWrite reports one write of store ("local" or "kv") over records,
+// which is the whole set locally but only the changed ones in KV. Every
+// recorder tolerates a nil instrument.
+func recordStateWrite(store string, records int, d time.Duration) {
 	inst := stateWriteMetrics()
 	set := metric.WithAttributeSet(attribute.NewSet(attribute.String("store", store)))
 	ctx := context.Background()
@@ -68,6 +69,6 @@ func recordStateWrite(store string, vmCount int, d time.Duration) {
 		inst.duration.Add(ctx, d.Seconds(), set)
 	}
 	if inst.vms != nil {
-		inst.vms.Add(ctx, int64(vmCount), set)
+		inst.vms.Add(ctx, int64(records), set)
 	}
 }

--- a/spinifex/daemon/state_write_metrics.go
+++ b/spinifex/daemon/state_write_metrics.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// stateWriteMeterName is the instrumentation scope for persistState timings.
+const stateWriteMeterName = "github.com/mulgadc/spinifex/spinifex/daemon/statewrite"
+
+// Duration is reported as a sum plus an op count rather than a histogram:
+// ES|QL cannot aggregate a native histogram field, so a panel computes
+// avg = SUM(duration.sum) / SUM(ops).
+type stateWriteInstruments struct {
+	ops      metric.Int64Counter
+	duration metric.Float64Counter
+	vms      metric.Int64Counter
+}
+
+var (
+	stateWriteOnce sync.Once
+	stateWriteInst stateWriteInstruments
+)
+
+func stateWriteMetrics() stateWriteInstruments {
+	stateWriteOnce.Do(func() {
+		meter := otel.Meter(stateWriteMeterName)
+
+		var err error
+		stateWriteInst.ops, err = meter.Int64Counter("mulga.daemon.state_write.ops",
+			metric.WithDescription("Count of local-file and KV state writes, by store."),
+			metric.WithUnit("{write}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		stateWriteInst.duration, err = meter.Float64Counter("mulga.daemon.state_write.duration.sum",
+			metric.WithDescription("Summed wall time of state writes, by store. Divide by ops for the mean."),
+			metric.WithUnit("s"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		stateWriteInst.vms, err = meter.Int64Counter("mulga.daemon.state_write.vms.sum",
+			metric.WithDescription("Summed instance count seen by each state write. Divide by ops for the mean set size."),
+			metric.WithUnit("{instance}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+	})
+	return stateWriteInst
+}
+
+// recordStateWrite reports one write of store ("local" or "kv") over vmCount
+// instances. Every recorder tolerates a nil instrument.
+func recordStateWrite(store string, vmCount int, d time.Duration) {
+	inst := stateWriteMetrics()
+	set := metric.WithAttributeSet(attribute.NewSet(attribute.String("store", store)))
+	ctx := context.Background()
+
+	if inst.ops != nil {
+		inst.ops.Add(ctx, 1, set)
+	}
+	if inst.duration != nil {
+		inst.duration.Add(ctx, d.Seconds(), set)
+	}
+	if inst.vms != nil {
+		inst.vms.Add(ctx, int64(vmCount), set)
+	}
+}


### PR DESCRIPTION
## What

`handleEC2RunInstances` replied with the reservation and only then inserted the VM records and wrote node state. A caller holding an instance ID could describe it and get `InvalidInstanceID.NotFound`, and a guest could reach IMDS before this node's state file knew the instance existed — IMDS runs in vpcd and reads the on-disk file, not `vmMgr`, so it could not see the launch either.

`msg.Respond` now happens after the inserts, after `WriteState`, and after the per-instance subscribe loop. By the time an ID reaches the customer the node can answer for it, and a terminate issued immediately finds a responder rather than `ErrNoResponders`.

A failed local write now fails the request. The file is what this node restores from, so a launch it did not record is a launch nothing can recover — running it anyway would leave an instance the customer was told did not exist. The handler undoes each insert with `DeleteIf` (so a slot another path already reclaimed is left alone), returns the capacity or releases it to the reservation, and answers `ErrorServerInternal`.

Also fixes the KV half of the state-write instrumentation added in `d24c278fe`: `WriteRunningSet` is digest-guarded and only touches changed records, so attributing the node's whole VM count to it overstated the per-record cost. Now `Written+Retired`, with the metric renamed `records.sum`.

## Measured first, on env19

The reorder was gated on measurement, and the measurement is what decided its shape.

`ec2.RecordRunInstances` wraps exactly the work being moved onto the response path. Before: p50 7.48ms at one instance, 10.96ms at two, 13.22ms at three. After: p50 9.45ms, p90 11.18ms, max 14.84ms over 40 samples. Client-observed end-to-end `run-instances` went from a 2.39–4.66s mean to 1.88–3.74s. Around two milliseconds on a multi-second call.

That killed the planned split of `persistState` to move the KV write off the response path. It would have added a second failure surface and two more invariants to preserve, to reclaim something that does not show up. The dominant cost is elsewhere: `ec2.PrepareRunInstances` is p50 1.39s, max 9.0s, entirely before the respond.

Worth recording: `RunInstances` fans out per node. A client call for N splits into per-node requests `ec2.RunInstances.<type>.<node>`, each running its own handler, so `instance.count` on the span is the per-node sub-batch — only ever 1–3 on a three-node cluster.

## Verification

15 of 15 launches passed the property this change exists for: immediately after `run-instances` returned, with no sleep and no retry, `describe-instances` returned the instance and the ID was already in the owning node's `instance-state.json`.

`TestHandleEC2RunInstances_LocalWriteFailureLaunchesNothing` covers the failure path by blocking the state directory path with a regular file so `MkdirAll` returns `ENOTDIR`, then asserting the error code, an empty manager and the returned capacity. Mutation-checked: deleting the rollback loop fails both of the latter two.

`make preflight` passes.

## Follow-ups

- `mulga-etrtp` — the local write is a whole-file rewrite and so O(N) in the node's total instance count. It measured flat at 2.1–3.6ms from N≈2 to N≈7, but env19 cannot hold more than seven instances per node, so the curve at N=30 is unmeasured and the SQLite-vs-JSON question stays open.
- `mulga-9xu4n` — a stray record stuck at `status: error` that terminate will not clear. Predates this change.
- This narrows the `ErrNoResponders` race behind `mulga-2i0b0` but does not close it; those retries also cover restart and resubscription after failover.