### PR TITLE
fix: pin viperblock for WALBaseDir, dev is currently broken

### DIFF
--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -386,6 +386,7 @@ var viperblockStartCmd = &cobra.Command{
 			NodeName:          clusterConfig.Node,
 			ShardWAL:          shardWAL,
 			GCEnabled:         gcEnabled,
+			WALBaseDir:        nodeConfig.Viperblock.WALBaseDir,
 			EncryptionKeyFile: encryptionKeyFile,
 			Threads:           nodeConfig.EBS.ResolvedThreads(),
 			CacheSizeMB:       nodeConfig.EBS.ResolvedCacheSizeMB(),

--- a/cmd/spinifex/cmd/templates/spinifex.toml
+++ b/cmd/spinifex/cmd/templates/spinifex.toml
@@ -118,6 +118,14 @@ token = "{{.NatsToken}}"
 [nodes.{{.Node}}.viperblock]
 shardwal = false
 gc_enabled = true
+#
+# wal_base_dir: put every volume's WAL under this directory instead of the
+# node's base_dir. A WAL fsync shares the device queue with predastore, the
+# chunk cache and every other volume on the node, so a busy node lengthens the
+# fsync tail that a datastore guest measures as its commit latency. Pointing
+# this at its own device keeps that traffic out of the WAL's queue. Unset
+# keeps the WAL under base_dir.
+#wal_base_dir = "/var/lib/spinifex-wal"
 {{- if .EncryptionKeyFile}}
 encryption_key_file = "{{.EncryptionKeyFile}}"
 {{- end}}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mulgadc/bluebottle v1.18.1-0.20260903003911-3d26c3a8def8
 	github.com/mulgadc/northstar v1.18.1-0.20260903173023-a0e741e2831f
 	github.com/mulgadc/predastore v1.18.1-0.20260831064140-ff6a1dc42441
-	github.com/mulgadc/viperblock v1.18.0
+	github.com/mulgadc/viperblock v1.18.1-0.20260907113913-8215aa76e262
 	github.com/nats-io/nats-server/v2 v2.14.6
 	github.com/nats-io/nats.go v1.53.1
 	github.com/opencontainers/runtime-spec v1.3.0
@@ -63,10 +63,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.19 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.10.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.11.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.41 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.108.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.20.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.110.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.36.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -564,6 +564,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.19 h1:bAdDl/
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.19/go.mod h1:KaUzbLxv4CeSxh6ZCl9B4m7CuFenS8kUEaDs+f/DQr4=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.10.0 h1:U8/A0RRBaEspzH1uul3JHLbypXwEGUkRkvoT9f0ATcM=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.10.0/go.mod h1:UELStX5KwtJNtQxa+UuF8dc3z4UYc40e8yHYJSozNwY=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.11.1 h1:s67hBfG5t9rn1NCvDuB4E3QIep3UFhHPtaIqFDjV3N8=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.11.1/go.mod h1:FpvjBMXtSNMLPmDJsWwcY5cRnqJlpS2y1R6n4pvzs4k=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.23/go.mod h1:9uPh+Hrz2Vn6oMnQYiUi/zbh3ovbnQk19YKINkQny44=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.2/go.mod h1:Ru7vg1iQ7cR4i7SZ/JTLYN9kaXtbL69UdgG0OQWQxW0=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15/go.mod h1:SwFBy2vjtA0vZbjjaFtfN045boopadnoVPhu4Fv66vY=
@@ -571,8 +573,12 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1 h1:RmmWQPREQ
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1/go.mod h1:0A3W4F+68ZnNk5XcNL/e9HFMwnP8RlEicFfy6eOEDyw=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.41 h1:Q9DIKDuJix/oJnQxFpQ26L0EwVa/YNo4k2kbktrjQjE=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.41/go.mod h1:x+TuqkOIG1SZS0+yN54sExGA9ZpjhPO6vPdYnpTFX1M=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.20.1 h1:ZMbtPZZQRca+3+XYQne9PBvRiYpHZlNJJOZfE9WNfT0=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.20.1/go.mod h1:YAGWQdCYlVCoqrzvfv3RLxO6zKwti7gsAULOGWPLYv4=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.108.0 h1:Yp+x5PKXEmoqHsgP/pAkBy5Tyq1UlXAzM0OInh0vxWw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.108.0/go.mod h1:locV6DtXyp7Xzr2BG6jtsbeBi3YAWJ/CY4xUThYmIwQ=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.110.0 h1:He8vaTTqAAJrux/KdpjFXNWueLJZyKqE49QEXoqAu4I=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.110.0/go.mod h1:CUr46sCpGAg/rHaclRyhJX0LJAmH73uWSJPPSaMUrSk=
 github.com/aws/aws-sdk-go-v2/service/signin v1.8.0 h1:bSvKIoLuRGFqGwASgeCQncCJDi9YKKBDEmCEZzOX1uU=
 github.com/aws/aws-sdk-go-v2/service/signin v1.8.0/go.mod h1:9IqUlsJDbUPcg6cgx3WEzXdjrbWzLDQrak0aaSqlTcI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.3/go.mod h1:jtLIhd+V+lft6ktxpItycqHqiVXrPIRjWIsFIlzMriw=
@@ -1335,6 +1341,8 @@ github.com/mulgadc/predastore v1.18.1-0.20260831064140-ff6a1dc42441 h1:5t+iuKpnR
 github.com/mulgadc/predastore v1.18.1-0.20260831064140-ff6a1dc42441/go.mod h1:ioGP2kHWYpW/opboAqlqQ5C2Jv+a1/z4txtenw7K7Ws=
 github.com/mulgadc/viperblock v1.18.0 h1:u6yu5lPfZ+RSmfzlg1OXI3whlRBnGp8t685xUzzxlns=
 github.com/mulgadc/viperblock v1.18.0/go.mod h1:OjqMFZba0TJl9zcW2oKmz2/MrApIxRIFNcafiv5vTkM=
+github.com/mulgadc/viperblock v1.18.1-0.20260907113913-8215aa76e262 h1:EzQREEFyuiqh3jqjTOCvNh0Bw0RJ3wDfFaoXJzv1lSc=
+github.com/mulgadc/viperblock v1.18.1-0.20260907113913-8215aa76e262/go.mod h1:zsXuTpChwa4CQ12aOs2hF43ptZs9CHy4CQDR5Rmk6SY=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -173,6 +173,12 @@ type ViperblockConfig struct {
 	// volume service. Default false when nil so existing deployments keep
 	// today's behavior until explicitly opted in.
 	GCEnabled *bool `json:"GCEnabled" mapstructure:"gc_enabled"`
+
+	// WALBaseDir puts every volume's WAL under this directory instead of the
+	// node's base_dir. A WAL fsync shares the device queue with everything
+	// else on the node, so giving it its own device keeps neighbouring IO out
+	// of its tail. Empty keeps the WAL under base_dir.
+	WALBaseDir string `json:"WALBaseDir" mapstructure:"wal_base_dir"`
 }
 
 // EBS provider selectors. Viperblockd routes EBS calls to the viperblockd

--- a/spinifex/nbd/nbd.go
+++ b/spinifex/nbd/nbd.go
@@ -30,6 +30,7 @@ type NBDKitConfig struct {
 	AccessKey  string `json:"access_key"`
 	SecretKey  string `json:"secret_key"`
 	BaseDir    string `json:"base_dir"`
+	WALBaseDir string `json:"wal_base_dir"`
 	Host       string `json:"host"`
 	CacheSize  int    `json:"cache_size"`
 	ShardWAL   bool   `json:"shardwal"` // Enable sharded WAL (default false)
@@ -124,6 +125,10 @@ func (cfg *NBDKitConfig) buildArgs() ([]string, error) {
 		fmt.Sprintf("shardwal=%t", cfg.ShardWAL),
 		fmt.Sprintf("gc_enabled=%t", cfg.GCEnabled),
 	}
+	if cfg.WALBaseDir != "" {
+		pluginArgs = append(pluginArgs, fmt.Sprintf("wal_base_dir=%s", cfg.WALBaseDir))
+	}
+
 	// Only forward the key when configured; an empty value would explicitly
 	// set the plugin to cleartext and override its ENCRYPTION_KEY_FILE fallback.
 	if cfg.EncryptionKeyFile != "" {

--- a/spinifex/nbd/wal_base_dir_test.go
+++ b/spinifex/nbd/wal_base_dir_test.go
@@ -1,0 +1,56 @@
+package nbd
+
+import (
+	"slices"
+	"testing"
+)
+
+// baseNBDKitConfig is the minimum a plugin invocation needs, so the tests below
+// vary only WALBaseDir.
+func baseNBDKitConfig() *NBDKitConfig {
+	return &NBDKitConfig{
+		UseTCP:     true,
+		Port:       10809,
+		PidFile:    "/tmp/nbd.pid",
+		PluginPath: "/usr/lib/nbdkit/plugins/vb.so",
+		Size:       1 << 30,
+		Volume:     "vol-abc123",
+		Bucket:     "my-bucket",
+		Region:     "us-east-1",
+		BaseDir:    "/data",
+		Host:       "localhost:9000",
+		CacheSize:  256,
+	}
+}
+
+// TestBuildArgsForwardsWALBaseDir pins that a node configured for a separate
+// WAL device passes it to the plugin. The plugin backs every mounted volume,
+// so without this the setting reaches only the short-lived control-plane VBs
+// and misses exactly the volumes whose fsync latency it exists to protect.
+func TestBuildArgsForwardsWALBaseDir(t *testing.T) {
+	cfg := baseNBDKitConfig()
+	cfg.WALBaseDir = "/wal"
+
+	args, err := cfg.buildArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Contains(args, "wal_base_dir=/wal") {
+		t.Errorf("wal_base_dir not forwarded to the plugin: %v", args)
+	}
+}
+
+// TestBuildArgsOmitsAnUnsetWALBaseDir pins that an unset value is absent
+// rather than empty. The plugin reads an empty wal_base_dir as an explicit
+// choice, which would override its own "same as base_dir" default.
+func TestBuildArgsOmitsAnUnsetWALBaseDir(t *testing.T) {
+	args, err := baseNBDKitConfig().buildArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, a := range args {
+		if a == "wal_base_dir=" {
+			t.Errorf("an unset WALBaseDir must be omitted, not passed empty: %v", args)
+		}
+	}
+}

--- a/spinifex/services/viperblockd/provider_handlers.go
+++ b/spinifex/services/viperblockd/provider_handlers.go
@@ -427,6 +427,7 @@ func buildProviderVBConfig(cfg *Config, volumeID string, volumeSizeBytes uint64,
 		MasterKey:         cfg.masterKey,
 		EncryptionEnabled: cfg.masterKey != nil,
 		GCEnabled:         cfg.GCEnabled,
+		WALBaseDir:        cfg.WALBaseDir,
 	}
 	if sourceSnapshotID != "" {
 		vbconfig.SnapshotID = sourceSnapshotID
@@ -1457,6 +1458,7 @@ func mountVolume(ctx context.Context, cfg *Config, nc *nats.Conn, volumeName str
 		CacheSize:         nbdCacheSize,
 		ShardWAL:          cfg.ShardWAL,
 		GCEnabled:         cfg.GCEnabled,
+		WALBaseDir:        cfg.WALBaseDir,
 		EncryptionKeyFile: cfg.EncryptionKeyFile,
 		ReadOnly:          readOnly,
 		Threads:           cfg.Threads,

--- a/spinifex/services/viperblockd/provider_handlers.go
+++ b/spinifex/services/viperblockd/provider_handlers.go
@@ -1259,6 +1259,7 @@ func constructMountedVB(ctx context.Context, cfg *Config, volumeName string) (*v
 		VolumeName: volumeName,
 		VolumeSize: 1, // Workaround, calculated on LoadState()
 		BaseDir:    cfg.BaseDir,
+		WALBaseDir: cfg.WALBaseDir,
 		Cache: viperblock.Cache{
 			Config: viperblock.CacheConfig{
 				Size: defaultCache,

--- a/spinifex/services/viperblockd/provider_handlers_test.go
+++ b/spinifex/services/viperblockd/provider_handlers_test.go
@@ -716,12 +716,13 @@ func TestProviderErrorConstructors(t *testing.T) {
 // AvailabilityZone) staying out of VolumeMetadata, and the SnapshotID/
 // SourceVolumeName fields only being set when a source snapshot is given.
 func TestBuildProviderVBConfig(t *testing.T) {
-	cfg := &Config{BaseDir: "/tmp/vb-base", GCEnabled: true}
+	cfg := &Config{BaseDir: "/tmp/vb-base", WALBaseDir: "/wal", GCEnabled: true}
 
 	vbconfig := buildProviderVBConfig(cfg, "vol-1", 8<<30, "", "")
 	assert.Equal(t, "vol-1", vbconfig.VolumeName)
 	assert.Equal(t, uint64(8<<30), vbconfig.VolumeSize)
 	assert.Equal(t, "/tmp/vb-base", vbconfig.BaseDir)
+	assert.Equal(t, "/wal", vbconfig.WALBaseDir)
 	assert.True(t, vbconfig.GCEnabled)
 	assert.Empty(t, vbconfig.VolumeConfig.VolumeMetadata.TenantID, "control-plane facts must not be set here")
 	assert.Empty(t, vbconfig.SnapshotID)

--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -163,6 +163,11 @@ type Config struct {
 	// Default false, matching ShardWAL.
 	GCEnabled bool
 
+	// WALBaseDir puts every volume's WAL under this directory instead of
+	// BaseDir, so a WAL fsync is not queued behind the node's other IO.
+	// Empty keeps the WAL under BaseDir.
+	WALBaseDir string
+
 	// EncryptionKeyFile is the path to the shared AES-256 master key for at-rest
 	// encryption. Empty → cleartext mode (legacy).
 	EncryptionKeyFile string
@@ -372,6 +377,7 @@ func volumeVBConfig(cfg *Config, volumeName string) (viperblock.VB, s3.S3Config)
 		VolumeName:        volumeName,
 		VolumeSize:        1, // Recalculated on LoadState.
 		BaseDir:           cfg.BaseDir,
+		WALBaseDir:        cfg.WALBaseDir,
 		VolumeConfig:      viperblock.VolumeConfig{},
 		MasterKey:         cfg.masterKey,
 		EncryptionEnabled: cfg.masterKey != nil,

--- a/spinifex/services/viperblockd/wal_base_dir_test.go
+++ b/spinifex/services/viperblockd/wal_base_dir_test.go
@@ -1,0 +1,25 @@
+package viperblockd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVolumeVBConfigCarriesWALBaseDir pins that the short-lived VBs the
+// service opens honour the node's WAL device choice, so a volume's WAL is in
+// one place regardless of which code path opened it.
+func TestVolumeVBConfigCarriesWALBaseDir(t *testing.T) {
+	cfg := &Config{BaseDir: "/tmp/vb-base", WALBaseDir: "/wal"}
+
+	vbconfig, _ := volumeVBConfig(cfg, "vol-1")
+	assert.Equal(t, "/tmp/vb-base", vbconfig.BaseDir)
+	assert.Equal(t, "/wal", vbconfig.WALBaseDir)
+}
+
+// TestVolumeVBConfigLeavesWALBaseDirUnsetByDefault pins the no-op default:
+// viperblock reads an empty WALBaseDir as "same as BaseDir".
+func TestVolumeVBConfigLeavesWALBaseDirUnsetByDefault(t *testing.T) {
+	vbconfig, _ := volumeVBConfig(&Config{BaseDir: "/tmp/vb-base"}, "vol-1")
+	assert.Empty(t, vbconfig.WALBaseDir)
+}


### PR DESCRIPTION
## Summary
PR #1010 merged `wal_base_dir` wiring that references `viperblock.VB.WALBaseDir`, but never bumped `go.mod` off `viperblock v1.18.0`, which predates that field. **`dev` does not currently build**:

```
spinifex/services/viperblockd/provider_handlers.go:430:3: unknown field WALBaseDir in struct literal of type viperblock.VB
spinifex/services/viperblockd/viperblockd.go:380:3: unknown field WALBaseDir in struct literal of type viperblock.VB
```//

This PR:
- Pins `go.mod`/`go.sum` to `github.com/mulgadc/viperblock v1.18.1-0.20260907113913-8215aa76e262`, a pseudo-version off the `feat/wal-base-dir` branch (commit `8215aa76e262`) that carries the `WALBaseDir` field. That branch is not yet merged to viperblock's `dev` — [viperblock#94](https://github.com/mulgadc/viperblock/pull/94) — so there is no tagged release to depend on yet. **Follow-up needed**: bump to a real release once #94 merges and is tagged.
- Adds the `WALBaseDir` wiring that #1010 missed in `constructMountedVB` (`spinifex/services/viperblockd/provider_handlers.go`), the VB literal shared by `mountVolume` and startup recovery. Without it, a mounted volume's WAL stayed on `BaseDir` regardless of `wal_base_dir` — the one code path that actually backs a live guest's writes.
- Extends `TestBuildProviderVBConfig` to assert `WALBaseDir` flows through `buildProviderVBConfig`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./spinifex/config/... ./spinifex/services/viperblockd/... ./spinifex/nbd/... ./cmd/spinifex/cmd/...`
- [x] `go test ./...` (full run passes; pre-existing unrelated failures in `cmd/ecr-credential-provider`, `cmd/ecs-agent`, `cmd/eks-*`, `cmd/rds-agent` are a FIPS-boot panic requiring `GOFIPS140`, not caused by this change)
- [x] `make preflight`