### PR TITLE
fix: make cell-24 able to pass — nvme work root and a realistic timeout

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1238,12 +1238,20 @@ jobs:
       - name: Clean Workspace
         run: sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/*
 
+      # STRESS_WORK_ROOT is set as well as TMPDIR because the harness ignores
+      # TMPDIR for the scenarios that need the most disk: large-object and
+      # multipart-upload default to $HOME/.cache/predastore-e2e, on the theory
+      # that TMPDIR is commonly tmpfs. Here it is a 938G nvme, so pointing them
+      # at it is both correct and the only path with room.
       - name: Configure work directories
         run: |
           E2E_ROOT=/mnt/nvme/e2e
-          mkdir -p "$E2E_ROOT/work" 2>/dev/null ||
-            { sudo mkdir -p "$E2E_ROOT/work" && sudo chown "$(id -u):$(id -g)" "$E2E_ROOT" "$E2E_ROOT/work"; }
+          for d in work stress-work; do
+            mkdir -p "$E2E_ROOT/$d" 2>/dev/null ||
+              { sudo mkdir -p "$E2E_ROOT/$d" && sudo chown "$(id -u):$(id -g)" "$E2E_ROOT" "$E2E_ROOT/$d"; }
+          done
           echo "TMPDIR=$E2E_ROOT/work" >> "$GITHUB_ENV"
+          echo "STRESS_WORK_ROOT=$E2E_ROOT/stress-work" >> "$GITHUB_ENV"
           echo "STRESS_RESULTS_ROOT=$E2E_ROOT/predastore-stress-$GITHUB_RUN_ID" >> "$GITHUB_ENV"
 
       - name: Checkout Spinifex
@@ -1271,15 +1279,25 @@ jobs:
       - name: Preflight
         run: |
           set -euo pipefail
-          mkdir -p "$TMPDIR"
-          find "$TMPDIR" -maxdepth 1 -name 'predastore-e2e-stress.*' \
-               -type d -mtime +0 -exec rm -rf {} + 2>/dev/null || true
-          df -h "$TMPDIR"
-          avail_gb=$(df -BG --output=avail "$TMPDIR" | tail -1 | tr -dc '0-9')
-          if [ "$avail_gb" -lt 10 ]; then
-            echo "::error::$TMPDIR has ${avail_gb} GiB free; the run needs headroom above predastore's 5% watermark."
-            exit 1
-          fi
+          mkdir -p "$TMPDIR" "$STRESS_WORK_ROOT"
+          for d in "$TMPDIR" "$STRESS_WORK_ROOT" "$HOME/.cache/predastore-e2e"; do
+            [ -d "$d" ] || continue
+            find "$d" -maxdepth 1 -name 'predastore-e2e-stress.*' \
+                 -type d -mtime +0 -exec rm -rf {} + 2>/dev/null || true
+          done
+          # Both paths, because they can be different filesystems and the one
+          # holding the large objects is not the one TMPDIR names. large-object
+          # needs 2GiB and 4GiB sharded with parity, multipart 1GiBx8.
+          rc=0
+          for d in "$TMPDIR" "$STRESS_WORK_ROOT"; do
+            df -h "$d"
+            avail_gb=$(df -BG --output=avail "$d" | tail -1 | tr -dc '0-9')
+            if [ "$avail_gb" -lt 40 ]; then
+              echo "::error::$d has ${avail_gb} GiB free; the run needs headroom above predastore's 5% watermark and room for the 1GiBx8 multipart case."
+              rc=1
+            fi
+          done
+          exit "$rc"
 
       # Leftovers from a run killed before its cleanup trap: a surviving node
       # holds its ports and fails this run somewhere unrelated.

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1225,7 +1225,10 @@ jobs:
       inputs.cells == '' ||
       contains(format(',{0},', inputs.cells), ',24,') )
     runs-on: [self-hosted, ci-single]
-    timeout-minutes: 30
+    # The thirteen scenarios run serially and are ~35 minutes of work on their
+    # own, measured from the per-scenario predastore matrix, before checkout
+    # and build. 30 could not have passed whatever the disk did.
+    timeout-minutes: 75
     env:
       # Freezes a follower. STRESS_HOST=leader is a known failure: a gate keeps
       # the frozen node first in its meta read order and pays the full client


### PR DESCRIPTION
Closes `mulga-uebz7`.

Two independent reasons cell-24 could not pass. It has been *skipped* in every earlier nightly, so neither had ever been exercised: run 33922059371 was its first real execution.

## 1. The preflight guarded the wrong filesystem

The fault-injection harness ignores `TMPDIR` for the two scenarios that need the most disk. `large-object` and `multipart-upload` default to `$HOME/.cache/predastore-e2e` because `TMPDIR` is commonly tmpfs, which would cap object sizes and charge object bytes to the RSS figure those scenarios measure.

On the ci-single runner those are different filesystems: run 33922059371 reported 691G free on `TMPDIR` and 12GiB on `$HOME`. So the guard measured a filesystem the scenarios that need disk never write to, and passed.

That run is what it looks like: `multipart-upload: SKIP 1GiBx8 — needs 27GiB free ... has 12GiB`, then 256MiBx8 failed `complete-multipart-upload` with `too few shards durable: 0 of 3`, the next scenario could not start its cluster, and the run aborted before reaching `partial-put`.

- Set `STRESS_WORK_ROOT=$E2E_ROOT/stress-work` alongside `TMPDIR`, so the harness's own override points at the same nvme rather than the root disk.
- Preflight checks free space on both paths, at a 40 GiB threshold that covers the 1GiBx8 multipart case, and names which path is short.
- Stale `predastore-e2e-stress.*` work directories are swept from both paths and from `$HOME/.cache/predastore-e2e`.

A run that would skip a size for want of disk now fails preflight rather than reporting a pass with less coverage.

## 2. The timeout was shorter than the suite

The thirteen scenarios run serially. Summing the per-scenario jobs from predastore run 33920560881 gives **34m46s** of scenario time alone, before checkout, build and cluster setup — against a `timeout-minutes: 30`. Raised to 75.

Workflow-only change; `make preflight` passes.