### PR TITLE
fix: remove the JetStream store during a node reset

### DIFF
--- a/scripts/node-reset.sh
+++ b/scripts/node-reset.sh
@@ -217,6 +217,18 @@ if ! $KEEP_DATA && [ -d "$DATA_DIR/predastore/cluster" ]; then
     run sudo rm -rf "$DATA_DIR/predastore/cluster"
 fi
 
+# JetStream needs the same treatment for the same reason, and the consequence of
+# skipping it is worse. Emptying the files leaves a $G/streams/KV_<name> directory
+# per stream the old cluster held; NATS enumerates those on start and reports them
+# as HA assets it must restore, so a four-node meta group sits at size=4 with no
+# leader, elected over hundreds of assets that have no data behind them. Every
+# service then fails to reach JetStream and the daemon aborts its bootstrap.
+# The directory is recreated on start, so its ownership is not installed state.
+if ! $KEEP_DATA && [ -d "$DATA_DIR/nats/jetstream" ]; then
+    log "removing the JetStream store"
+    run sudo rm -rf "$DATA_DIR/nats/jetstream"
+fi
+
 # Directories may survive — a mountpoint cannot be removed, and neither can the
 # path leading down to one. Files may not: a surviving file is state that would
 # carry into the new cluster, which is the exact failure this script exists to


### PR DESCRIPTION
## Summary

`node-reset.sh` wipes files but keeps directories, so every `$G/streams/KV_<name>` directory from the old cluster survived the reset. NATS enumerates those on start and reports them as HA assets it must restore, so the meta group comes up with no leader over hundreds of assets that have no data behind them, every service fails to reach JetStream, and the daemon aborts its bootstrap.

This removes `$DATA_DIR/nats/jetstream` outright when the reset is not keeping data, mirroring the `predastore/cluster` removal directly above it. The directory is recreated on start, so its ownership is not installed state.

## Why it matters

On the 2026-09-11 prod rebuild this left 542 empty `KV_*` directories across the four nodes. The meta group sat at `size=4, leader=None` over 201 phantom assets, the daemons failed with `nats: no responders available`, and formation reported `expected 4 Ready nodes, got 0`. Removing the tree by hand and re-running the reset formed the cluster cleanly.

## Testing

`make preflight` passes. Verified end to end on node1–node4: a full `provision-iso-cluster.sh --force-reset` with this change reached 4 Ready nodes, and the smoke test and workload benchmark both passed.

Bead: mulga-ld3jl