### PR TITLE
feat: let a node put every volume's WAL on its own device

### DIFF
--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -386,6 +386,7 @@ var viperblockStartCmd = &cobra.Command{
 			NodeName:          clusterConfig.Node,
 			ShardWAL:          shardWAL,
 			GCEnabled:         gcEnabled,
+			WALBaseDir:        nodeConfig.Viperblock.WALBaseDir,
 			EncryptionKeyFile: encryptionKeyFile,
 			Threads:           nodeConfig.EBS.ResolvedThreads(),
 			CacheSizeMB:       nodeConfig.EBS.ResolvedCacheSizeMB(),

--- a/cmd/spinifex/cmd/templates/spinifex.toml
+++ b/cmd/spinifex/cmd/templates/spinifex.toml
@@ -118,6 +118,14 @@ token = "{{.NatsToken}}"
 [nodes.{{.Node}}.viperblock]
 shardwal = false
 gc_enabled = true
+#
+# wal_base_dir: put every volume's WAL under this directory instead of the
+# node's base_dir. A WAL fsync shares the device queue with predastore, the
+# chunk cache and every other volume on the node, so a busy node lengthens the
+# fsync tail that a datastore guest measures as its commit latency. Pointing
+# this at its own device keeps that traffic out of the WAL's queue. Unset
+# keeps the WAL under base_dir.
+#wal_base_dir = "/var/lib/spinifex-wal"
 {{- if .EncryptionKeyFile}}
 encryption_key_file = "{{.EncryptionKeyFile}}"
 {{- end}}

--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -173,6 +173,12 @@ type ViperblockConfig struct {
 	// volume service. Default false when nil so existing deployments keep
 	// today's behavior until explicitly opted in.
 	GCEnabled *bool `json:"GCEnabled" mapstructure:"gc_enabled"`
+
+	// WALBaseDir puts every volume's WAL under this directory instead of the
+	// node's base_dir. A WAL fsync shares the device queue with everything
+	// else on the node, so giving it its own device keeps neighbouring IO out
+	// of its tail. Empty keeps the WAL under base_dir.
+	WALBaseDir string `json:"WALBaseDir" mapstructure:"wal_base_dir"`
 }
 
 // EBS provider selectors. Viperblockd routes EBS calls to the viperblockd

--- a/spinifex/nbd/nbd.go
+++ b/spinifex/nbd/nbd.go
@@ -30,6 +30,7 @@ type NBDKitConfig struct {
 	AccessKey  string `json:"access_key"`
 	SecretKey  string `json:"secret_key"`
 	BaseDir    string `json:"base_dir"`
+	WALBaseDir string `json:"wal_base_dir"`
 	Host       string `json:"host"`
 	CacheSize  int    `json:"cache_size"`
 	ShardWAL   bool   `json:"shardwal"` // Enable sharded WAL (default false)
@@ -124,6 +125,10 @@ func (cfg *NBDKitConfig) buildArgs() ([]string, error) {
 		fmt.Sprintf("shardwal=%t", cfg.ShardWAL),
 		fmt.Sprintf("gc_enabled=%t", cfg.GCEnabled),
 	}
+	if cfg.WALBaseDir != "" {
+		pluginArgs = append(pluginArgs, fmt.Sprintf("wal_base_dir=%s", cfg.WALBaseDir))
+	}
+
 	// Only forward the key when configured; an empty value would explicitly
 	// set the plugin to cleartext and override its ENCRYPTION_KEY_FILE fallback.
 	if cfg.EncryptionKeyFile != "" {

--- a/spinifex/nbd/wal_base_dir_test.go
+++ b/spinifex/nbd/wal_base_dir_test.go
@@ -1,0 +1,56 @@
+package nbd
+
+import (
+	"slices"
+	"testing"
+)
+
+// baseNBDKitConfig is the minimum a plugin invocation needs, so the tests below
+// vary only WALBaseDir.
+func baseNBDKitConfig() *NBDKitConfig {
+	return &NBDKitConfig{
+		UseTCP:     true,
+		Port:       10809,
+		PidFile:    "/tmp/nbd.pid",
+		PluginPath: "/usr/lib/nbdkit/plugins/vb.so",
+		Size:       1 << 30,
+		Volume:     "vol-abc123",
+		Bucket:     "my-bucket",
+		Region:     "us-east-1",
+		BaseDir:    "/data",
+		Host:       "localhost:9000",
+		CacheSize:  256,
+	}
+}
+
+// TestBuildArgsForwardsWALBaseDir pins that a node configured for a separate
+// WAL device passes it to the plugin. The plugin backs every mounted volume,
+// so without this the setting reaches only the short-lived control-plane VBs
+// and misses exactly the volumes whose fsync latency it exists to protect.
+func TestBuildArgsForwardsWALBaseDir(t *testing.T) {
+	cfg := baseNBDKitConfig()
+	cfg.WALBaseDir = "/wal"
+
+	args, err := cfg.buildArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Contains(args, "wal_base_dir=/wal") {
+		t.Errorf("wal_base_dir not forwarded to the plugin: %v", args)
+	}
+}
+
+// TestBuildArgsOmitsAnUnsetWALBaseDir pins that an unset value is absent
+// rather than empty. The plugin reads an empty wal_base_dir as an explicit
+// choice, which would override its own "same as base_dir" default.
+func TestBuildArgsOmitsAnUnsetWALBaseDir(t *testing.T) {
+	args, err := baseNBDKitConfig().buildArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, a := range args {
+		if a == "wal_base_dir=" {
+			t.Errorf("an unset WALBaseDir must be omitted, not passed empty: %v", args)
+		}
+	}
+}

--- a/spinifex/services/viperblockd/provider_handlers.go
+++ b/spinifex/services/viperblockd/provider_handlers.go
@@ -427,6 +427,7 @@ func buildProviderVBConfig(cfg *Config, volumeID string, volumeSizeBytes uint64,
 		MasterKey:         cfg.masterKey,
 		EncryptionEnabled: cfg.masterKey != nil,
 		GCEnabled:         cfg.GCEnabled,
+		WALBaseDir:        cfg.WALBaseDir,
 	}
 	if sourceSnapshotID != "" {
 		vbconfig.SnapshotID = sourceSnapshotID
@@ -1457,6 +1458,7 @@ func mountVolume(ctx context.Context, cfg *Config, nc *nats.Conn, volumeName str
 		CacheSize:         nbdCacheSize,
 		ShardWAL:          cfg.ShardWAL,
 		GCEnabled:         cfg.GCEnabled,
+		WALBaseDir:        cfg.WALBaseDir,
 		EncryptionKeyFile: cfg.EncryptionKeyFile,
 		ReadOnly:          readOnly,
 		Threads:           cfg.Threads,

--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -163,6 +163,11 @@ type Config struct {
 	// Default false, matching ShardWAL.
 	GCEnabled bool
 
+	// WALBaseDir puts every volume's WAL under this directory instead of
+	// BaseDir, so a WAL fsync is not queued behind the node's other IO.
+	// Empty keeps the WAL under BaseDir.
+	WALBaseDir string
+
 	// EncryptionKeyFile is the path to the shared AES-256 master key for at-rest
 	// encryption. Empty → cleartext mode (legacy).
 	EncryptionKeyFile string
@@ -372,6 +377,7 @@ func volumeVBConfig(cfg *Config, volumeName string) (viperblock.VB, s3.S3Config)
 		VolumeName:        volumeName,
 		VolumeSize:        1, // Recalculated on LoadState.
 		BaseDir:           cfg.BaseDir,
+		WALBaseDir:        cfg.WALBaseDir,
 		VolumeConfig:      viperblock.VolumeConfig{},
 		MasterKey:         cfg.masterKey,
 		EncryptionEnabled: cfg.masterKey != nil,

--- a/spinifex/services/viperblockd/wal_base_dir_test.go
+++ b/spinifex/services/viperblockd/wal_base_dir_test.go
@@ -1,0 +1,25 @@
+package viperblockd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVolumeVBConfigCarriesWALBaseDir pins that the short-lived VBs the
+// service opens honour the node's WAL device choice, so a volume's WAL is in
+// one place regardless of which code path opened it.
+func TestVolumeVBConfigCarriesWALBaseDir(t *testing.T) {
+	cfg := &Config{BaseDir: "/tmp/vb-base", WALBaseDir: "/wal"}
+
+	vbconfig, _ := volumeVBConfig(cfg, "vol-1")
+	assert.Equal(t, "/tmp/vb-base", vbconfig.BaseDir)
+	assert.Equal(t, "/wal", vbconfig.WALBaseDir)
+}
+
+// TestVolumeVBConfigLeavesWALBaseDirUnsetByDefault pins the no-op default:
+// viperblock reads an empty WALBaseDir as "same as BaseDir".
+func TestVolumeVBConfigLeavesWALBaseDirUnsetByDefault(t *testing.T) {
+	vbconfig, _ := volumeVBConfig(&Config{BaseDir: "/tmp/vb-base"}, "vol-1")
+	assert.Empty(t, vbconfig.WALBaseDir)
+}


### PR DESCRIPTION
Pairs with viperblock #94, which adds the `WALBaseDir` this configures.

## Why

A WAL fsync shares the device queue with predastore, the chunk cache and every other volume on the node. Measured on the e2e stack, competing filesystem traffic alone moves fsync p99 from 4.7 ms to 22 ms with no change to viperblock at all, and an idle fsync there already costs 3.1 ms against etcd's 10 ms p99 budget. Four different WAL append designs measure identically, so the tail is the device queue rather than anything about how the WAL is written. etcd documents a dedicated disk for the same reason.

## What

`wal_base_dir` under `[nodes.<node>.viperblock]`. Unset keeps the WAL under `base_dir`, so this is a no-op for existing deployments.

It reaches both paths that open a volume:

- the short-lived VBs the service opens, via `volumeVBConfig`
- the nbdkit plugin backing each mounted volume, via a `wal_base_dir=` argv entry

The second matters most: without it the setting would reach only the control-plane VBs and miss exactly the volumes whose fsync latency it exists to protect. The argv entry is omitted rather than passed empty when unset, because the plugin reads an empty value as an explicit choice that would override its own default.