### PR TITLE
fix: family-qualify unscoped firewall accepts to IPv4

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -400,21 +400,24 @@ table inet spinifex_filter {
         # gateway, never NATS, so no cluster port needs to face the guests.
         # 443 has no listener yet and is held for the nginx TLS edge, so the
         # rollout does not need a firewall change on every node.
-        tcp dport { 443, 3000, 8443, 9999 } accept
+        # nfproto ipv4: these accepts carry no source scope, so without a family
+        # qualifier they would also serve on any global IPv6 a node autoconfigures
+        # from an upstream RA. The scoped rules are v4-only via `ip saddr` already.
+        meta nfproto ipv4 tcp dport { 443, 3000, 8443, 9999 } accept
 
         # Transiently open to any source, for cluster formation. A node dialling
         # in to join is not a peer yet, so the peer-scoped rule below cannot let
         # it in; `spx admin init` opens the formation port here for the length of
         # the formation window and closes it again afterwards. Normally holds
         # only the sentinel, which no packet can match.
-        tcp dport $spinifex_open_ports accept
+        meta nfproto ipv4 tcp dport $spinifex_open_ports accept
 
         # 53 is open on every node, deliberately: northstar serves public
         # authoritative DNS and binds its advertise address. A node running no
         # public zone answers here too, which is the accepted cost of not
         # templating the policy per node.
-        tcp dport 53 accept
-        udp dport 53 accept
+        meta nfproto ipv4 tcp dport 53 accept
+        meta nfproto ipv4 udp dport 53 accept
 
         # Cluster plane, peer-scoped. On a single-NIC node the planes collapse
         # onto the public address, which is why these are peer addresses rather


### PR DESCRIPTION
## Problem

The host firewall's public, formation and DNS accept rules carry no address
family qualifier, so they match IPv6 as well as IPv4. Three of four prod nodes
autoconfigure a routable global IPv6 via SLAAC from an upstream MikroTik Router
Advertisement, and on that address the console (3000), predastore S3 gate (8443),
AWS gateway (9999) and DNS (53) answered with **none** of the source scoping that
protects them on IPv4. The `ip saddr`-scoped rules (SSH, cluster, encap, ime-*)
were already v4-only and fail closed on v6; only these four unscoped accepts
leaked.

This is the customer-proof shape of the fix: a node is safe whether or not it
ever forms a v6 address, so it holds regardless of a customer's upstream (RA
floods, `accept_ra=1`, DHCPv6, or a rogue RA).

## Change

Qualify the four unscoped accepts with `meta nfproto ipv4`; v6 then falls through
to `policy drop`. No IPv4 behaviour changes.

## Verification

Applied to the running `spinifex.nft` on all four prod nodes and reloaded, then
tested with the v6 address present (the real test):

- Before: `node2 → node4` over v6 to `:3000/:8443/:9999` all OPEN.
- After: all closed, both directions, plus `:53`; v4 to those ports unchanged
  (`72.52.77.231:9999/:3000` still open); public API `403×4`; SSH unaffected.

`nft -c` passed before each reload; `make preflight` passes.

## Notes

- Guest overlay is unaffected — OVN contains the RA (verified on the live EC2
  guest), so no tenant instance can pick up a v6.
- Plan: `docs/development/improvements/ipv6-node-exposure.md` (mulga), bead
  `mulga-iaafd`. Optional per-deployment RA-disable and the F3 logging follow-ups
  are tracked there, not in this PR.