### PR TITLE
fix: repair the three guards protecting a node reset

### DIFF
--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -379,6 +379,32 @@ done
 declare -a WAS_ARMED
 for i in $(seq 0 $((N - 1))); do WAS_ARMED[i]=false; done
 
+# Anything that aborts between here and the re-arm below leaves every node it
+# disarmed open on a public address, and `fail` is called from a dozen places in
+# between. The 2026-09-11 rebuild ended with all four nodes unarmed for exactly
+# that reason: one node failed to restore its own policy, verification failed,
+# and the three that had been disarmed for formation were never put back.
+DISARMED_HOSTS=()
+restore_firewall_on_abort() {
+    local status=$?
+    if [ "$status" -eq 0 ] || [ ${#DISARMED_HOSTS[@]} -eq 0 ]; then
+        return "$status"
+    fi
+    echo ""
+    log "aborting — re-arming the ${#DISARMED_HOSTS[@]} host(s) disarmed for formation"
+    local host
+    for host in "${DISARMED_HOSTS[@]}"; do
+        if on "$host" "sudo systemctl restart spinifex-daemon"; then
+            log "  $host re-armed"
+        else
+            log "  $host: COULD NOT RE-ARM — it is open on its public addresses."
+            log "    Repair: ssh $SSH_USER@$host 'sudo systemctl restart spinifex-daemon'"
+        fi
+    done
+    return "$status"
+}
+trap restore_firewall_on_abort EXIT
+
 if $MANAGE_FIREWALL; then
     log "disarming the host firewall while the cluster forms"
     for i in $(seq 0 $((N - 1))); do
@@ -389,6 +415,7 @@ if $MANAGE_FIREWALL; then
         on "$host" "if [ -x $FIREWALL_HELPER ]; then sudo $FIREWALL_HELPER disable; fi" ||
             fail "$host: could not disarm the host firewall"
         if ${WAS_ARMED[$i]}; then
+            DISARMED_HOSTS+=("$host")
             log "  $host disarmed"
         else
             log "  $host had no policy loaded"
@@ -722,8 +749,17 @@ if $MANAGE_FIREWALL; then
 
     for i in $(seq 0 $((N - 1))); do
         host="${HOSTS[$i]}"
+        # Said at this volume because it used to read as a routine note and is
+        # not one: this host is joining a cluster on public addresses with
+        # nothing in front of it. A node that arrives unarmed is usually a reset
+        # that failed after deleting the policy, not a deliberate choice.
         if ! ${WAS_ARMED[$i]}; then
-            log "  $host: firewall was not armed before forming, leaving it off"
+            log "  $host: WARNING — no firewall policy before forming, leaving it OFF."
+            log "    This node is open on its public addresses. If that was not"
+            log "    deliberate, arm it with:"
+            log "      ssh $SSH_USER@$host 'sudo env SETUP_STAGES=firewall \\"
+            log "        /usr/local/share/spinifex/setup.sh --firewall on'"
+            log "      ssh $SSH_USER@$host 'sudo systemctl restart spinifex-daemon'"
             continue
         fi
 
@@ -763,6 +799,10 @@ if $MANAGE_FIREWALL; then
 
         log "  $host armed: $(grep -c . <<<"$loaded") peers, $encap_count tunnel endpoints"
     done
+
+    # Every disarmed host has been put back and verified, so a later failure is
+    # not a firewall failure and the abort handler has nothing left to repair.
+    DISARMED_HOSTS=()
 else
     echo ""
     log "host firewall: left alone (--no-firewall). If these nodes arrived armed they"

--- a/scripts/node-reset.sh
+++ b/scripts/node-reset.sh
@@ -103,17 +103,69 @@ fi
 log "stopping services"
 run sudo systemctl stop spinifex.target 2>/dev/null || true
 run sudo systemctl reset-failed 'spinifex-*' 2>/dev/null || true
-run sudo pkill -x qemu-system-x86_64 2>/dev/null || true
-run sudo pkill -x qemu-system-aarch64 2>/dev/null || true
+
+# Stopping the target is not the same as its services being stopped.
+# spinifex-shutdown.service is ordered After= the storage services so its drain
+# runs while they are still up, which queues their stop jobs behind its
+# ExecStop, and `systemctl stop` returns as soon as the target itself is
+# inactive. NATS surviving that is what lets JetStream rewrite its index after
+# the wipe and before the verification, failing the reset on a file the script
+# had already deleted. update-nodes.sh carries the same wait.
+if ! $DRY_RUN; then
+    for unit in spinifex-predastore spinifex-viperblock spinifex-nats; do
+        if systemctl is-active --quiet "$unit"; then
+            sudo systemctl stop "$unit" || true
+        fi
+    done
+    elapsed=0
+    while [ -n "$(pgrep -x spx || true)" ]; do
+        if [ "$elapsed" -ge 120 ]; then
+            echo "ERROR: spx still running after 120s:" >&2
+            pgrep -ax spx >&2 || true
+            echo "  Wiping under a live service races JetStream, which rewrites" >&2
+            echo "  its index after the rm. Stop them manually and re-run." >&2
+            exit 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+fi
+
+# `pgrep -x` and `pkill -x` match against comm, which the kernel truncates to 15
+# characters, so `qemu-system-x86_64` is stored as `qemu-system-x86` and an -x
+# match on the full name can never fire. Match the prefix instead: it is 11
+# characters, well under the limit, and covers both x86_64 and aarch64. This is
+# the same rule qemuProcessPrefix applies in spinifex/vm/orphan_scan.go.
+#
+# Deliberately not -f. That matches the whole command line, where argv[0] may
+# carry a path, so an anchored pattern misses the process it was written for.
+#
+# Scoped by owner, because a host carrying libvirt guests alongside Spinifex
+# ones has both under the same comm and an unscoped kill would take the wrong
+# set down. The daemon runs guests as its own service user on an installed node;
+# a dev install runs them as whoever invoked spx.
+QEMU_PGREP=('^qemu-system')
+for qemu_user in spinifex-daemon spinifex "${SUDO_USER:-$(id -un)}"; do
+    if id -u "$qemu_user" >/dev/null 2>&1; then
+        QEMU_PGREP=(-u "$qemu_user" "${QEMU_PGREP[@]}")
+        break
+    fi
+done
+qemu_pids() { sudo pgrep "${QEMU_PGREP[@]}" 2>/dev/null || true; }
+
+if [ -n "$(qemu_pids)" ]; then
+    log "signalling QEMU guests owned by $qemu_user"
+    run sudo pkill "${QEMU_PGREP[@]}" 2>/dev/null || true
+fi
 
 # Viperblock state must not be torn out from under a live guest, so wait for
 # QEMU to actually exit rather than assuming the signal was enough.
 if ! $DRY_RUN; then
     elapsed=0
-    while pgrep -x 'qemu-system-x86_64|qemu-system-aarch64' >/dev/null 2>&1; do
+    while [ -n "$(qemu_pids)" ]; do
         if [ "$elapsed" -ge 30 ]; then
             echo "ERROR: QEMU still running after 30s:" >&2
-            pgrep -af 'qemu-system-' >&2 || true
+            sudo pgrep -a "${QEMU_PGREP[@]}" >&2 || true
             echo "  Kill them manually and re-run." >&2
             exit 1
         fi
@@ -150,9 +202,28 @@ run sudo rm -f /etc/openvswitch/system-id.conf
 # stays open forever. Read the arming mode now and regenerate the stage after
 # the wipe. peers.nft is the one file here that really is cluster state, and
 # regenerating does not bring it back.
+#
+# Reading it from $ETC_DIR alone is not enough, because a run that fails between
+# the wipe and the restore has already deleted the file. The retry then reads
+# the absence as "this node was never armed", skips the restore, and
+# install-node.sh honours that and forms the cluster with an open node on a
+# public address. Stash the mode outside every wiped tree so the retry can still
+# find it, and keep it there until the policy is back.
+FIREWALL_STASH=/var/lib/spinifex-reset/firewall-mode
+
 FIREWALL_MODE=""
 if [ -r "$ETC_DIR/firewall/mode" ]; then
     FIREWALL_MODE=$(sudo cat "$ETC_DIR/firewall/mode" 2>/dev/null | tr -d '[:space:]')
+elif [ -r "$FIREWALL_STASH" ]; then
+    FIREWALL_MODE=$(sudo cat "$FIREWALL_STASH" 2>/dev/null | tr -d '[:space:]')
+    log "recovered the firewall mode from an interrupted reset: $FIREWALL_MODE"
+fi
+
+# Absent from both means this node genuinely has no policy — a fresh install or
+# a dev tree — and arming one here would be inventing a decision nobody made.
+if [ -n "$FIREWALL_MODE" ] && ! $DRY_RUN; then
+    sudo mkdir -p "$(dirname "$FIREWALL_STASH")"
+    printf '%s\n' "$FIREWALL_MODE" | sudo tee "$FIREWALL_STASH" >/dev/null
 fi
 
 # Named in the transcript because the risk runs the other way too: an allowlist
@@ -237,13 +308,31 @@ fi
 
 # Put the firewall policy back. Only this stage runs, so the node stays on the
 # build it was already running — nothing is downloaded or reinstalled.
+#
+# A node that arrived armed and leaves unarmed is a failure, not a warning. It
+# sits on a public address with nothing in front of it, and the only signal used
+# to be a log line that reads as cosmetic. Exit non-zero so the caller stops
+# rather than forming a cluster around it, and leave the stash in place so the
+# retry still knows what mode to restore.
 SETUP_SH=/usr/local/share/spinifex/setup.sh
-if [ -n "$FIREWALL_MODE" ] && [ -x "$SETUP_SH" ]; then
+if [ -n "$FIREWALL_MODE" ]; then
+    if [ ! -x "$SETUP_SH" ]; then
+        echo "ERROR: $SETUP_SH is missing, cannot restore the firewall policy." >&2
+        echo "  This node was armed ($FIREWALL_MODE) and is now open. Reinstall it" >&2
+        echo "  or arm it by hand before forming a cluster." >&2
+        $DRY_RUN || exit 1
+    fi
     log "restoring the host firewall policy (mode: $FIREWALL_MODE)"
-    run sudo env SETUP_STAGES=firewall "$SETUP_SH" --firewall "$FIREWALL_MODE" ||
-        log "  WARNING: could not restore the firewall policy — this node will not re-arm"
-elif [ -n "$FIREWALL_MODE" ]; then
-    log "  WARNING: $SETUP_SH is missing, cannot restore the firewall policy"
+    if run sudo env SETUP_STAGES=firewall "$SETUP_SH" --firewall "$FIREWALL_MODE"; then
+        run sudo rm -f "$FIREWALL_STASH"
+    else
+        echo "ERROR: could not restore the firewall policy." >&2
+        echo "  This node was armed ($FIREWALL_MODE) and is now open on its public" >&2
+        echo "  addresses. Repair with:" >&2
+        echo "    sudo env SETUP_STAGES=firewall $SETUP_SH --firewall $FIREWALL_MODE" >&2
+        echo "    sudo systemctl restart spinifex-daemon" >&2
+        $DRY_RUN || exit 1
+    fi
 fi
 
 if [ ! -d /etc/spinifex ]; then


### PR DESCRIPTION
## Summary

Three guards in `node-reset.sh` were meant to make a reset safe. None of them worked. Each has its own bead, and the third has a second half in `install-node.sh`.

### The QEMU guard never fired — `mulga-tfpft`

`pgrep -x` and `pkill -x` match against `comm`, which the kernel truncates to 15 bytes, so `qemu-system-x86_64` is stored as `qemu-system-x86`. Neither `pkill -x qemu-system-x86_64` nor `pgrep -x 'qemu-system-x86_64|qemu-system-aarch64'` could ever match. The script therefore never signalled a guest, never waited the 30 seconds its comment describes, and went straight to emptying `/var/lib/spinifex` — the exact hazard the comment says the wait exists to prevent.

Fixed by matching the 11-character prefix against `comm`, which is the rule `qemuProcessPrefix` already applies in `spinifex/vm/orphan_scan.go:13-15`. Deliberately not `-f`: that matches the whole command line, where `argv[0]` may carry a path, so an anchored pattern misses the process it was written for. Scoped by owner so a host carrying libvirt guests alongside Spinifex ones does not lose the wrong set.

### Nothing waited for `spx` — `mulga-wmrvz`

`systemctl stop spinifex.target` returns once the target is inactive, but `spinifex-shutdown.service` is ordered `After=` the storage services, so their stop jobs queue behind its `ExecStop` and NATS can still be running. JetStream then rewrites `$SYS/_js_/*/tav.idx` after the `rm` and before the verification, failing the reset on a file the script had already deleted. This is non-deterministic — it failed node3 during the 2026-08-18 rebuild while node1 and node2 wiped cleanly and node4 was never reached, leaving the cluster split three ways.

Fixed with the per-unit stop and `pgrep -x spx` wait that `update-nodes.sh` has carried since `d9bc6e35`.

### The firewall restore was gated on a file the failed run deleted — `mulga-wmdbd`

`node-reset.sh` reads `/etc/spinifex/firewall/mode` before wiping and restores only if it found one. A run that fails after the wipe has already deleted it, so the retry reads the absence as "this node was never armed" and skips the restore. `install-node.sh` honours that and forms the cluster around an open node on a public address.

Fixed by stashing the mode at `/var/lib/spinifex-reset/firewall-mode`, outside every wiped tree, and clearing it only once the policy is back. A node that arrived armed and cannot be put back now exits non-zero instead of logging a warning — it is sitting on a public address with nothing in front of it, which is a failure, not a note.

Absence from **both** locations still means no policy, so a fresh install or a dev tree is left alone rather than having a firewall invented for it.

### `install-node.sh` held the other half of that cascade

It disarms every host to let the OVN raft ports through and only re-arms at the very end, with `fail` called from a dozen places in between. That is why the 2026-09-11 rebuild ended with **all four** nodes unarmed rather than one: node1 failed to restore its own policy, verification failed, and the three disarmed for formation were never put back.

Re-arm from an `EXIT` trap, and make the "arrived with no policy" line a warning with repair steps instead of a routine log entry that reads as cosmetic.

## Testing

`make preflight` passes. `shellcheck -S warning` clean on both scripts. `node-reset.sh --dry-run` exercised end to end.

The QEMU matcher was verified against a real process with a truncated `comm`, since that is the part that was silently dead:

```
comm='qemu-system-x86'  cmdline='./qemu-system-x86_64 60'

OLD  -x full name                              : no match   <- the bug
OLD  -x alternation                            : no match   <- the bug
     -f anchored on '^qemu-system-'            : no match   <- why this PR does not use -f
NEW  comm prefix, owner-scoped                 : MATCH
NEW  scoped to another user (must miss)        : no match
```

## Notes

- Stacks cleanly beside #1018 (the JetStream store removal); the hunks do not overlap.
- `scripts/` is outside the `test-build-scripts` glob, so none of this is covered by an automated suite. A shell suite for `scripts/` would have caught the QEMU guard years ago and is worth doing separately — it widens the preflight contract, so it did not belong in this change.

Beads: `mulga-tfpft`, `mulga-wmrvz`, `mulga-wmdbd`