### PR TITLE
feat: block outbound SMTP by default, raise drop-log ceiling

### DIFF
--- a/docs/compute/vpc-networking/README.md
+++ b/docs/compute/vpc-networking/README.md
@@ -892,6 +892,41 @@ nc -vz 169.254.169.254 22                                                       
 A missing `spinifex_filter` table means the host firewall is off and this plane
 is unprotected regardless of the rule above.
 
+## Default outbound restrictions
+
+Like AWS, Spinifex blocks outbound SMTP from instances by default. A fresh
+account whose instance is compromised is a favourite tool for spam, so
+connections to the mail submission ports are dropped at the hypervisor before
+they reach the wire:
+
+| Port | Protocol | Purpose |
+| --- | --- | --- |
+| 25 | TCP | SMTP relay |
+| 465 | TCP | SMTP over implicit TLS |
+| 587 | TCP | SMTP submission |
+
+The block applies only to **public** destinations. Mail to private ranges
+(`10/8`, `172.16/12`, `192.168/16`, `100.64/10`, link-local) is untouched, so an
+in-VPC or on-prem relay still works. It is enforced in the host firewall's
+`forward` chain, so — like every other host-firewall rule — it is only in force
+when the host firewall is on (see the table above).
+
+**Operators who run legitimate mail infrastructure can lift it.** The rule lives
+in the generated `inet spinifex_filter` `forward` chain. Removing the two
+`tcp dport { 25, 465, 587 }` rules from the policy template (`scripts/setup.sh`)
+and re-running `setup.sh` clears the block cluster-wide. There is no per-instance
+exception today; that, and moving the enforcement point into vpcd so it travels
+with the VPC rather than the host, are tracked in the egress-abuse-controls plan.
+
+Verify from an instance — the submission ports must fail, ordinary egress must
+not:
+
+```bash
+nc -vz smtp.example.com 25    # must fail (blocked by default)
+nc -vz smtp.example.com 587   # must fail (blocked by default)
+nc -vz example.com 443        # must succeed
+```
+
 ## Elastic IPs
 
 Elastic IPs are static public IPs that persist across instance stop/start cycles. Unlike auto-assigned public IPs (which change on stop/start), an Elastic IP stays with your instance.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -342,10 +342,13 @@ install_firewall() {
 # tables and reinstalls them only when the service starts, so anything that
 # flushes the whole ruleset breaks elastic IPs silently until the next restart.
 #
-# INPUT only. nftables runs every table registered on a hook and any drop is
-# final, so a forward-hook policy here could not be rescued by vpcd's ACCEPTs in
-# the other table. OUTPUT is untouched: the IMDS reply path egresses under
-# per-tap policy routing.
+# INPUT is policy drop. The forward chain is policy ACCEPT and drops only a few
+# named egress ports: nftables runs every table registered on a hook and a drop
+# is final, so a forward-hook *policy drop* could not be rescued by vpcd's
+# ACCEPTs in the other table — but a policy-accept chain that drops a specific
+# port only silences that port and leaves every other forwarded packet for the
+# other table to accept as before. OUTPUT is untouched: the IMDS reply path
+# egresses under per-tap policy routing.
 
 include "/etc/spinifex/firewall/local.nft"
 include "/etc/spinifex/firewall/open-ports.nft"
@@ -437,8 +440,23 @@ table inet spinifex_filter {
         ip saddr $spinifex_encap_peers meta l4proto esp accept
 
         # Rate-limited so a scan cannot fill the journal. This is the only way
-        # to tell a policy gap from an application fault after the fact.
-        limit rate 5/minute burst 10 packets log prefix "spinifex-fw drop: " level info
+        # to tell a policy gap from an application fault after the fact. The
+        # ceiling is generous: operators ship these logs to an external system,
+        # so dropping detail here costs more than a few extra journal lines.
+        limit rate 10/second burst 20 packets log prefix "spinifex-fw drop: " level info
+    }
+
+    chain forward {
+        type filter hook forward priority filter; policy accept;
+
+        # AWS blocks outbound SMTP by default so a compromised guest cannot turn
+        # a fresh account into a spam relay; match that out of the box. Only
+        # public destinations are blocked — mail to private ranges (an in-VPC or
+        # on-prem relay) still flows. Operators who run mail infrastructure can
+        # remove this by clearing the port set. Logged rate-limited for abuse
+        # triage, then dropped unconditionally.
+        ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 169.254.0.0/16 } tcp dport { 25, 465, 587 } limit rate 10/minute burst 5 packets log prefix "spinifex-fw smtp-egress: " level info
+        ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 169.254.0.0/16 } tcp dport { 25, 465, 587 } drop
     }
 }
 RULES


### PR DESCRIPTION
## Summary

Adds the AWS-parity anti-abuse basics to the host firewall, on a branch left open for further egress tweaks from other sessions.

- **Block outbound SMTP by default.** A `forward` chain (`policy accept`) drops guest egress to TCP 25/465/587 for **public** destinations only — private ranges (`10/8`, `172.16/12`, `192.168/16`, `100.64/10`, link-local) are exempt so an in-VPC or on-prem relay still works. Rate-limited log (`spinifex-fw smtp-egress:`) for abuse triage, then unconditional drop. Operators who run mail infra can lift it by clearing the port set and re-running `setup.sh`.
- **Safe placement.** `policy accept` + a targeted port drop, not a default-deny forward policy — a default-deny there would break elastic IPs, since vpcd's per-EIP ACCEPTs live in a different table and an nftables drop is final across tables. The targeted drop only silences those three ports and leaves everything else for the other table.
- **Raise the input drop-log ceiling** from `5/minute burst 10` to `10/second burst 20`. Operators ship these logs to an external system, so dropping detail costs more than a few extra journal lines.
- **Operator docs.** New "Default outbound restrictions" section in `docs/compute/vpc-networking/README.md`.

## Notes

- NFT placement is the simple first step. Moving the SMTP drop into vpcd (so it travels with the VPC and supports a per-account exception) is the better long-term home — tracked in the mulga `egress-abuse-controls` plan alongside the DNS query-logging roadmap.
- **Branch left open** for additional egress tweaks from concurrent sessions; not necessarily to merge immediately.

## Testing

- `make preflight` passes.
- `nft -c -f` validates the rendered chains (checked on a node).
- Guest: `nc -vz <public> 25/465/587` must fail, `443` must succeed, `<private-relay> 25` must succeed.