### PR TITLE
fix: invalidate the host ARP entry when a management IP is released

### DIFF
--- a/.github/actions/e2e-analyze/analyze.go
+++ b/.github/actions/e2e-analyze/analyze.go
@@ -134,18 +134,16 @@ var cascadeMarkers = []string{
 	"Expected value not to be nil",
 }
 
-// nonFailurePatterns match content a test emits AFTER the assertion that failed:
-// t.Cleanup and harness diagnostics, and a t.Logf on a passing branch of a loop
-// whose earlier iteration called t.Errorf. Both are the LAST file:line lines in
-// the body, so extractErrorLine's keep-the-last rule picks them over the
-// assertion unless they are skipped. Go emits t.Logf and t.Errorf identically,
-// so nothing in the body distinguishes them — this is an anchored allowlist, not
-// a general rule, and a fragment loose enough to match an assertion would blank
-// out the one line the report exists to show.
+// nonFailurePatterns match content a test emits AFTER the assertion that failed
+// — t.Cleanup, harness diagnostics, or a t.Logf on a passing branch — which
+// extractErrorLine's keep-the-last rule would otherwise pick over the assertion.
+// Go emits t.Logf and t.Errorf identically, so anchor every entry: a fragment
+// loose enough to match an assertion blanks out the line the report exists to
+// show. `\bas expected\b` unanchored also matches "did not fail as expected".
 var nonFailurePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^DB instance \S+ is gone$`),
 	regexp.MustCompile(`^db diagnostics \S+:`),
-	regexp.MustCompile(`\bas expected\b`),
+	regexp.MustCompile(`^\S+: management bridge \S+:\d+ refused as expected$`),
 }
 
 // isNonFailureLine reports whether a candidate error line was emitted after the
@@ -299,15 +297,23 @@ func extractFileHint(body string) string {
 	}
 	// Scanned line by line rather than across the body so a cleanup line's own
 	// file:line does not become the site the report points a reader at.
-	hint := ""
+	hint, filtered := "", ""
 	for _, raw := range strings.Split(body, "\n") {
 		l := strings.TrimSpace(raw)
-		if m := goFileLineRe.FindStringSubmatch(l); m != nil && isNonFailureLine(strings.TrimSpace(m[1])) {
+		all := fileHintRe.FindAllString(l, -1)
+		if len(all) == 0 {
 			continue
 		}
-		if all := fileHintRe.FindAllString(l, -1); len(all) > 0 {
-			hint = all[len(all)-1]
+		if m := goFileLineRe.FindStringSubmatch(l); m != nil && isNonFailureLine(strings.TrimSpace(m[1])) {
+			filtered = all[len(all)-1]
+			continue
 		}
+		hint = all[len(all)-1]
+	}
+	// A body whose only file:line was allowlisted still gets a pointer: coarse
+	// beats none, and extractErrorLine has the same last-resort shape.
+	if hint == "" {
+		return filtered
 	}
 	return hint
 }

--- a/.github/actions/e2e-analyze/analyze.go
+++ b/.github/actions/e2e-analyze/analyze.go
@@ -134,21 +134,24 @@ var cascadeMarkers = []string{
 	"Expected value not to be nil",
 }
 
-// teardownPatterns match the content a test logs from t.Cleanup or from the
-// harness's on-failure diagnostics — i.e. after it has already failed. They are
-// the LAST file:line lines in the failure body, so extractErrorLine's
-// keep-the-last rule picks them over the assertion unless they are skipped.
-// Anchored deliberately: a fragment loose enough to match an assertion would
-// blank out the one line the report exists to show.
-var teardownPatterns = []*regexp.Regexp{
+// nonFailurePatterns match content a test emits AFTER the assertion that failed:
+// t.Cleanup and harness diagnostics, and a t.Logf on a passing branch of a loop
+// whose earlier iteration called t.Errorf. Both are the LAST file:line lines in
+// the body, so extractErrorLine's keep-the-last rule picks them over the
+// assertion unless they are skipped. Go emits t.Logf and t.Errorf identically,
+// so nothing in the body distinguishes them — this is an anchored allowlist, not
+// a general rule, and a fragment loose enough to match an assertion would blank
+// out the one line the report exists to show.
+var nonFailurePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^DB instance \S+ is gone$`),
 	regexp.MustCompile(`^db diagnostics \S+:`),
+	regexp.MustCompile(`\bas expected\b`),
 }
 
-// isTeardownLine reports whether a candidate error line was emitted after the
-// failure it would otherwise be mistaken for.
-func isTeardownLine(content string) bool {
-	for _, re := range teardownPatterns {
+// isNonFailureLine reports whether a candidate error line was emitted after the
+// failure it would otherwise be mistaken for, or reports an expected outcome.
+func isNonFailureLine(content string) bool {
+	for _, re := range nonFailurePatterns {
 		if re.MatchString(content) {
 			return true
 		}
@@ -245,12 +248,12 @@ func extractErrorLine(body string) string {
 			// progress lines from the same file:line pattern before the
 			// failing assertion finally fires. Cleanup runs after it, though,
 			// so its lines are last of all and have to be skipped.
-			if content := strings.TrimSpace(m[1]); !isTeardownLine(content) {
+			if content := strings.TrimSpace(m[1]); !isNonFailureLine(content) {
 				goFileLine = content
 			}
 			continue
 		}
-		if fileHintRe.MatchString(l) && !isTeardownLine(l) {
+		if fileHintRe.MatchString(l) && !isNonFailureLine(l) {
 			lastTestLine = l
 		}
 	}
@@ -299,7 +302,7 @@ func extractFileHint(body string) string {
 	hint := ""
 	for _, raw := range strings.Split(body, "\n") {
 		l := strings.TrimSpace(raw)
-		if m := goFileLineRe.FindStringSubmatch(l); m != nil && isTeardownLine(strings.TrimSpace(m[1])) {
+		if m := goFileLineRe.FindStringSubmatch(l); m != nil && isNonFailureLine(strings.TrimSpace(m[1])) {
 			continue
 		}
 		if all := fileHintRe.FindAllString(l, -1); len(all) > 0 {

--- a/.github/actions/e2e-analyze/analyze_test.go
+++ b/.github/actions/e2e-analyze/analyze_test.go
@@ -156,6 +156,31 @@ func TestExtractErrorLine_SkipsSuccessLoggedAfterTheFailure(t *testing.T) {
 	}
 }
 
+// "as expected" reads the same in an affirmation and in its negation, so an
+// unanchored pattern suppresses the assertion it was meant to outrank and
+// promotes a harness progress line in its place.
+func TestExtractErrorLine_KeepsNegatedExpectationAssertions(t *testing.T) {
+	body := `    isolation_test.go:60: waiting for the db instance to become available
+    isolation_test.go:80: rds-e2e-iso-a: management bridge 10.15.8.10:5432 was not refused as expected: got a connection`
+	got := extractErrorLine(body)
+	if !strings.Contains(got, "was not refused as expected") {
+		t.Errorf("extractErrorLine = %q, want the assertion at isolation_test.go:80", got)
+	}
+	if hint := extractFileHint(body); hint != "isolation_test.go:80" {
+		t.Errorf("extractFileHint = %q, want isolation_test.go:80", hint)
+	}
+}
+
+// Every candidate allowlisted leaves extractFileHint with nothing to return,
+// and unlike extractErrorLine it has no last-resort branch. A coarse pointer
+// beats sending the reader to no file at all.
+func TestExtractFileHint_FallsBackWhenEveryCandidateFiltered(t *testing.T) {
+	body := `    isolation_test.go:84: rds-e2e-iso-b: management bridge 10.15.8.11:5432 refused as expected`
+	if hint := extractFileHint(body); hint != "isolation_test.go:84" {
+		t.Errorf("extractFileHint = %q, want isolation_test.go:84", hint)
+	}
+}
+
 func TestExtractFileHint_PicksLastMatch(t *testing.T) {
 	body := "ec2helpers.go:50: setup\n    vpc_test.go:227: Eventually: condition not met"
 	got := extractFileHint(body)

--- a/.github/actions/e2e-analyze/analyze_test.go
+++ b/.github/actions/e2e-analyze/analyze_test.go
@@ -141,6 +141,21 @@ func TestExtractErrorLine_SkipsCleanupLoggedAfterTheFailure(t *testing.T) {
 	}
 }
 
+// A subtest looping over two subjects calls t.Errorf for the first and t.Logf
+// for the second, so the success line is last in the body. Nightly run
+// 34383800404 reported that log line as the failure.
+func TestExtractErrorLine_SkipsSuccessLoggedAfterTheFailure(t *testing.T) {
+	body := `    isolation_test.go:80: rds-e2e-iso-a-1788981456: management bridge 10.15.8.10:5432 could not be tested: want connection refused, got dial tcp 10.15.8.10:5432: i/o timeout
+    isolation_test.go:84: rds-e2e-iso-b-1788981456: management bridge 10.15.8.11:5432 refused as expected`
+	got := extractErrorLine(body)
+	if !strings.Contains(got, "could not be tested") {
+		t.Errorf("extractErrorLine = %q, want the assertion at isolation_test.go:80", got)
+	}
+	if hint := extractFileHint(body); hint != "isolation_test.go:80" {
+		t.Errorf("extractFileHint = %q, want isolation_test.go:80", hint)
+	}
+}
+
 func TestExtractFileHint_PicksLastMatch(t *testing.T) {
 	body := "ec2helpers.go:50: setup\n    vpc_test.go:227: Eventually: condition not met"
 	got := extractFileHint(body)

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1335,10 +1335,7 @@ func (d *Daemon) startLocal() error {
 	}
 
 	// Detect management bridge for system instance control plane NICs.
-	mgmtBridge := "br-mgmt"
-	if d.config.Daemon.MgmtBridge != "" {
-		mgmtBridge = d.config.Daemon.MgmtBridge
-	}
+	mgmtBridge := d.mgmtBridgeName()
 	bridgeIP, bridgeErr := host.GetBridgeIPv4(mgmtBridge)
 	if bridgeErr != nil {
 		slog.Warn("Management bridge not detected, system instances will not get mgmt NIC", "bridge", mgmtBridge, "err", bridgeErr)

--- a/spinifex/daemon/daemon_mgmt_ip.go
+++ b/spinifex/daemon/daemon_mgmt_ip.go
@@ -356,7 +356,9 @@ func (d *Daemon) mgmtBridgeName() string {
 // br-mgmt is one flat L2 segment and the address is re-handed within seconds
 // with a fresh MAC, so a surviving entry blackholes the next holder.
 func (d *Daemon) invalidateMgmtNeigh(instanceID, mgmtIP string) {
-	if mgmtIP == "" {
+	// mgmtBridgeIP is empty when startLocal found no bridge, so there is no
+	// neighbour table to hold a stale entry and `ip neigh` would only ENODEV.
+	if mgmtIP == "" || d.mgmtBridgeIP == "" {
 		return
 	}
 	bridge := d.mgmtBridgeName()

--- a/spinifex/daemon/daemon_mgmt_ip.go
+++ b/spinifex/daemon/daemon_mgmt_ip.go
@@ -1,12 +1,15 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/network/host"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -325,4 +328,58 @@ func (a *MgmtIPAllocator) AllocatedCount() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return len(a.allocated)
+}
+
+// defaultMgmtBridge is the management bridge assumed when config names none.
+const defaultMgmtBridge = "br-mgmt"
+
+// mgmtNeighTimeout bounds one `ip neigh` invocation. The kernel answers at once;
+// the budget covers a wedged exec, not slow work.
+const mgmtNeighTimeout = 5 * time.Second
+
+// Kernel neighbour-table hooks, indirected so the unit suite can observe them
+// without running `ip neigh` as root. Same idiom as health.go's gateDialFn.
+var (
+	flushMgmtNeigh = host.FlushNeigh
+	primeMgmtNeigh = host.ReplaceNeigh
+)
+
+// mgmtBridgeName returns the configured management bridge, or the default.
+func (d *Daemon) mgmtBridgeName() string {
+	if d.config != nil && d.config.Daemon.MgmtBridge != "" {
+		return d.config.Daemon.MgmtBridge
+	}
+	return defaultMgmtBridge
+}
+
+// invalidateMgmtNeigh drops the host ARP entry for a released management IP.
+// br-mgmt is one flat L2 segment and the address is re-handed within seconds
+// with a fresh MAC, so a surviving entry blackholes the next holder.
+func (d *Daemon) invalidateMgmtNeigh(instanceID, mgmtIP string) {
+	if mgmtIP == "" {
+		return
+	}
+	bridge := d.mgmtBridgeName()
+	ctx, cancel := context.WithTimeout(context.Background(), mgmtNeighTimeout)
+	defer cancel()
+	if err := flushMgmtNeigh(ctx, nil, bridge, mgmtIP); err != nil {
+		slog.Warn("Failed to flush mgmt ARP entry; a recycled address may blackhole until the entry expires",
+			"instanceId", instanceID, "mgmtIP", mgmtIP, "bridge", bridge, "err", err)
+	}
+}
+
+// primeMgmtNeighEntry programs the ARP entry for a freshly assigned management
+// IP. Preferred over relying on the release-side flush alone: the MAC is known
+// here, so the first dial does not race an ARP round trip.
+func (d *Daemon) primeMgmtNeighEntry(instanceID, mgmtIP, mgmtMAC string) {
+	if mgmtIP == "" || mgmtMAC == "" {
+		return
+	}
+	bridge := d.mgmtBridgeName()
+	ctx, cancel := context.WithTimeout(context.Background(), mgmtNeighTimeout)
+	defer cancel()
+	if err := primeMgmtNeigh(ctx, nil, bridge, mgmtIP, mgmtMAC); err != nil {
+		slog.Warn("Failed to prime mgmt ARP entry; the first dial falls back to ARP resolution",
+			"instanceId", instanceID, "mgmtIP", mgmtIP, "mgmtMAC", mgmtMAC, "bridge", bridge, "err", err)
+	}
 }

--- a/spinifex/daemon/daemon_mgmt_ip_test.go
+++ b/spinifex/daemon/daemon_mgmt_ip_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/mulgadc/spinifex/spinifex/config"
+	"github.com/mulgadc/spinifex/spinifex/network/host"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
 )
@@ -615,5 +617,128 @@ func TestMgmtIPAllocator_Allocate_RefusedWhenKVNeverBound(t *testing.T) {
 
 	if _, err := a.Allocate("i-brand-new"); err == nil {
 		t.Fatal("expected allocation to be refused with no KV bound")
+	}
+}
+
+// recordingPlumber satisfies vm.NetworkPlumber for the cleanup-path tests. Only
+// CleanupTap is exercised; the rest are here to satisfy the interface.
+type recordingPlumber struct {
+	cleanedTaps []string
+}
+
+var _ vm.NetworkPlumber = (*recordingPlumber)(nil)
+
+func (p *recordingPlumber) SetupTap(vm.TapSpec) error { return nil }
+func (p *recordingPlumber) CleanupTap(name string) error {
+	p.cleanedTaps = append(p.cleanedTaps, name)
+	return nil
+}
+func (p *recordingPlumber) EnsureIMDSDatapathBridge() error         { return nil }
+func (p *recordingPlumber) AttachIMDSDatapath(_, _, _ string) error { return nil }
+func (p *recordingPlumber) DetachIMDSDatapath(string) error         { return nil }
+func (p *recordingPlumber) EnsureVPCHostPort(_, _, _ string) error  { return nil }
+func (p *recordingPlumber) RemoveVPCHostPort(string) error          { return nil }
+
+// neighCall is one recorded flush or prime.
+type neighCall struct {
+	dev string
+	ip  string
+	mac string
+}
+
+// captureNeighHooks swaps the kernel neighbour hooks for recorders and restores
+// them when the test ends.
+func captureNeighHooks(t *testing.T) (flushed, primed *[]neighCall) {
+	t.Helper()
+	var f, p []neighCall
+	origFlush, origPrime := flushMgmtNeigh, primeMgmtNeigh
+	flushMgmtNeigh = func(_ context.Context, _ host.Runner, dev, ip string) error {
+		f = append(f, neighCall{dev: dev, ip: ip})
+		return nil
+	}
+	primeMgmtNeigh = func(_ context.Context, _ host.Runner, dev, ip, mac string) error {
+		p = append(p, neighCall{dev: dev, ip: ip, mac: mac})
+		return nil
+	}
+	t.Cleanup(func() { flushMgmtNeigh, primeMgmtNeigh = origFlush, origPrime })
+	return &f, &p
+}
+
+// A released address is re-handed within seconds with a different MAC, so the
+// stale entry has to go or the next holder blackholes until the kernel expires
+// it. This is the defect behind the nightly rds isolation failure.
+func TestCleanupMgmtNetwork_FlushesNeighForReleasedAddress(t *testing.T) {
+	flushed, _ := captureNeighHooks(t)
+
+	alloc, err := NewMgmtIPAllocator("10.15.8.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	plumber := &recordingPlumber{}
+	d := &Daemon{networkPlumber: plumber, mgmtIPAllocator: alloc}
+
+	newInstanceCleanerAdapter(d).CleanupMgmtNetwork(&vm.VM{ID: "i-abc", MgmtIP: "10.15.8.10"})
+
+	if len(*flushed) != 1 {
+		t.Fatalf("flush calls = %d, want 1", len(*flushed))
+	}
+	if got := (*flushed)[0]; got.ip != "10.15.8.10" || got.dev != "br-mgmt" {
+		t.Errorf("flushed %+v, want ip 10.15.8.10 on br-mgmt", got)
+	}
+	if len(plumber.cleanedTaps) != 1 {
+		t.Errorf("tap cleanup calls = %d, want 1", len(plumber.cleanedTaps))
+	}
+}
+
+// An instance that never got a mgmt NIC has no address to invalidate, and
+// flushing "" would be an error the operator cannot act on.
+func TestCleanupMgmtNetwork_NoMgmtIPSkipsFlush(t *testing.T) {
+	flushed, _ := captureNeighHooks(t)
+
+	d := &Daemon{networkPlumber: &recordingPlumber{}}
+	newInstanceCleanerAdapter(d).CleanupMgmtNetwork(&vm.VM{ID: "i-abc"})
+
+	if len(*flushed) != 0 {
+		t.Errorf("flush calls = %d, want 0", len(*flushed))
+	}
+}
+
+func TestInvalidateMgmtNeigh_UsesConfiguredBridge(t *testing.T) {
+	flushed, _ := captureNeighHooks(t)
+
+	d := &Daemon{config: &config.Config{}}
+	d.config.Daemon.MgmtBridge = "br-ctrl"
+	d.invalidateMgmtNeigh("i-abc", "10.15.8.10")
+
+	if len(*flushed) != 1 || (*flushed)[0].dev != "br-ctrl" {
+		t.Fatalf("flushed %+v, want one call on br-ctrl", *flushed)
+	}
+}
+
+// The MAC is known at attach time, so the entry is programmed directly rather
+// than left for the first dial to resolve — the same choice the EIP path makes.
+func TestPrimeMgmtNeighEntry_ProgramsAddressAndMAC(t *testing.T) {
+	_, primed := captureNeighHooks(t)
+
+	d := &Daemon{}
+	d.primeMgmtNeighEntry("i-abc", "10.15.8.10", "02:d9:f3:a8:fb:be")
+
+	if len(*primed) != 1 {
+		t.Fatalf("prime calls = %d, want 1", len(*primed))
+	}
+	want := neighCall{dev: "br-mgmt", ip: "10.15.8.10", mac: "02:d9:f3:a8:fb:be"}
+	if (*primed)[0] != want {
+		t.Errorf("primed %+v, want %+v", (*primed)[0], want)
+	}
+}
+
+func TestPrimeMgmtNeighEntry_NoMACIsNoOp(t *testing.T) {
+	_, primed := captureNeighHooks(t)
+
+	d := &Daemon{}
+	d.primeMgmtNeighEntry("i-abc", "10.15.8.10", "")
+
+	if len(*primed) != 0 {
+		t.Errorf("prime calls = %d, want 0", len(*primed))
 	}
 }

--- a/spinifex/daemon/daemon_mgmt_ip_test.go
+++ b/spinifex/daemon/daemon_mgmt_ip_test.go
@@ -675,7 +675,7 @@ func TestCleanupMgmtNetwork_FlushesNeighForReleasedAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 	plumber := &recordingPlumber{}
-	d := &Daemon{networkPlumber: plumber, mgmtIPAllocator: alloc}
+	d := &Daemon{networkPlumber: plumber, mgmtIPAllocator: alloc, mgmtBridgeIP: "10.15.8.1"}
 
 	newInstanceCleanerAdapter(d).CleanupMgmtNetwork(&vm.VM{ID: "i-abc", MgmtIP: "10.15.8.10"})
 
@@ -706,12 +706,26 @@ func TestCleanupMgmtNetwork_NoMgmtIPSkipsFlush(t *testing.T) {
 func TestInvalidateMgmtNeigh_UsesConfiguredBridge(t *testing.T) {
 	flushed, _ := captureNeighHooks(t)
 
-	d := &Daemon{config: &config.Config{}}
+	d := &Daemon{config: &config.Config{}, mgmtBridgeIP: "10.15.8.1"}
 	d.config.Daemon.MgmtBridge = "br-ctrl"
 	d.invalidateMgmtNeigh("i-abc", "10.15.8.10")
 
 	if len(*flushed) != 1 || (*flushed)[0].dev != "br-ctrl" {
 		t.Fatalf("flushed %+v, want one call on br-ctrl", *flushed)
+	}
+}
+
+// startLocal tolerates an absent bridge, and every persisted instance still
+// carries a mgmt IP. Flushing against a device that is not there would warn
+// about a blackhole that cannot happen, on every terminate.
+func TestInvalidateMgmtNeigh_NoBridgeIsNoOp(t *testing.T) {
+	flushed, _ := captureNeighHooks(t)
+
+	d := &Daemon{}
+	d.invalidateMgmtNeigh("i-abc", "10.15.8.10")
+
+	if len(*flushed) != 0 {
+		t.Errorf("flush calls = %d, want 0", len(*flushed))
 	}
 }
 

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -342,10 +342,7 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 
 	// Management NIC: allocate IP, generate MAC, create TAP on br-mgmt
 	if d.mgmtIPAllocator != nil && d.mgmtBridgeIP != "" {
-		mgmtBridge := "br-mgmt"
-		if d.config.Daemon.MgmtBridge != "" {
-			mgmtBridge = d.config.Daemon.MgmtBridge
-		}
+		mgmtBridge := d.mgmtBridgeName()
 
 		mgmtIP, allocErr := d.mgmtIPAllocator.Allocate(instance.ID)
 		if allocErr != nil {
@@ -378,6 +375,7 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 				}
 				slog.Error("LaunchSystemInstance: failed to setup mgmt tap", "instanceId", instance.ID, "err", tapErr)
 			} else {
+				d.primeMgmtNeighEntry(instance.ID, mgmtIP, instance.MgmtMAC)
 				slog.Info("LaunchSystemInstance: mgmt NIC configured",
 					"instanceId", instance.ID, "mgmtIP", mgmtIP, "mgmtMAC", instance.MgmtMAC, "mgmtTap", tapName)
 			}
@@ -571,10 +569,7 @@ func (d *Daemon) attachSystemMgmtNIC(inst *vm.VM) error {
 	if d.mgmtIPAllocator == nil || d.mgmtBridgeIP == "" {
 		return errors.New("sysinstance: management bridge unavailable; system VM would have no route to the daemon")
 	}
-	mgmtBridge := "br-mgmt"
-	if d.config.Daemon.MgmtBridge != "" {
-		mgmtBridge = d.config.Daemon.MgmtBridge
-	}
+	mgmtBridge := d.mgmtBridgeName()
 	mgmtIP, err := d.mgmtIPAllocator.Allocate(inst.ID)
 	if err != nil {
 		return fmt.Errorf("allocate mgmt IP: %w", err)
@@ -588,6 +583,7 @@ func (d *Daemon) attachSystemMgmtNIC(inst *vm.VM) error {
 		inst.MgmtIP = ""
 		return fmt.Errorf("setup mgmt tap: %w", err)
 	}
+	d.primeMgmtNeighEntry(inst.ID, mgmtIP, inst.MgmtMAC)
 	slog.Info("System instance mgmt NIC configured",
 		"instanceId", inst.ID, "mgmtIP", mgmtIP, "mgmtMAC", inst.MgmtMAC, "mgmtTap", tapName)
 	return nil

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -750,14 +750,17 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) error {
 }
 
 // CleanupMgmtNetwork tears down the management TAP device (derived from
-// instance.ID so unsetup instances are tolerated) and releases the
-// management IP allocation if the daemon has one.
+// instance.ID so unsetup instances are tolerated), invalidates the host ARP
+// entry for the address, and releases the management IP allocation.
 func (a *instanceCleanerAdapter) CleanupMgmtNetwork(instance *vm.VM) {
 	mgmtTap := vm.MgmtTapName(instance.ID)
 	if err := a.d.networkPlumber.CleanupTap(mgmtTap); err != nil {
 		slog.Warn("Failed to clean up mgmt tap device",
 			"tap", mgmtTap, "instanceId", instance.ID, "err", err)
 	}
+	// Before Release: once the address is back in the pool the next launch can
+	// take it, and it must not find the terminated instance's MAC still cached.
+	a.d.invalidateMgmtNeigh(instance.ID, instance.MgmtIP)
 	if a.d.mgmtIPAllocator != nil {
 		a.d.mgmtIPAllocator.Release(instance.ID)
 	}


### PR DESCRIPTION
Two fixes from the RCA on E2E Nightly run 34383800404, cell-27 (`single/static/debian-13/rds`).

## 1. Recycled br-mgmt address blackholes the new instance

`MgmtIPAllocator.Release` frees a management address with no cool-down, and `nextFreeIP` scans from `rangeMin`, so the lowest address goes straight back out — 1.45 s after the prior holder terminated in the nightly rds suite, with a freshly generated MAC. Nothing invalidated the kernel neighbour entry for it.

br-mgmt is one flat L2 segment with no ACLs, so any host still holding an entry sent frames to a MAC that was no longer on the bridge, and the address blackholed until the entry expired 60-300 s later.

That is what failed the run: `TestDBVMIsolation/TheEngineIsNotBoundOnTheManagementBridge` got `i/o timeout` instead of `ECONNREFUSED` and failed on an unproven premise. The sibling probe, whose address had been idle for 7.5 minutes, was refused as expected. `10.15.8.10` was recycled 15 times in 45 minutes in that one suite.

This is not test-only: a host holding a stale br-mgmt entry blackholes the recycled VM in production the same way.

**Change** — mirrors the flush-on-detach / prime-on-attach pair the EIP path already has in `network/policy/nat.go`:

- `CleanupMgmtNetwork` flushes the neighbour entry for the address **before** `Release` hands it back to the pool.
- Both mgmt-NIC attach sites prime the entry against the newly generated MAC. Priming is preferred where the MAC is known, for the reason `nat.go` already gives: a flush costs an ARP round trip the datapath can race.
- Both are best-effort and logged at warn — neither can fail a launch or a terminate.
- `mgmtBridgeName()` factors out the `"br-mgmt"`-unless-configured default, previously written out three times.

The hooks are package-level vars over `host.FlushNeigh` / `host.ReplaceNeigh`, following `health.go`'s `gateDialFn` idiom, so the unit suite observes the calls without root.

**Scope.** Local host only. On a multi-node br-mgmt segment remote hosts keep their own stale entries and a local flush cannot reach them — closing that needs the guest to announce itself (gratuitous ARP on boot) and is a separate bead. Single node, where the runner and the host share one neighbour table, is fully covered.

Deliberately **not** changing allocation to round-robin or quarantine addresses: it widens the race rather than closing it, and the flush closes it.

## 2. e2e-analyze reported the success log as the failure

`extractErrorLine` keeps the last `foo.go:NNN:` content line so harness progress logs do not outrank the assertion. The isolation subtest loops over two subjects, calling `t.Errorf` for the first and `t.Logf` for the second, so the success line is last and won under that rule — analysis.md and failure.txt both named `management bridge 10.15.8.11:5432 refused as expected` as the failure, when the real one was the `i/o timeout` on the line above. The signature bucketed on it too, so repeats would not have grouped.

Go emits `t.Logf` and `t.Errorf` identically, so nothing in the body distinguishes them. This widens the existing anchored teardown allowlist to cover a line reporting an expected outcome, and renames it (`isTeardownLine` → `isNonFailureLine`) for what it now does. An allowlist extension, not a general solution, and the comment says so.

## Testing

- `go test ./spinifex/daemon/` — flush on release, prime on attach, configured-bridge override, and the no-mgmt-IP / no-MAC no-ops.
- `go test ./.github/actions/e2e-analyze/` — the errorf-then-logf body yields the `t.Errorf` line and hint; existing teardown and golden cases unchanged.
- `make preflight` passes.
- Acceptance run is nightly cell-27: `TestDBVMIsolation` passes when the address it probes was recycled seconds earlier.